### PR TITLE
fix(portal): key mobile chat loop and make tool pill a div to stop render crash

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
@@ -97,15 +97,23 @@ else
             {
                 @if (msg.IsBoundary)
                 {
-                    <div class="session-boundary">@(msg.BoundaryLabel ?? "New session")</div>
+                    <div class="session-boundary" @key="msg.Id">@(msg.BoundaryLabel ?? "New session")</div>
                 }
                 else if (msg.IsToolCall)
                 {
                     var toolIcon = msg.ToolIsError == true ? "&#x274C;" : msg.ToolResult is not null ? "&#x2705;" : "&#x23F3;";
                     var toolDuration = msg.ToolDuration is not null ? $" {msg.ToolDuration.Value.TotalSeconds:F1}s" : "";
-                    <button class="tool-pill @(msg.ToolIsError == true ? "tool-pill-error" : "")"
-                            @onclick="() => OpenToolModal(msg)"
-                            title="Tap to view details">
+                    @* Render the tool pill as a <div role="button"> so every branch in this
+                       loop shares a <div> root. Combined with @key this prevents Blazor from
+                       patching a <div> into a <button> at the same tree position mid-stream
+                       (issue #1483). @onkeydown keeps it keyboard-activatable. *@
+                    <div class="tool-pill @(msg.ToolIsError == true ? "tool-pill-error" : "")"
+                         role="button"
+                         tabindex="0"
+                         @key="msg.Id"
+                         @onclick="() => OpenToolModal(msg)"
+                         @onkeydown="(e) => OnToolPillKeyDown(e, msg)"
+                         title="Tap to view details">
                         <span class="tool-pill-icon">@((MarkupString)toolIcon)</span>
                         <span class="tool-pill-name">@msg.ToolName</span>
                         @if (!string.IsNullOrEmpty(toolDuration))
@@ -113,11 +121,11 @@ else
                             <span class="tool-pill-duration">@toolDuration</span>
                         }
                         <span class="tool-pill-chevron">&#x25B8;</span>
-                    </button>
+                    </div>
                 }
                 else
                 {
-                    <div class="message @GetMessageClass(msg)">
+                    <div class="message @GetMessageClass(msg)" @key="msg.Id">
                         @if (ShouldRenderAsMarkdown(msg.Role) && _markdownCache.TryGetValue(msg.Id, out var rendered))
                         {
                             <div class="message-content">@((MarkupString)rendered)</div>
@@ -594,6 +602,16 @@ else
     {
         _modalToolMessage = msg;
         StateHasChanged();
+    }
+
+    // Keyboard activation for the tool pill, which is a <div role="button"> (see #1483).
+    // Enter or Space opens the tool detail modal, matching native <button> semantics.
+    private void OnToolPillKeyDown(KeyboardEventArgs e, ChatMessage msg)
+    {
+        if (e.Key is "Enter" or " " or "Spacebar")
+        {
+            OpenToolModal(msg);
+        }
     }
 
     private void CloseToolModal()

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/css/mobile.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/css/mobile.css
@@ -342,6 +342,12 @@ body {
     white-space: nowrap;
     overflow: hidden;
     margin: 2px 0;
+    user-select: none;
+}
+
+.tool-pill:focus-visible {
+    outline: 2px solid rgba(100, 160, 220, 0.6);
+    outline-offset: 2px;
 }
 
 .tool-pill:hover, .tool-pill:active {

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileToolPillRenderTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileToolPillRenderTests.cs
@@ -1,0 +1,148 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Pages;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Tests for issue #1483: the mobile chat message loop must not throw a Blazor render
+/// exception when the message list mutates mid-stream and a tool-call pill replaces a
+/// text bubble at the same tree position.
+///
+/// Two compounding defects caused the crash on <c>main</c>:
+///  1. The message <c>@foreach</c> had no <c>@key</c>, so Blazor diffed by position.
+///  2. The tool-call branch rendered a <c>&lt;button&gt;</c> root while every other
+///     branch rendered a <c>&lt;div&gt;</c>, so an in-place element-type swap was attempted.
+///
+/// The fix keys the loop by <see cref="ChatMessage.Id"/> and makes the tool pill a
+/// <c>&lt;div role="button"&gt;</c> so the renderer only ever diffs <c>div</c>→<c>div</c>.
+/// These tests pin both the render-stability invariant and the element-type contract.
+/// </summary>
+public sealed class MobileToolPillRenderTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly IClientStateStore _store;
+    private readonly IPortalLoadService _portalLoad;
+    private readonly IAgentInteractionService _interaction;
+
+    public MobileToolPillRenderTests()
+    {
+        _store = Substitute.For<IClientStateStore>();
+        _portalLoad = Substitute.For<IPortalLoadService>();
+        _interaction = Substitute.For<IAgentInteractionService>();
+
+        _portalLoad.IsReady.Returns(true);
+        _portalLoad.IsLoading.Returns(false);
+        _portalLoad.LoadError.Returns((string?)null);
+        _portalLoad.InitializeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+
+        var agent = new AgentState
+        {
+            AgentId = "agent-1",
+            DisplayName = "Alpha",
+            ActiveConversationId = "conv-1",
+            IsConnected = true
+        };
+        agent.Conversations["conv-1"] = new ConversationState { ConversationId = "conv-1", Title = "C" };
+        _store.Agents.Returns(new Dictionary<string, AgentState> { ["agent-1"] = agent }.AsReadOnly());
+        _store.ActiveAgentId.Returns("agent-1");
+        _store.GetAgent("agent-1").Returns(agent);
+        _store.GetStreamState(Arg.Any<string>()).Returns(new ConversationStreamState());
+
+        _ctx.Services.AddSingleton(_store);
+        _ctx.Services.AddSingleton(_portalLoad);
+        _ctx.Services.AddSingleton(_interaction);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    [Fact]
+    public void Tool_call_message_renders_as_keyed_div_not_button_root()
+    {
+        var messages = new List<ChatMessage>
+        {
+            new("assistant", "Working on it", DateTimeOffset.UtcNow),
+            new("tool", string.Empty, DateTimeOffset.UtcNow)
+            {
+                IsToolCall = true,
+                ToolName = "read",
+                ToolResult = "ok"
+            }
+        };
+        _store.GetMessages("conv-1").Returns(messages.AsReadOnly());
+
+        var cut = _ctx.Render<Chat>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        // The tool pill renders...
+        var pill = cut.Find(".tool-pill");
+        // ...as a <div> root, NOT a <button>, matching its <div> siblings so the renderer
+        // never has to patch a <div> into a <button> at the same position.
+        Assert.Equal("DIV", pill.TagName);
+        // ...and remains keyboard-activatable / a11y-labelled as a button surrogate.
+        Assert.Equal("button", pill.GetAttribute("role"));
+        Assert.Equal("0", pill.GetAttribute("tabindex"));
+        Assert.Contains("read", cut.Markup);
+    }
+
+    [Fact]
+    public void Message_list_transition_from_text_to_tool_call_does_not_throw()
+    {
+        // Start: a single streaming assistant text bubble (<div>).
+        var initial = new List<ChatMessage>
+        {
+            new("assistant", "Let me check", DateTimeOffset.UtcNow)
+        };
+        _store.GetMessages("conv-1").Returns(initial.AsReadOnly());
+
+        var cut = _ctx.Render<Chat>(p => p.Add(c => c.AgentId, "agent-1"));
+        Assert.Contains("Let me check", cut.Markup);
+
+        // Mid-stream mutation: a tool-call is inserted at the front and the text bubble
+        // moves down. Without @key this reorders an element-type boundary in place; with
+        // the fix both branches are <div> and keyed, so the re-render must not throw.
+        var mutated = new List<ChatMessage>
+        {
+            new("tool", string.Empty, DateTimeOffset.UtcNow)
+            {
+                IsToolCall = true,
+                ToolName = "grep"
+            },
+            initial[0]
+        };
+        _store.GetMessages("conv-1").Returns(mutated.AsReadOnly());
+
+        // Re-render via a store change; must complete without a render exception.
+        var ex = Record.Exception(() => _store.OnChanged += Raise.Event<Action>());
+        Assert.Null(ex);
+        // The newly-inserted tool pill renders, and the message list still shows two
+        // message bubbles (a tool pill + the text bubble) after the in-place reorder.
+        Assert.Contains("grep", cut.Markup);
+        Assert.Contains("tool-pill", cut.Markup);
+        Assert.Single(cut.FindAll(".tool-pill"));
+        Assert.NotEmpty(cut.FindAll(".message"));
+    }
+
+    [Fact]
+    public void Mixed_boundary_text_and_tool_messages_render_without_throwing()
+    {
+        var messages = new List<ChatMessage>
+        {
+            new("system", string.Empty, DateTimeOffset.UtcNow) { Kind = "boundary", BoundaryLabel = "New session" },
+            new("user", "hello", DateTimeOffset.UtcNow),
+            new("assistant", "hi", DateTimeOffset.UtcNow),
+            new("tool", string.Empty, DateTimeOffset.UtcNow)
+            {
+                IsToolCall = true,
+                ToolName = "ls",
+                ToolIsError = true
+            }
+        };
+        _store.GetMessages("conv-1").Returns(messages.AsReadOnly());
+
+        var ex = Record.Exception(() => _ctx.Render<Chat>(p => p.Add(c => c.AgentId, "agent-1")));
+        Assert.Null(ex);
+    }
+}


### PR DESCRIPTION
Closes #1483

## Changes
The mobile portal (`BlazorClient.Mobile/Pages/Chat.razor`) threw a Blazor render
exception when tool-execution pills appeared mid-stream, surfacing in the
`#blazor-error-ui` strip (a JS-side render fault, so it never reached the .NET
`GlobalErrorBoundary` or the gateway logs). Two compounding defects on `main`:

1. The message `@foreach` had **no `@key`**, so Blazor diffed the list by position.
2. The tool-call branch rendered a `<button>` root while every other branch
   (boundary, assistant/text, system) rendered a `<div>`.

When the list mutated (a streaming text bubble becoming a tool call, or a tool
message inserted/reordered at an index that previously held a `<div>`), Blazor
tried to patch a `<div>` into a `<button>` at the same tree position, which throws
in the WASM render batch. Desktop is immune because its tool branch already
renders a `<div>`.

Fix (both, for defence-in-depth, as the issue specifies):
- **`@key="msg.Id"`** added to every branch of the mobile message loop (boundary,
  tool, and text) so the renderer never patches across element-type changes or
  reorders. `ChatMessage.Id` is a stable `Guid`-derived identity, already suitable
  for keying.
- **Tool pill is now a `<div role="button" tabindex="0">`** with an `@onkeydown`
  handler (Enter/Space activate the tool detail modal), so every loop branch shares
  a `<div>` root and the diff only ever swaps `<div>`→`<div>`.
- `mobile.css`: `.tool-pill` gains `user-select: none` and a `:focus-visible`
  outline to preserve the button look and keyboard accessibility now that it is a
  `<div>` rather than a native `<button>`.

## Tests
New `MobileToolPillRenderTests` (3 cases, mobile bUnit):
- the tool pill renders as a keyed `<div role="button" tabindex="0">`, not a `<button>`;
- a message list transitioning a text bubble into a tool call (with a front-insert
  reorder) re-renders without throwing;
- a mixed boundary + text + error-tool list renders without throwing.

`test-impacted.ps1` green: Architecture 192, Mobile.Tests 48 (+3), Scenarios 29.
Full `-warnaserror` build of the impacted projects clean.

## Merge Notes
Touches only `Chat.razor` (mobile), `mobile.css`, and the new mobile test file.
- Conflicts with **#1480** (also edits mobile `Chat.razor` for list ordering) — sequence,
  do not merge in parallel. Whichever merges first, the other should sync.
- Disjoint from **#1481** (mobile error *reporting* — `index.html`/diagnostics wiring),
  which can merge in parallel.
- This is the *cause* of one of the `#blazor-error-ui` errors #1481 would surface;
  because it is a JS-side render fault, #1481's `GlobalErrorBoundary` path would not
  even capture it.
- No overlap with the only other open PR, #1170 (GatewayHub.cs).
