### PR TITLE
fix(persistence): set SQLite busy_timeout on every connection across stores

### DIFF
--- a/src/extensions/BotNexus.Extensions.DataStore/SqliteDataStoreBackend.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/SqliteDataStoreBackend.cs
@@ -341,10 +341,13 @@ internal sealed class SqliteDataStoreBackend : IDataStoreBackend
         _connection = new SqliteConnection($"Data Source={_dbPath}");
         await _connection.OpenAsync(ct).ConfigureAwait(false);
 
-        // Enable WAL for better concurrent read performance
-        using var wal = _connection.CreateCommand();
-        wal.CommandText = "PRAGMA journal_mode=WAL";
-        await wal.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        // busy_timeout MUST be set before WAL negotiation and on every open. This connection is
+        // cached and reused for the lifetime of the backend, so applying it here once covers every
+        // operation. busy_timeout lets a concurrent cross-process writer wait briefly for the lock
+        // instead of failing immediately with SQLITE_BUSY (#1450).
+        using var pragmas = _connection.CreateCommand();
+        pragmas.CommandText = "PRAGMA busy_timeout=5000; PRAGMA journal_mode=WAL;";
+        await pragmas.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
         return _connection;
     }

--- a/src/gateway/BotNexus.Cron/SqliteCronStore.cs
+++ b/src/gateway/BotNexus.Cron/SqliteCronStore.cs
@@ -483,7 +483,24 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
         return runs;
     }
 
-    private SqliteConnection CreateConnection() => new(_connectionString);
+    private SqliteConnection CreateConnection()
+    {
+        var connection = new SqliteConnection(_connectionString);
+        // busy_timeout is per-connection and resets to 0 on every open, so it must be applied on
+        // EVERY connection (operations open a fresh connection each time) - not just at init like
+        // the database-level journal_mode=WAL. Without it a concurrent cross-process writer hits
+        // SQLITE_BUSY immediately instead of waiting briefly for the lock to clear (#1450).
+        connection.StateChange += (_, e) =>
+        {
+            if (e.CurrentState == System.Data.ConnectionState.Open)
+            {
+                using var pragma = connection.CreateCommand();
+                pragma.CommandText = "PRAGMA busy_timeout=5000;";
+                pragma.ExecuteNonQuery();
+            }
+        };
+        return connection;
+    }
 
     private static void BindJob(SqliteCommand command, CronJob job)
     {

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -1039,7 +1039,25 @@ public sealed class SqliteSessionStore : SessionStoreBase
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    private SqliteConnection CreateConnection() => new(_connectionString);
+    private SqliteConnection CreateConnection()
+    {
+        var connection = new SqliteConnection(_connectionString);
+        // busy_timeout is per-connection and resets to 0 on every open, so it must be applied on
+        // EVERY connection (operations open a fresh connection each time) - not just at init like
+        // the database-level journal_mode=WAL. Without it a concurrent cross-process writer hits
+        // SQLITE_BUSY immediately instead of waiting briefly for the lock to clear, complementing
+        // the existing transient-error retry loop (#1450).
+        connection.StateChange += (_, e) =>
+        {
+            if (e.CurrentState == System.Data.ConnectionState.Open)
+            {
+                using var pragma = connection.CreateCommand();
+                pragma.CommandText = "PRAGMA busy_timeout=5000;";
+                pragma.ExecuteNonQuery();
+            }
+        };
+        return connection;
+    }
 
     // SQLite error codes that indicate a transient condition safe to retry.
     private static readonly int[] TransientSqliteErrorCodes = [5 /* BUSY */, 10 /* IOERR */];

--- a/src/gateway/BotNexus.Gateway.Webhooks/SqliteWebhookRegistrationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Webhooks/SqliteWebhookRegistrationStore.cs
@@ -233,7 +233,24 @@ public sealed class SqliteWebhookRegistrationStore(
         }
     }
 
