### PR TITLE
docs: daily documentation grooming 2026-06-14

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -76,16 +76,18 @@ You should see the root command help listing all available subcommands.
 24. [prompt run](#prompt-run) — Render and execute a prompt template
 25. [satellite](#satellite) — Manage satellite nodes
 26. [doctor](#doctor) — Diagnose configuration issues
-27. [locations](#locations) — Show resolved file paths
-28. [update](#update) — Check for and apply updates
-29. [memory](#memory) — Manage agent memory
-30. [cron](#cron-command) — Manage cron jobs from the CLI
-31. [debug sessions](#debug-sessions) — Inspect session SQLite database
-32. [debug logs](#debug-logs) — Inspect log files
-33. [debug db](#debug-db) — Inspect raw databases
-34. [debug gateway](#debug-gateway) — Live gateway diagnostics
-35. [debug cron](#debug-cron) — Cron scheduler diagnostics
-36. [Examples](#examples)
+27. [doctor config](#doctor-config) — Guided config migration
+28. [locations](#locations) — Show resolved file paths
+29. [update](#update) — Check for and apply updates
+30. [memory](#memory) — Manage agent memory
+31. [cron](#cron-command) — Manage cron jobs from the CLI
+32. [debug sessions](#debug-sessions) — Inspect session SQLite database
+33. [debug logs](#debug-logs) — Inspect log files
+34. [debug memory](#debug-memory) — Inspect agent memory directories
+35. [debug db](#debug-db) — Inspect raw databases
+36. [debug gateway](#debug-gateway) — Live gateway diagnostics
+37. [debug cron](#debug-cron) — Cron scheduler diagnostics
+38. [Examples](#examples)
 
 ---
 
@@ -1537,6 +1539,13 @@ botnexus doctor [OPTIONS]
 | `--target <DIR>` | BotNexus home directory. Defaults to `~/.botnexus`. |
 | `--verbose` | Show detailed check output. |
 
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `locations` | Check that every resolved BotNexus location (config, logs, sessions, agents) is accessible. |
+| `config` | Guided config migration — detect and optionally apply missing settings. See [doctor config](#doctor-config). |
+
 ### Examples
 
 ```powershell
@@ -1545,9 +1554,50 @@ botnexus doctor
 
 # Check a specific instance
 botnexus doctor --target /opt/botnexus-prod
+
+# Verify location accessibility
+botnexus doctor locations
 ```
 
 Checks include: config validity, provider reachability, directory permissions, extension loading, and port availability.
+
+---
+
+## doctor config
+
+Guided config migration. Compares your existing `config.json` against a set of built-in checks, reports any missing or outdated settings, and optionally applies the fixes in place. Operates offline — no running gateway required.
+
+Current checks include: the `extensions` block, the Skills world default, cron configuration, the memory agent default, and the compaction model settings.
+
+### Usage
+
+```powershell
+botnexus doctor config [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--yes` | Apply all applicable fixes without prompting. |
+| `--dry-run` | Report what would change but do not write anything. |
+| `--target <DIR>` | BotNexus home directory. Defaults to `~/.botnexus`. |
+| `--verbose` | Show detailed output for each check. |
+
+> Without `--yes` or `--dry-run`, the command prompts before applying each fix. The config file is only modified when a fix is applied.
+
+### Examples
+
+```powershell
+# Detect gaps and prompt before each fix
+botnexus doctor config
+
+# Preview changes without writing
+botnexus doctor config --dry-run
+
+# Apply every applicable fix non-interactively
+botnexus doctor config --yes
+```
 
 ---
 
@@ -1790,6 +1840,41 @@ botnexus debug logs search --query "timeout"
 
 # Filter by session
 botnexus debug logs session --id "session-abc123"
+```
+
+---
+
+## debug memory
+
+Inspect agent memory directories — daily notes, the consolidated `MEMORY.md`, and on-disk usage — without requiring a running gateway. Reads each agent's `workspace/memory/` folder and `workspace/MEMORY.md` file directly.
+
+### Usage
+
+```powershell
+botnexus debug memory [OPTIONS]
+```
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--target <DIR>` | `~/.botnexus` | BotNexus home directory |
+| `--agent <ID>` | (all) | Show a detailed view for a single agent, including a per-file daily-note breakdown |
+| `--format` | `table` | Output format: `table` or `json` |
+
+The summary view lists every agent that has a memory directory or `MEMORY.md`, with the `MEMORY.md` size, daily-note count, most recent note, and total size. Passing `--agent` switches to a detailed per-agent view.
+
+### Examples
+
+```powershell
+# Summary of memory usage across all agents
+botnexus debug memory
+
+# Detailed view for a single agent
+botnexus debug memory --agent assistant
+
+# JSON output for scripting
+botnexus debug memory --format json
 ```
 
 ---


### PR DESCRIPTION
## Changes

Documented two CLI commands that were registered in code but missing from the CLI reference.

## New pages

None — both additions are sections within the existing `docs/cli-reference.md` Reference page.

## Content fixes

- **`debug memory`** — new section. `DebugMemoryCommand` is registered in `DebugCommand.cs` (the `debug memory` subcommand, shipped via #1328) but was never documented. Covers the offline agent-memory inspector with its `--target`, `--agent`, and `--format` options, plus summary vs detailed views.
- **`doctor config`** — new section. `DoctorConfigCommand` is registered as a subcommand of `doctor` (`DoctorCommand.cs`) but only the root `doctor` command was documented. Covers guided config migration with `--yes` / `--dry-run` and the offline check set (extensions block, Skills world default, cron, memory agent default, compaction model).
- **`doctor`** — added a Subcommands table (`locations`, `config`) and a `doctor locations` example; previously the doc didn't surface that `doctor` has subcommands.
- **Table of Contents** — added entries for `doctor config` (#27) and `debug memory` (#34) and renumbered; verified 1..38 sequential with no duplicates and all new anchors resolve.

## Structural improvements

None — no folder or sidebar changes. Both commands live under pages already present in the VitePress sidebar.

---
Automated by the daily documentation groomer. Docs-only, no code changes (`docs/cli-reference.md`, +95/-10).
