### PR TITLE
feat(prompts): wrap runtime-context block in internal delimiters

### DIFF
--- a/src/gateway/BotNexus.Gateway.Prompts/RuntimeLineFormatter.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/RuntimeLineFormatter.cs
@@ -6,6 +6,19 @@ namespace BotNexus.Gateway.Prompts;
 public static class RuntimeLineFormatter
 {
     /// <summary>
+    /// Delimiter line that marks the start of the hidden runtime-context block in the system prompt.
+    /// Models see this as a bounded block; an outbound strip routine can target these markers to redact
+    /// the runtime context from user-visible replies (see follow-up work for the strip half).
+    /// </summary>
+    public const string RuntimeContextBeginDelimiter = "INTERNAL_RUNTIME_CONTEXT_BEGIN";
+
+    /// <summary>
+    /// Delimiter line that marks the end of the hidden runtime-context block in the system prompt.
+    /// Pairs with <see cref="RuntimeContextBeginDelimiter"/> to bracket the runtime-context body.
+    /// </summary>
+    public const string RuntimeContextEndDelimiter = "INTERNAL_RUNTIME_CONTEXT_END";
+
+    /// <summary>
     /// Executes build runtime line.
     /// </summary>
     /// <param name="runtime">The runtime.</param>

--- a/src/gateway/BotNexus.Gateway/Agents/SystemPromptBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/SystemPromptBuilder.cs
@@ -548,8 +548,10 @@ public static class SystemPromptBuilder
         var data = GetGatewayData(context);
         return
         [
+            RuntimeLineFormatter.RuntimeContextBeginDelimiter,
             buildRuntimeLine(data.Parameters.Runtime),
-            $"Reasoning: {(data.Parameters.ReasoningLevel ?? "off")} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled."
+            $"Reasoning: {(data.Parameters.ReasoningLevel ?? "off")} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.",
+            RuntimeLineFormatter.RuntimeContextEndDelimiter
         ];
     }
 

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/RuntimeLineFormatterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/RuntimeLineFormatterTests.cs
@@ -123,4 +123,18 @@ public sealed class RuntimeLineFormatterTests
         line.ShouldContain("channel=signalr");
         line.ShouldContain("session=sess-42");
     }
+
+    [Fact]
+    public void RuntimeContextDelimiters_AreInternalRuntimeContextMarkers()
+    {
+        RuntimeLineFormatter.RuntimeContextBeginDelimiter.ShouldBe("INTERNAL_RUNTIME_CONTEXT_BEGIN");
+        RuntimeLineFormatter.RuntimeContextEndDelimiter.ShouldBe("INTERNAL_RUNTIME_CONTEXT_END");
+    }
+
+    [Fact]
+    public void RuntimeContextDelimiters_BeginAndEndDiffer()
+    {
+        RuntimeLineFormatter.RuntimeContextBeginDelimiter
+            .ShouldNotBe(RuntimeLineFormatter.RuntimeContextEndDelimiter);
+    }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SystemPromptBuilderSnapshotTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SystemPromptBuilderSnapshotTests.cs
@@ -119,6 +119,91 @@ public sealed class SystemPromptBuilderSnapshotTests
     }
 
     [Fact]