-    private SqliteConnection CreateConnection() => new(_connectionString);
+    private SqliteConnection CreateConnection()
+    {
+        var connection = new SqliteConnection(_connectionString);
+        // busy_timeout is per-connection and resets to 0 on every open, so it must be applied on
+        // EVERY connection (operations open a fresh connection each time) - not just at init like
+        // the database-level journal_mode=WAL. Without it a concurrent cross-process writer hits
+        // SQLITE_BUSY immediately instead of waiting briefly for the lock to clear (#1450).
+        connection.StateChange += (_, e) =>
+        {
+            if (e.CurrentState == System.Data.ConnectionState.Open)
+            {
+                using var pragma = connection.CreateCommand();
+                pragma.CommandText = "PRAGMA busy_timeout=5000;";
+                pragma.ExecuteNonQuery();
+            }
+        };
+        return connection;
+    }
 
     private static void BindRegistration(SqliteCommand cmd, WebhookRegistration r)
     {

--- a/src/gateway/BotNexus.Gateway.Webhooks/SqliteWebhookRunStore.cs
+++ b/src/gateway/BotNexus.Gateway.Webhooks/SqliteWebhookRunStore.cs
@@ -200,7 +200,24 @@ public sealed class SqliteWebhookRunStore(
         }
     }
 
-    private SqliteConnection CreateConnection() => new(_connectionString);
+    private SqliteConnection CreateConnection()
+    {
+        var connection = new SqliteConnection(_connectionString);
+        // busy_timeout is per-connection and resets to 0 on every open, so it must be applied on
+        // EVERY connection (operations open a fresh connection each time) - not just at init like
+        // the database-level journal_mode=WAL. Without it a concurrent cross-process writer hits
+        // SQLITE_BUSY immediately instead of waiting briefly for the lock to clear (#1450).
+        connection.StateChange += (_, e) =>
+        {
+            if (e.CurrentState == System.Data.ConnectionState.Open)
+            {
+                using var pragma = connection.CreateCommand();
+                pragma.CommandText = "PRAGMA busy_timeout=5000;";
+                pragma.ExecuteNonQuery();
+            }
+        };
+        return connection;
+    }
 
     private static void BindRun(SqliteCommand cmd, WebhookRun r)
     {

--- a/src/gateway/BotNexus.Gateway/Extensions/SqliteExtensionStateStore.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/SqliteExtensionStateStore.cs
@@ -194,5 +194,22 @@ public sealed class SqliteExtensionStateStore(
         }
     }
 
-    private SqliteConnection CreateConnection() => new(_connectionString);
+    private SqliteConnection CreateConnection()
+    {
+        var connection = new SqliteConnection(_connectionString);
+        // busy_timeout is per-connection and resets to 0 on every open, so it must be applied on
+        // EVERY connection (operations open a fresh connection each time) - not just at init like
+        // the database-level journal_mode=WAL. Without it a concurrent cross-process writer hits
+        // SQLITE_BUSY immediately instead of waiting briefly for the lock to clear (#1450).
+        connection.StateChange += (_, e) =>
+        {
+            if (e.CurrentState == System.Data.ConnectionState.Open)
+            {
+                using var pragma = connection.CreateCommand();
+                pragma.CommandText = "PRAGMA busy_timeout=5000;";
+                pragma.ExecuteNonQuery();
+            }
+        };
+        return connection;
+    }
 }

--- a/src/gateway/BotNexus.Memory/SqliteMemoryStore.cs
+++ b/src/gateway/BotNexus.Memory/SqliteMemoryStore.cs
@@ -318,7 +318,24 @@ public sealed class SqliteMemoryStore(
         return ValueTask.CompletedTask;
     }
 
