### PR TITLE
fix(conversations): populate participant roster in File and SQLite summaries

### DIFF
--- a/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
@@ -373,7 +373,14 @@ public sealed class FileConversationStore : IConversationStore
             c.Purpose,
             c.Kind.ToString(),
             c.IsPinned,
-            c.PinnedAt);
+            c.PinnedAt,
+            // #1427: populate the participant roster (avatar-chip list the portal renders)
+            // so File-backed listings match the InMemory reference shape instead of returning
+            // a null roster. The conversation already carries its hydrated Participants here.
+            c.Participants.Select(p => new ParticipantSummary(
+                p.CitizenId.Kind.ToString(),
+                p.CitizenId.Value,
+                p.Role)).ToList());
 
     // ── Canvas State ───────────────────────────────────────────────────────
     // The file store persists canvas state in the CanvasState property of the Conversation

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -514,11 +514,13 @@ public sealed class SqliteConversationStore : IConversationStore
             """;
 
         var summaries = new List<ConversationSummary>();
+        var rosters = await LoadActiveParticipantRostersAsync(connection, ct).ConfigureAwait(false);
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
         while (await reader.ReadAsync(ct).ConfigureAwait(false))
         {
+            var conversationId = reader.GetString(0);
             summaries.Add(new ConversationSummary(
-                reader.GetString(0),
+                conversationId,
                 reader.GetString(1),
                 reader.GetString(2),
                 reader.GetInt64(4) != 0,
@@ -532,10 +534,54 @@ public sealed class SqliteConversationStore : IConversationStore
                     ? reader.GetString(11)
                     : ConversationKind.HumanAgent.ToString(),
                 reader.FieldCount > 12 && !reader.IsDBNull(12) && reader.GetInt64(12) != 0,
-                reader.FieldCount > 13 && !reader.IsDBNull(13) ? ParseTimestamp(reader.GetString(13)) : null));
+                reader.FieldCount > 13 && !reader.IsDBNull(13) ? ParseTimestamp(reader.GetString(13)) : null,
+                // #1427: attach the participant roster so SQLite-backed listings match the
+                // InMemory reference shape. Resolved once via a single batch query above to
+                // avoid an N+1 per-conversation participant lookup.
+                rosters.TryGetValue(conversationId, out var roster) ? roster : []));
         }
 
         return summaries;
+    }
+
+    /// <summary>
+    /// Loads the participant rosters for every active conversation in a single query so
+    /// <see cref="GetSummariesAsync"/> can attach them without an N+1 per-conversation lookup.
+    /// Returns a map of conversation id to its ordered <see cref="ParticipantSummary"/> list.
+    /// </summary>
+    private static async Task<Dictionary<string, IReadOnlyList<ParticipantSummary>>> LoadActiveParticipantRostersAsync(
+        SqliteConnection connection,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT p.conversation_id, p.citizen_kind, p.citizen_id, p.role
+            FROM conversation_participants p
+            INNER JOIN conversations c ON c.id = p.conversation_id
+            WHERE c.status = 'Active'
+            ORDER BY p.citizen_kind ASC, p.citizen_id ASC
+            """;
+
+        var rosters = new Dictionary<string, List<ParticipantSummary>>(StringComparer.Ordinal);
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var conversationId = reader.GetString(0);
+            var kind = reader.GetString(1);
+            var id = reader.GetString(2);
+            var role = reader.IsDBNull(3) ? null : reader.GetString(3);
+            if (!rosters.TryGetValue(conversationId, out var list))
+            {
+                list = [];
+                rosters[conversationId] = list;
+            }
+            list.Add(new ParticipantSummary(kind, id, role));
+        }
+
+        return rosters.ToDictionary(
+            kvp => kvp.Key,
+            kvp => (IReadOnlyList<ParticipantSummary>)kvp.Value,
+            StringComparer.Ordinal);
     }
 
     private async Task EnsureCreatedAsync(CancellationToken ct)

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/ConversationStoreParticipantsContractTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/ConversationStoreParticipantsContractTests.cs
@@ -134,6 +134,65 @@ public sealed class ConversationStoreParticipantsContractTests
 
     [Theory]
     [MemberData(nameof(StoreHarnesses))]