+    public void Build_FullMode_WrapsRuntimeContextInDelimiters()
+    {
+        var prompt = SystemPromptBuilder.Build(new SystemPromptParams
+        {
+            WorkspaceDir = Path.Combine(Path.GetTempPath(), "repo", "workspace"),
+            ToolNames = ["read"],
+            PromptMode = PromptMode.Full,
+            Runtime = new RuntimeInfo
+            {
+                AgentId = "agent-a",
+                Host = "host-a",
+                Channel = "signalr"
+            },
+            ReasoningLevel = "medium"
+        });
+
+        var beginIndex = prompt.IndexOf("INTERNAL_RUNTIME_CONTEXT_BEGIN", StringComparison.Ordinal);
+        var runtimeLineIndex = prompt.IndexOf("Runtime: agent=agent-a", StringComparison.Ordinal);
+        var reasoningIndex = prompt.IndexOf("Reasoning: medium", StringComparison.Ordinal);
+        var endIndex = prompt.IndexOf("INTERNAL_RUNTIME_CONTEXT_END", StringComparison.Ordinal);
+
+        beginIndex.ShouldBeGreaterThanOrEqualTo(0);
+        endIndex.ShouldBeGreaterThan(beginIndex);
+        runtimeLineIndex.ShouldBeGreaterThan(beginIndex);
+        runtimeLineIndex.ShouldBeLessThan(endIndex);
+        reasoningIndex.ShouldBeGreaterThan(beginIndex);
+        reasoningIndex.ShouldBeLessThan(endIndex);
+    }
+
+    [Fact]
+    public void Build_MinimalMode_WrapsRuntimeContextInDelimiters()
+    {
+        var prompt = SystemPromptBuilder.Build(new SystemPromptParams
+        {
+            WorkspaceDir = Path.Combine(Path.GetTempPath(), "repo", "workspace"),
+            ToolNames = ["read"],
+            PromptMode = PromptMode.Minimal,
+            Runtime = new RuntimeInfo
+            {
+                AgentId = "agent-a",
+                Channel = "signalr"
+            }
+        });
+
+        var beginIndex = prompt.IndexOf("INTERNAL_RUNTIME_CONTEXT_BEGIN", StringComparison.Ordinal);
+        var endIndex = prompt.IndexOf("INTERNAL_RUNTIME_CONTEXT_END", StringComparison.Ordinal);
+        var runtimeLineIndex = prompt.IndexOf("Runtime: agent=agent-a", StringComparison.Ordinal);
+
+        beginIndex.ShouldBeGreaterThanOrEqualTo(0);
+        endIndex.ShouldBeGreaterThan(beginIndex);
+        runtimeLineIndex.ShouldBeGreaterThan(beginIndex);
+        runtimeLineIndex.ShouldBeLessThan(endIndex);
+    }
+
+    [Fact]
+    public void Build_RuntimeContextEndDelimiter_ClosesRuntimeContextBody()
+    {
+        var prompt = SystemPromptBuilder.Build(new SystemPromptParams
+        {
+            WorkspaceDir = Path.Combine(Path.GetTempPath(), "repo", "workspace"),
+            ToolNames = ["read"],
+            PromptMode = PromptMode.Full,
+            Runtime = new RuntimeInfo
+            {
+                AgentId = "agent-a",
+                Channel = "signalr"
+            }
+        });
+
+        var lines = prompt
+            .Replace("\r\n", "\n")
+            .Split('\n')
+            .Where(static line => !string.IsNullOrWhiteSpace(line))
+            .ToList();
+
+        var reasoningIndex = lines.FindIndex(static line => line.StartsWith("Reasoning:", StringComparison.Ordinal));
+        var endIndex = lines.FindIndex(static line => string.Equals(line, "INTERNAL_RUNTIME_CONTEXT_END", StringComparison.Ordinal));
+
+        // The END delimiter must close the runtime-context body: it comes immediately after the
+        // last body line (the Reasoning line) and bounds the block models see.
+        reasoningIndex.ShouldBeGreaterThanOrEqualTo(0);
+        endIndex.ShouldBe(reasoningIndex + 1);
+    }
+
+    [Fact]
     public void Build_FullMode_MatchesSnapshot()
     {
         var prompt = SystemPromptBuilder.Build(new SystemPromptParams

--- a/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-full.prompt.txt
+++ b/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-full.prompt.txt
@@ -154,6 +154,8 @@ HEARTBEAT_OK
 BotNexus treats a leading/trailing "HEARTBEAT_OK" as a heartbeat ack (and may discard it).
 If something needs attention, do NOT include "HEARTBEAT_OK"; reply with the alert text instead.
 <runtime>
+INTERNAL_RUNTIME_CONTEXT_BEGIN
 Runtime: agent=agent-a | host=host-a | os=Windows (x64) | provider=openai | model=gpt-5 | default_model=gpt-5-mini | shell=pwsh | channel=telegram | capabilities=inlinebuttons,reactions
 Reasoning: medium (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.
+INTERNAL_RUNTIME_CONTEXT_END
 </runtime>

--- a/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-minimal.prompt.txt
+++ b/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-minimal.prompt.txt
@@ -80,6 +80,8 @@ Heartbeat context
 ## Subagent Context
 Sub-agent context
 <runtime>
+INTERNAL_RUNTIME_CONTEXT_BEGIN
 Runtime: agent=agent-a | host=host-a | os=Windows (x64) | provider=openai | model=gpt-5 | shell=pwsh | channel=signalr | capabilities=reactions
 Reasoning: off (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.
+INTERNAL_RUNTIME_CONTEXT_END
 </runtime>

--- a/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-no-tools.prompt.txt
+++ b/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-no-tools.prompt.txt
@@ -87,6 +87,8 @@ Use NO_REPLY ONLY when no user-visible reply is required.
 <!-- BOTNEXUS_CACHE_BOUNDARY -->
 
 <runtime>
+INTERNAL_RUNTIME_CONTEXT_BEGIN
 Runtime: agent=agent-a | channel=signalr | capabilities=none
 Reasoning: off (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.
+INTERNAL_RUNTIME_CONTEXT_END
 </runtime>


### PR DESCRIPTION
Closes #1369

## Changes
Wraps the hidden runtime-context block in the assembled system prompt in explicit `INTERNAL_RUNTIME_CONTEXT_BEGIN` / `INTERNAL_RUNTIME_CONTEXT_END` delimiter lines (OpenClaw port of [`21aa8faf`](https://github.com/openclaw/openclaw/commit/21aa8faf8a875bcc089bbd924e18d8b4ee8b69a7)).

- `RuntimeLineFormatter` gains two public delimiter constants (`RuntimeContextBeginDelimiter` / `RuntimeContextEndDelimiter`) so the follow-up outbound-strip routine (#1430) has a single source for the markers it must target.
- `SystemPromptBuilder.BuildRuntimeSection` now brackets the runtime-context body (the `Runtime:` line + `Reasoning:` line) with those delimiters, inside the existing `<runtime>` section.

This is **the wrap half only** -- purely additive. Models see a bounded block; nothing on the user-visible / fan-out path changes. The existing header lines are untouched (header-fallback strip stays viable).

## Tests
- 2 new `RuntimeLineFormatterTests` asserting the delimiter constant values and that begin != end.
- 3 new `SystemPromptBuilderSnapshotTests`: full + minimal modes bracket the runtime body between BEGIN/END; END delimiter immediately closes the body after the `Reasoning:` line.
- Regenerated the 3 gateway prompt snapshots (`gateway-full` / `gateway-minimal` / `gateway-no-tools`) to include the delimiters.
- Verified: full `--warnaserror` solution build clean; `test-impacted.ps1` green (Architecture 180, Gateway.Prompts 113, Gateway 3002, CodingAgent 224, Scenarios 29).

## Merge Notes
Touches only `RuntimeLineFormatter.cs` + `SystemPromptBuilder.cs` + their tests/snapshots -- **zero file overlap with any of the 9 other open PRs** (verified against the full open-PR file-lock map). Safe to merge in any order. Prerequisite for #1430 (outbound strip of these delimited blocks).