### PR TITLE
refactor(gateway): extract MapAgentEvent pure function from StreamCoreAsync

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -892,6 +892,74 @@ internal sealed class InProcessAgentHandle : IAgentHandle, IHealthCheckable, IAg
     public IAsyncEnumerable<AgentStreamEvent> StreamAsync(AgentCoreUserMessage message, CancellationToken cancellationToken = default)
         => StreamCoreAsync(ct => _agent.PromptAsync(message, ct), cancellationToken);
 
+    /// <summary>
+    /// Maps a raw <see cref="AgentEvent"/> to the gateway-facing <see cref="AgentStreamEvent"/>, or
+    /// <see langword="null"/> when the event has no client-visible representation.
+    /// </summary>
+    /// <remarks>
+    /// Extracted from <see cref="StreamCoreAsync"/> as a pure function (#1382) so the agent-event
+    /// translation can be unit-tested directly without driving a live agent subscription/channel
+    /// pipeline. <paramref name="messageId"/> is the stable per-turn correlation id stamped onto
+    /// every emitted event.
+    /// </remarks>
+    internal static AgentStreamEvent? MapAgentEvent(AgentEvent agentEvent, string messageId)
+        => agentEvent switch
+        {
+            MessageStartEvent start when start.Message is AssistantAgentMessage
+                => new AgentStreamEvent { Type = AgentStreamEventType.MessageStart, MessageId = messageId },
+            MessageUpdateEvent update when update.ContentDelta is not null => update.IsThinking
+                ? new AgentStreamEvent
+                {
+                    Type = AgentStreamEventType.ThinkingDelta,
+                    ThinkingContent = update.ContentDelta,
+                    MessageId = messageId
+                }
+                : new AgentStreamEvent
+                {
+                    Type = AgentStreamEventType.ContentDelta,
+                    ContentDelta = update.ContentDelta,
+                    MessageId = messageId
+                },
+            ToolExecutionStartEvent toolStart => new AgentStreamEvent
+            {
+                Type = AgentStreamEventType.ToolStart,
+                ToolCallId = toolStart.ToolCallId,
+                ToolName = toolStart.ToolName,
+                ToolArgs = toolStart.Args,
+                MessageId = messageId
+            },
+            ToolExecutionEndEvent toolEnd => new AgentStreamEvent
+            {
+                Type = AgentStreamEventType.ToolEnd,
+                ToolCallId = toolEnd.ToolCallId,
+                ToolName = toolEnd.ToolName,
+                ToolResult = toolEnd.Result.Content.FirstOrDefault()?.ToString(),
+                ToolIsError = toolEnd.IsError,
+                MessageId = messageId
+            },
+            MessageEndEvent end when end.Message is AssistantAgentMessage assistant
+                => new AgentStreamEvent
+                {
+                    Type = AgentStreamEventType.MessageEnd,
+                    MessageId = messageId,
+                    Usage = assistant.Usage is null ? null : new AgentResponseUsage(
+                        InputTokens: assistant.Usage.InputTokens,
+                        OutputTokens: assistant.Usage.OutputTokens,
+                        CacheRead: assistant.Usage.CacheRead,
+                        CacheWrite: assistant.Usage.CacheWrite)
+                },
+            ToolExecutionUpdateEvent { PartialResult.Details: AskUserRequest askUserRequest }
+                => new AgentStreamEvent
+                {
+                    Type = AgentStreamEventType.UserInputRequired,
+                    UserInputRequest = askUserRequest,
+                    MessageId = messageId
+                },
+            TurnEndEvent
+                => new AgentStreamEvent { Type = AgentStreamEventType.TurnEnd, MessageId = messageId },
+            _ => null
+        };
+
     private async IAsyncEnumerable<AgentStreamEvent> StreamCoreAsync(
         Func<CancellationToken, Task> runPrompt,
         [EnumeratorCancellation] CancellationToken cancellationToken)