-    private SqliteConnection CreateConnection() => new(_connectionString);
+    private SqliteConnection CreateConnection()
+    {
+        var connection = new SqliteConnection(_connectionString);
+        // busy_timeout is per-connection and resets to 0 on every open, so it must be applied on
+        // EVERY connection (operations open a fresh connection each time) - not just at init like
+        // the database-level journal_mode=WAL. Without it a concurrent cross-process writer hits
+        // SQLITE_BUSY immediately instead of waiting briefly for the lock to clear (#1450).
+        connection.StateChange += (_, e) =>
+        {
+            if (e.CurrentState == System.Data.ConnectionState.Open)
+            {
+                using var pragma = connection.CreateCommand();
+                pragma.CommandText = "PRAGMA busy_timeout=5000;";
+                pragma.ExecuteNonQuery();
+            }
+        };
+        return connection;
+    }
 
     private static string SanitizeFtsQuery(string query)
     {

--- a/tests/architecture/BotNexus.Architecture.Tests/SqliteBusyTimeoutArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SqliteBusyTimeoutArchitectureTests.cs
@@ -1,0 +1,161 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness function guarding the SQLite <c>busy_timeout</c> contract (#1450).
+///
+/// Every BotNexus SQLite store sets <c>PRAGMA journal_mode = WAL</c> but historically none set
+/// <c>PRAGMA busy_timeout</c>. <c>busy_timeout</c> is a <b>per-connection</b> runtime setting that
+/// resets to <c>0</c> on every fresh connection - unlike <c>journal_mode = WAL</c>, which is a
+/// persistent database-level property. Without a busy timeout, a concurrent cross-process writer
+/// (gateway + a CLI <c>debug-db</c>/<c>doctor</c> reader, or two gateways on the same state dir)
+/// hits <c>SQLITE_BUSY</c> immediately instead of waiting briefly for the lock to clear.
+///
+/// This fence requires every store that opens SQLite connections to apply <c>busy_timeout</c>
+/// somewhere in the file (either inline in the init PRAGMA block for cached-connection stores,
+/// or in the per-open <c>CreateConnection</c> path for fresh-connection stores). It runs with zero
+/// runtime dependency - it parses the store source text, which is the right guard because
+/// <c>busy_timeout</c> is per-connection and awkward to assert reliably across the differing store
+/// connection shapes at runtime.
+///
+/// The one store deliberately excluded is <see cref="SqliteConversationStore"/> - it is owned by an
+/// in-flight PR (#1442) and is wired separately in #1437 once that lands. See #1435/#1436 for the
+/// shared-helper consolidation that will eventually replace these inline PRAGMAs.
+/// </summary>
+public sealed class SqliteBusyTimeoutArchitectureTests
+{
+    private static string RepoRoot => FindRepoRoot();
+
+    // The SQLite store source files that #1450 covers (relative to repo root).
+    // SqliteConversationStore.cs is intentionally NOT here - owned by PR #1442, wired in #1437.
+    private static readonly string[] StoreFiles =
+    {
+        "src/gateway/BotNexus.Cron/SqliteCronStore.cs",
+        "src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs",
+        "src/gateway/BotNexus.Memory/SqliteMemoryStore.cs",
+        "src/gateway/BotNexus.Gateway/Extensions/SqliteExtensionStateStore.cs",
+        "src/gateway/BotNexus.Gateway.Webhooks/SqliteWebhookRegistrationStore.cs",
+        "src/gateway/BotNexus.Gateway.Webhooks/SqliteWebhookRunStore.cs",
+        "src/extensions/BotNexus.Extensions.DataStore/SqliteDataStoreBackend.cs",
+    };
+
+    private static readonly Regex BusyTimeoutPragma =
+        new(@"PRAGMA\s+busy_timeout", RegexOptions.IgnoreCase);
+
+    private static readonly Regex JournalModeWalPragma =
+        new(@"PRAGMA\s+journal_mode\s*=\s*WAL", RegexOptions.IgnoreCase);
+
+    [Fact]
+    public void AllCoveredStoreFiles_Exist()
+    {
+        foreach (var rel in StoreFiles)
+        {
+            var path = Path.Combine(RepoRoot, rel.Replace('/', Path.DirectorySeparatorChar));
+            File.Exists(path).ShouldBeTrue($"Expected SQLite store source not found: {path}");
+        }
+    }
+
+    [Fact]
+    public void EveryWalStore_AlsoSetsBusyTimeout()
+    {
+        foreach (var rel in StoreFiles)
+        {
+            var path = Path.Combine(RepoRoot, rel.Replace('/', Path.DirectorySeparatorChar));
+            var source = File.ReadAllText(path);
+
+            // Sanity: the file must still set WAL - otherwise the fence is matching the wrong file.
+            JournalModeWalPragma.IsMatch(source).ShouldBeTrue(
+                $"Expected `PRAGMA journal_mode = WAL` in {rel}. If WAL was removed, update this fence " +
+                "to match the new connection-init shape. See #1450.");
+
+            BusyTimeoutPragma.IsMatch(source).ShouldBeTrue(
+                $"{rel} sets `PRAGMA journal_mode = WAL` but never sets `PRAGMA busy_timeout`. " +
+                "Without a busy timeout a concurrent cross-process writer hits SQLITE_BUSY immediately " +
+                "instead of waiting for the lock. Add `PRAGMA busy_timeout = <ms>` to the connection " +
+                "path (inline in the init block for cached-connection stores, or in CreateConnection for " +
+                "per-operation stores so EVERY open gets it - busy_timeout is per-connection and does not " +
+                "persist like WAL). See #1450.\nFile: " + path);
+        }
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_DetectsWalWithoutBusyTimeout()
+    {
+        // Synthetic regression: the pre-#1450 shape - WAL set, no busy_timeout. The detectors MUST
+        // recognise WAL is present AND busy_timeout is absent, so the fence would flag it.
+        const string preFixSource = """
+            public sealed class FakeStore
+            {
+                public async Task InitAsync(CancellationToken ct)
+                {
+                    await using var connection = new SqliteConnection(_cs);
+                    await connection.OpenAsync(ct);
+                    await using var cmd = connection.CreateCommand();
+                    cmd.CommandText = "PRAGMA journal_mode = WAL;";
+                    await cmd.ExecuteNonQueryAsync(ct);
+                }
+            }
+            """;
+
+        JournalModeWalPragma.IsMatch(preFixSource).ShouldBeTrue(
+            "Vacuity guard: the pre-fix shape sets WAL and the detector must see it.");
+        BusyTimeoutPragma.IsMatch(preFixSource).ShouldBeFalse(
+            "Vacuity guard: the pre-fix shape has no busy_timeout and the detector must report that. " +
+            "If this fails, the busy_timeout detector is too loose and the fence passes vacuously.");
+    }
+
+    [Fact]
+    public void Fence_PositivePin_AcceptsWalWithBusyTimeout()
+    {
+        // Synthetic positive: a store applying busy_timeout in CreateConnection (per-open) AND WAL at
+        // init must be accepted, so the fence does not over-tighten against the real fixed shape.
+        const string fixedSource = """
+            public sealed class FakeStore
+            {
+                private SqliteConnection CreateConnection()
+                {
+                    var connection = new SqliteConnection(_cs);
+                    connection.StateChange += (_, e) =>
+                    {
+                        if (e.CurrentState == ConnectionState.Open)
+                        {
+                            using var pragma = connection.CreateCommand();
+                            pragma.CommandText = "PRAGMA busy_timeout = 5000;";
+                            pragma.ExecuteNonQuery();
+                        }
+                    };
+                    return connection;
+                }
+
+                public async Task InitAsync(CancellationToken ct)
+                {
+                    await using var connection = CreateConnection();
+                    await connection.OpenAsync(ct);
+                    await using var cmd = connection.CreateCommand();
+                    cmd.CommandText = "PRAGMA journal_mode = WAL;";
+                    await cmd.ExecuteNonQueryAsync(ct);
+                }
+            }
+            """;
+
+        JournalModeWalPragma.IsMatch(fixedSource).ShouldBeTrue(
+            "Positive pin precondition: the fixed shape still sets WAL.");
+        BusyTimeoutPragma.IsMatch(fixedSource).ShouldBeTrue(
+            "Positive pin: a store that applies busy_timeout in CreateConnection must be accepted. " +
+            "If this fails, the busy_timeout detector is over-tight.");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        current.ShouldNotBeNull("Could not locate repo root (BotNexus.slnx) from " + AppContext.BaseDirectory);
+        return current!.FullName;
+    }
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/SqliteBusyTimeoutBehaviourTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SqliteBusyTimeoutBehaviourTests.cs
@@ -1,0 +1,133 @@
+using System.Data;
+using Microsoft.Data.Sqlite;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Behavioural verification that the <c>StateChange</c>-based per-open <c>busy_timeout</c> pattern
+/// used by the fresh-connection SQLite stores (#1450) actually takes effect at runtime - i.e. a
+/// connection produced by that pattern reports the configured <c>busy_timeout</c>, on every open,
+/// not just on the first.
+///
+/// This complements <see cref="SqliteBusyTimeoutArchitectureTests"/> (which guards that the PRAGMA
+/// is present in source) by proving the chosen mechanism is not a silent no-op. It mirrors the exact
+/// shape stores use: <c>new SqliteConnection(cs)</c> with a <c>StateChange</c> handler that runs
+/// <c>PRAGMA busy_timeout</c> when the connection transitions to Open.
+/// </summary>
+public sealed class SqliteBusyTimeoutBehaviourTests
+{
+    private const int BusyTimeoutMs = 5000;
+
+    private static SqliteConnection CreateConnectionLikeStore(string connectionString)
+    {
+        var connection = new SqliteConnection(connectionString);
+        connection.StateChange += (_, e) =>
+        {
+            if (e.CurrentState == ConnectionState.Open)
+            {
+                using var pragma = connection.CreateCommand();
+                pragma.CommandText = $"PRAGMA busy_timeout = {BusyTimeoutMs};";
+                pragma.ExecuteNonQuery();
+            }
+        };
+        return connection;
+    }
+
+    private static async Task<long> ReadBusyTimeoutAsync(SqliteConnection connection, CancellationToken ct)
+    {
+        await using var read = connection.CreateCommand();
+        read.CommandText = "PRAGMA busy_timeout;";
+        var value = await read.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        return Convert.ToInt64(value);
+    }
+
+    [Fact]
+    public async Task StateChangeHandler_AppliesBusyTimeout_OnOpen()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"botnexus-busytimeout-{Guid.NewGuid():N}.db");
+        var cs = new SqliteConnectionStringBuilder { DataSource = dbPath, Pooling = false }.ToString();
+        try
+        {
+            await using var connection = CreateConnectionLikeStore(cs);
+            await connection.OpenAsync(CancellationToken.None);
+
+            var busyTimeout = await ReadBusyTimeoutAsync(connection, CancellationToken.None);
+            busyTimeout.ShouldBe(BusyTimeoutMs);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TryDelete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task StateChangeHandler_AppliesBusyTimeout_OnEveryFreshConnection()
+    {
+        // The whole point of #1450: busy_timeout is per-connection and resets to 0 on each open.
+        // A fresh connection (as stores do per operation) must ALSO get the timeout applied, not
+        // only the first/init connection.
+        var dbPath = Path.Combine(Path.GetTempPath(), $"botnexus-busytimeout-{Guid.NewGuid():N}.db");
+        var cs = new SqliteConnectionStringBuilder { DataSource = dbPath, Pooling = false }.ToString();
+        try
+        {
+            // First (init-like) connection.
+            await using (var first = CreateConnectionLikeStore(cs))
+            {
+                await first.OpenAsync(CancellationToken.None);
+                (await ReadBusyTimeoutAsync(first, CancellationToken.None)).ShouldBe(BusyTimeoutMs);
+            }
+
+            // Second, completely fresh connection (per-operation pattern). With pooling off this is a
+            // brand-new connection whose busy_timeout would be 0 without the per-open handler.
+            await using (var second = CreateConnectionLikeStore(cs))
+            {
+                await second.OpenAsync(CancellationToken.None);
+                (await ReadBusyTimeoutAsync(second, CancellationToken.None)).ShouldBe(BusyTimeoutMs);
+            }
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TryDelete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task FreshConnection_WithoutHandler_HasZeroBusyTimeout()
+    {
+        // Baseline / vacuity: prove the default really is 0, so the above assertions are meaningful
+        // (i.e. the handler is what produces 5000, not some ambient default).
+        var dbPath = Path.Combine(Path.GetTempPath(), $"botnexus-busytimeout-{Guid.NewGuid():N}.db");
+        var cs = new SqliteConnectionStringBuilder { DataSource = dbPath, Pooling = false }.ToString();
+        try
+        {
+            await using var bare = new SqliteConnection(cs);
+            await bare.OpenAsync(CancellationToken.None);
+
+            var busyTimeout = await ReadBusyTimeoutAsync(bare, CancellationToken.None);
+            busyTimeout.ShouldBe(0);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TryDelete(dbPath);
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; SQLite file locks can linger briefly on Windows.
+        }
+    }
+}


### PR DESCRIPTION
Closes #1450

## Changes
All BotNexus SQLite stores set `PRAGMA journal_mode = WAL` but none set `PRAGMA busy_timeout`. WAL is a **persistent database-level** property that sticks across connections; `busy_timeout` is a **per-connection** runtime setting that resets to `0` on every open. Without it, a concurrent cross-process writer (the gateway plus a CLI `debug-db`/`doctor` reader, or two gateways pointed at the same state dir) hits `SQLITE_BUSY` immediately instead of waiting briefly for the lock to clear.

This applies `PRAGMA busy_timeout = 5000` (before WAL negotiation, mirroring the OpenClaw `configureSqliteConnectionPragmas` ordering from lineage `b470316fc0`) across the stores:

- **Cached-connection store** — `SqliteDataStoreBackend` reuses one cached connection, so the PRAGMA is set inline in its init path (before `journal_mode=WAL`), covering every operation.
- **Fresh-connection stores** — Cron, Sessions, Memory, ExtensionState, Webhook registration, Webhook run all open a fresh `SqliteConnection` per operation. Setting the PRAGMA only at init would miss those per-op connections (busy_timeout does not persist like WAL), so each `CreateConnection()` now attaches a `StateChange` handler that runs the PRAGMA whenever the connection transitions to `Open` — guaranteeing **every** open gets the timeout, with zero call-site churn.

`SqliteSessionStore` already declared `TransientSqliteErrorCodes = [5 BUSY, 10 IOERR]` and retried `SQLITE_BUSY` in C#; letting SQLite's own `busy_timeout` absorb the transient lock first is cheaper and now covers all seven stores uniformly.

## Tests
- `SqliteBusyTimeoutArchitectureTests` — fitness function scanning each covered store source: asserts a store that sets WAL also sets `busy_timeout`, with vacuity + positive pins (mirrors the `DockerHealthcheckArchitectureTests` pattern). CI-deterministic regression guard.
- `SqliteBusyTimeoutBehaviourTests` — proves the `StateChange` mechanism actually applies `busy_timeout=5000` at runtime on **every** fresh connection (per-op pattern), and that a bare connection defaults to `0` (so the assertion is meaningful).
- TDD: red (fence failed before the fix) → green (7/7). `test-impacted.ps1` green (Architecture 192, Scenarios 29, all store test projects). Full `-warnaserror` solution build clean.

## Scope
Seven of the eight WAL stores. `SqliteConversationStore` is intentionally **not** touched here — it is owned by open PR #1442 and is wired in the follow-up #1437. The architecture fence deliberately excludes it for the same reason.

## Merge Notes
Standalone, low-risk. Zero file overlap with the other open PRs — touches only the seven store source files plus a new architecture test file. The `StateChange` per-open approach is the no-new-project path explicitly allowed by #1450 option (B); it does not block or duplicate the eventual shared `SqliteWalMaintenance` helper (#1435/#1436), which can later fold `busy_timeout` into a single helper and replace these inline PRAGMAs. Safe to merge in any order relative to all other open PRs.