+    public async Task GetSummariesAsync_IncludesParticipantRoster_ForEveryStore(
+        string _,
+        Func<IStoreHarness> create)
+    {
+        // #1427: the participant roster (avatar-chip list the portal renders) must be
+        // populated in ConversationSummary by ALL three stores, not just InMemory.
+        // FileConversationStore.ToSummary and SqliteConversationStore.GetSummariesAsync
+        // previously omitted the Participants argument (=> null) while InMemory populated it.
+        using var harness = create();
+        var store = harness.Store;
+        var convoId = ConversationId.Create();
+        await store.CreateAsync(NewConversation(convoId, AgentId.From("owner")));
+
+        await store.AddParticipantsAsync(convoId,
+        [
+            new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-alpha")), Role = "peer" },
+            new SessionParticipant { CitizenId = CitizenId.Of(UserId.From("user-1")) }
+        ]);
+
+        var summaries = await store.GetSummariesAsync();
+        var summary = summaries.SingleOrDefault(s => s.ConversationId == convoId.Value);
+        summary.ShouldNotBeNull();
+        summary!.Participants.ShouldNotBeNull(
+            "#1427: every store must populate the participant roster in ConversationSummary.");
+        summary.Participants!.Count.ShouldBe(2);
+
+        var agent = summary.Participants.SingleOrDefault(p => p.Id == "agent-alpha");
+        agent.ShouldNotBeNull();
+        agent!.Kind.ShouldBe(CitizenKind.Agent.ToString());
+        agent.Role.ShouldBe("peer");
+
+        var user = summary.Participants.SingleOrDefault(p => p.Id == "user-1");
+        user.ShouldNotBeNull();
+        user!.Kind.ShouldBe(CitizenKind.User.ToString());
+    }
+
+    [Theory]
+    [MemberData(nameof(StoreHarnesses))]
+    public async Task GetSummariesAsync_ReturnsEmptyRoster_WhenNoParticipantsAdded(
+        string _,
+        Func<IStoreHarness> create)
+    {
+        // A conversation with no explicit participants must still expose a (possibly empty)
+        // roster rather than diverging across stores. The roster is never null for an
+        // existing conversation summary post-#1427.
+        using var harness = create();
+        var store = harness.Store;
+        var convoId = ConversationId.Create();
+        await store.CreateAsync(NewConversation(convoId, AgentId.From("owner")));
+
+        var summaries = await store.GetSummariesAsync();
+        var summary = summaries.SingleOrDefault(s => s.ConversationId == convoId.Value);
+        summary.ShouldNotBeNull();
+        summary!.Participants.ShouldNotBeNull();
+        summary.Participants!.Count.ShouldBe(0);
+    }
+
+    [Theory]
+    [MemberData(nameof(StoreHarnesses))]
     public async Task AddParticipantsAsync_ConcurrentCalls_ProduceUnion_NotRaceSubset(
         string _,
         Func<IStoreHarness> create)


### PR DESCRIPTION
Closes #1427

## Changes
`FileConversationStore.ToSummary` and `SqliteConversationStore.GetSummariesAsync` previously omitted the `ConversationSummary.Participants` argument (defaulting to `null`), while `InMemoryConversationStore` populated it — a silent behavioural drift surfaced by #1383 Finding 3. The portal's participant-roster avatar chips were therefore empty for the production File- and SQLite-backed stores.

- **File store**: `ToSummary` now mirrors the InMemory projection (`c.Participants.Select(p => new ParticipantSummary(...))`). The conversation already carries its hydrated participants, so no extra query.
- **SQLite store**: new `LoadActiveParticipantRostersAsync` runs a single batch query joining `conversation_participants` to active conversations (no N+1) and the summary loop attaches each conversation's roster.
- Roster shape matches InMemory exactly: `Kind = citizen kind ("Agent"/"User")`, `Id = citizen value`, `Role`.
- A conversation with no participants yields a non-null empty roster (consistent across all stores).

## Tests
- Added two 3-store parity theories to `ConversationStoreParticipantsContractTests`:
  - `GetSummariesAsync_IncludesParticipantRoster_ForEveryStore` (agent + user, role preserved)
  - `GetSummariesAsync_ReturnsEmptyRoster_WhenNoParticipantsAdded`
- TDD: the two new theories failed for File + SQLite (4 reds) before the fix, all 8 green after.
- `test-impacted.ps1` green: Architecture 185, Gateway.Conversations 222, Gateway 3029, Cli 298, Mcp 186, Scenarios 29. Full `--warnaserror` solution build clean.

## Notes
This is an intentional **behaviour change** (File/SQLite listings now include participants) — deliberately filed separately from the #1383 refactor (which was strictly behaviour-preserving) so the unification is an explicit, reviewed decision. No new contract type needed (`ConversationSummary`/`ParticipantSummary` already exist).

## Merge Notes
Independent of #1170 (SignalR, `GatewayHub.cs`) and the providers refactor (#1405 — Providers projects). Zero file overlap; safe to merge in any order.