@@ -912,62 +980,7 @@ internal sealed class InProcessAgentHandle : IAgentHandle, IHealthCheckable, IAg
             _activityTracker?.RecordActivity();
             try
             {
-                var streamEvent = agentEvent switch
-                {
-                    MessageStartEvent start when start.Message is AssistantAgentMessage
-                        => new AgentStreamEvent { Type = AgentStreamEventType.MessageStart, MessageId = messageId },
-                    MessageUpdateEvent update when update.ContentDelta is not null => update.IsThinking
-                        ? new AgentStreamEvent
-                        {
-                            Type = AgentStreamEventType.ThinkingDelta,
-                            ThinkingContent = update.ContentDelta,
-                            MessageId = messageId
-                        }
-                        : new AgentStreamEvent
-                        {
-                            Type = AgentStreamEventType.ContentDelta,
-                            ContentDelta = update.ContentDelta,
-                            MessageId = messageId
-                        },
-                    ToolExecutionStartEvent toolStart => new AgentStreamEvent
-                    {
-                        Type = AgentStreamEventType.ToolStart,
-                        ToolCallId = toolStart.ToolCallId,
-                        ToolName = toolStart.ToolName,
-                        ToolArgs = toolStart.Args,
-                        MessageId = messageId
-                    },
-                    ToolExecutionEndEvent toolEnd => new AgentStreamEvent
-                    {
-                        Type = AgentStreamEventType.ToolEnd,
-                        ToolCallId = toolEnd.ToolCallId,
-                        ToolName = toolEnd.ToolName,
-                        ToolResult = toolEnd.Result.Content.FirstOrDefault()?.ToString(),
-                        ToolIsError = toolEnd.IsError,
-                        MessageId = messageId
-                    },
-                    MessageEndEvent end when end.Message is AssistantAgentMessage assistant
-                        => new AgentStreamEvent
-                        {
-                            Type = AgentStreamEventType.MessageEnd,
-                            MessageId = messageId,
-                            Usage = assistant.Usage is null ? null : new AgentResponseUsage(
-                                InputTokens: assistant.Usage.InputTokens,
-                                OutputTokens: assistant.Usage.OutputTokens,
-                                CacheRead: assistant.Usage.CacheRead,
-                                CacheWrite: assistant.Usage.CacheWrite)
-                        },
-                    ToolExecutionUpdateEvent { PartialResult.Details: AskUserRequest askUserRequest }
-                        => new AgentStreamEvent
-                        {
-                            Type = AgentStreamEventType.UserInputRequired,
-                            UserInputRequest = askUserRequest,
-                            MessageId = messageId
-                        },
-                    TurnEndEvent
-                        => new AgentStreamEvent { Type = AgentStreamEventType.TurnEnd, MessageId = messageId },
-                    _ => null
-                };
+                var streamEvent = MapAgentEvent(agentEvent, messageId);
 
                 if (streamEvent is not null)
                     await events.Writer.WriteAsync(streamEvent, cancellationToken);

--- a/tests/gateway/BotNexus.Gateway.Tests/InProcessIsolationStrategyMapAgentEventTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/InProcessIsolationStrategyMapAgentEventTests.cs
@@ -1,0 +1,251 @@
+﻿using System.Collections.Generic;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Isolation;
+using BotNexus.Domain.Primitives;
+using AgentCoreUserMessage = BotNexus.Agent.Core.Types.UserMessage;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for the pure agent-event -> <see cref="AgentStreamEvent"/> mapping extracted from
+/// <c>StreamCoreAsync</c> (#1382). Because the mapping is now a static pure function it can be
+/// exercised directly without driving a live <c>_agent.Subscribe</c> channel pipeline.
+/// </summary>
+public sealed class InProcessIsolationStrategyMapAgentEventTests
+{
+    private const string MessageId = "msg-abc123";
+    private static readonly DateTimeOffset Now = DateTimeOffset.UnixEpoch;
+
+    [Fact]
+    public void MapAgentEvent_AssistantMessageStart_MapsToMessageStart()
+    {
+        var evt = new MessageStartEvent(new AssistantAgentMessage("hi"), Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldNotBeNull();
+        result!.Type.ShouldBe(AgentStreamEventType.MessageStart);
+        result.MessageId.ShouldBe(MessageId);
+    }
+
+    [Fact]
+    public void MapAgentEvent_NonAssistantMessageStart_MapsToNull()
+    {
+        // MessageStartEvent for a user message must not produce a stream start marker.
+        var evt = new MessageStartEvent(new AgentCoreUserMessage("hello"), Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void MapAgentEvent_ContentDelta_MapsToContentDelta()
+    {
+        var evt = new MessageUpdateEvent(
+            Message: new AssistantAgentMessage("partial"),
+            ContentDelta: "partial",
+            IsThinking: false,
+            ToolCallId: null,
+            ToolName: null,
+            ArgumentsDelta: null,
+            FinishReason: null,
+            InputTokens: null,
+            OutputTokens: null,
+            Timestamp: Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldNotBeNull();
+        result!.Type.ShouldBe(AgentStreamEventType.ContentDelta);
+        result.ContentDelta.ShouldBe("partial");
+        result.ThinkingContent.ShouldBeNull();
+        result.MessageId.ShouldBe(MessageId);
+    }
+
+    [Fact]
+    public void MapAgentEvent_ThinkingDelta_MapsToThinkingDelta()
+    {
+        var evt = new MessageUpdateEvent(
+            Message: new AssistantAgentMessage("reasoning"),
+            ContentDelta: "reasoning",
+            IsThinking: true,
+            ToolCallId: null,
+            ToolName: null,
+            ArgumentsDelta: null,
+            FinishReason: null,
+            InputTokens: null,
+            OutputTokens: null,
+            Timestamp: Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldNotBeNull();
+        result!.Type.ShouldBe(AgentStreamEventType.ThinkingDelta);
+        result.ThinkingContent.ShouldBe("reasoning");
+        result.ContentDelta.ShouldBeNull();
+        result.MessageId.ShouldBe(MessageId);
+    }
+
+    [Fact]
+    public void MapAgentEvent_MessageUpdateWithNullContentDelta_MapsToNull()
+    {
+        // A tool-call-streaming update (no content delta) must not emit a content/thinking delta.
+        var evt = new MessageUpdateEvent(
+            Message: new AssistantAgentMessage(string.Empty),
+            ContentDelta: null,
+            IsThinking: false,
+            ToolCallId: "call-1",
+            ToolName: "read",
+            ArgumentsDelta: "{\"path\":",
+            FinishReason: null,
+            InputTokens: null,
+            OutputTokens: null,
+            Timestamp: Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void MapAgentEvent_ToolExecutionStart_MapsToToolStart()
+    {
+        var args = new Dictionary<string, object?> { ["path"] = "/tmp/x" };
+        var evt = new ToolExecutionStartEvent("call-7", "read", args, Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldNotBeNull();
+        result!.Type.ShouldBe(AgentStreamEventType.ToolStart);
+        result.ToolCallId.ShouldBe("call-7");
+        result.ToolName.ShouldBe("read");
+        result.ToolArgs.ShouldBe(args);
+        result.MessageId.ShouldBe(MessageId);
+    }
+
+    [Fact]
+    public void MapAgentEvent_ToolExecutionEnd_MapsToToolEndWithResultAndError()
+    {
+        var content = new AgentToolContent(AgentToolContentType.Text, "done");
+        var result0 = new AgentToolResult(new List<AgentToolContent> { content });
+        var evt = new ToolExecutionEndEvent("call-7", "read", result0, IsError: true, Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldNotBeNull();
+        result!.Type.ShouldBe(AgentStreamEventType.ToolEnd);
+        result.ToolCallId.ShouldBe("call-7");
+        result.ToolName.ShouldBe("read");
+        // Preserves the original behaviour: ToString() of the first content block.
+        result.ToolResult.ShouldBe(content.ToString());
+        result.ToolIsError.ShouldBe(true);
+        result.MessageId.ShouldBe(MessageId);
+    }
+
+    [Fact]
+    public void MapAgentEvent_ToolExecutionEnd_WithNoContent_ToolResultIsNull()
+    {
+        var result0 = new AgentToolResult(new List<AgentToolContent>());
+        var evt = new ToolExecutionEndEvent("call-9", "exec", result0, IsError: false, Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldNotBeNull();
+        result!.Type.ShouldBe(AgentStreamEventType.ToolEnd);
+        result.ToolResult.ShouldBeNull();
+        result.ToolIsError.ShouldBe(false);
+    }
+
+    [Fact]
+    public void MapAgentEvent_AssistantMessageEnd_MapsToMessageEndWithUsage()
+    {
+        var assistant = new AssistantAgentMessage(
+            "final",
+            Usage: new AgentUsage(InputTokens: 12, OutputTokens: 34, CacheRead: 5, CacheWrite: 6));
+        var evt = new MessageEndEvent(assistant, Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldNotBeNull();
+        result!.Type.ShouldBe(AgentStreamEventType.MessageEnd);
+        result.MessageId.ShouldBe(MessageId);
+        result.Usage.ShouldNotBeNull();
+        result.Usage!.InputTokens.ShouldBe(12);
+        result.Usage.OutputTokens.ShouldBe(34);
+        result.Usage.CacheRead.ShouldBe(5);
+        result.Usage.CacheWrite.ShouldBe(6);
+    }
+
+    [Fact]
+    public void MapAgentEvent_AssistantMessageEnd_WithNullUsage_MapsToMessageEndWithNullUsage()
+    {
+        var evt = new MessageEndEvent(new AssistantAgentMessage("final", Usage: null), Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldNotBeNull();
+        result!.Type.ShouldBe(AgentStreamEventType.MessageEnd);
+        result.Usage.ShouldBeNull();
+    }
+
+    [Fact]
+    public void MapAgentEvent_NonAssistantMessageEnd_MapsToNull()
+    {
+        var evt = new MessageEndEvent(new AgentCoreUserMessage("user echo"), Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void MapAgentEvent_ToolUpdateWithAskUserRequest_MapsToUserInputRequired()
+    {
+        var ask = new AskUserRequest
+        {
+            RequestId = "req-1",
+            ConversationId = ConversationId.From("conv-1"),
+            SessionId = SessionId.From("sess-1"),
+            AgentId = AgentId.From("agent-1"),
+            Prompt = "Pick one"
+        };
+        var partial = new AgentToolResult(new List<AgentToolContent>(), Details: ask);
+        var evt = new ToolExecutionUpdateEvent("call-x", "ask_user", new Dictionary<string, object?>(), partial, Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldNotBeNull();
+        result!.Type.ShouldBe(AgentStreamEventType.UserInputRequired);
+        result.UserInputRequest.ShouldBe(ask);
+        result.MessageId.ShouldBe(MessageId);
+    }
+
+    [Fact]
+    public void MapAgentEvent_ToolUpdateWithoutAskUserRequest_MapsToNull()
+    {
+        // A tool update whose PartialResult.Details is not an AskUserRequest must not map.
+        var partial = new AgentToolResult(new List<AgentToolContent>(), Details: "not-an-ask");
+        var evt = new ToolExecutionUpdateEvent("call-x", "read", new Dictionary<string, object?>(), partial, Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void MapAgentEvent_TurnEnd_MapsToTurnEnd()
+    {
+        var evt = new TurnEndEvent(
+            new AssistantAgentMessage("done"),
+            new List<ToolResultAgentMessage>(),
+            Now);
+
+        var result = InProcessAgentHandle.MapAgentEvent(evt, MessageId);
+
+        result.ShouldNotBeNull();
+        result!.Type.ShouldBe(AgentStreamEventType.TurnEnd);
+        result.MessageId.ShouldBe(MessageId);
+    }
+}


### PR DESCRIPTION
Part of #1382

## Changes
Decomposition increment for `#1382` (Finding "Bonus" -- `StreamCoreAsync` `MapAgentEvent` extraction).

`InProcessAgentHandle.StreamCoreAsync` previously inlined a ~50-line `agentEvent switch` that maps raw `AgentEvent`s to gateway-facing `AgentStreamEvent`s, buried inside the `_agent.Subscribe` callback alongside the channel-plumbing / subscription / abort lifecycle. That made the mapping logic impossible to unit-test without driving a live agent subscription and channel pipeline.

This PR lifts the switch verbatim into a pure function:

```csharp
internal static AgentStreamEvent? MapAgentEvent(AgentEvent agentEvent, string messageId)
```

`StreamCoreAsync` now calls `MapAgentEvent(agentEvent, messageId)` and keeps only the Channel/subscription/cancellation orchestration. **The switch arms are byte-identical** -- this is a pure extract-method with no behaviour change.

## Tests
- New `InProcessIsolationStrategyMapAgentEventTests` (14 cases) exercising `MapAgentEvent` directly: every mapped branch (MessageStart, ContentDelta, ThinkingDelta, ToolStart, ToolEnd w/ + w/o content, MessageEnd w/ + w/o usage, UserInputRequired) **and** the sad/`null` paths (non-assistant MessageStart/MessageEnd, null ContentDelta, tool-update without an `AskUserRequest`).
- `test-impacted.ps1` green: Architecture 185, Gateway.Tests 3043 (+14, 1 pre-existing SignalR integration skip), Gateway.Conversations 216, Cli 298, Mcp 186, Scenarios 29.
- Full-solution `dotnet build BotNexus.slnx -warnaserror` clean (0 warnings / 0 errors).

## Scope note
This does **not** close `#1382` -- it is the third decomposition increment after Finding 2 (resolve-once, PR #1429 merged). The headline Finding 1 (`IToolProvider` collection rewrite of `CreateAsync`) remains under the `farnsworth:hold-1382` marker for an attended session.

## Merge Notes
Touches only `InProcessIsolationStrategy.cs` (the `InProcessAgentHandle` class) + a new test file. No file overlap with any other open PR (#1170, #1442, #1443, #1444, #1445) -- safe to merge in any order.