### PR TITLE
fix(portal): report unrecoverable #blazor-error-ui failures to diagnostics

### DIFF
--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -505,6 +505,40 @@ tail -f ~/.botnexus/logs/gateway.log
 
 ---
 
+### WebUI Shows "An error has occurred"
+
+**Symptom:** The portal displays the framework error strip ("An error has
+occurred" on mobile, "An unhandled error has occurred" on desktop) at the bottom
+of the page.
+
+**Cause:** An unrecoverable Blazor WebAssembly failure (dead circuit, fatal
+render fault, or unhandled JS interop error). Unlike recoverable render
+exceptions caught by the in-app error boundary, this `#blazor-error-ui` path runs
+when the .NET side may no longer be alive.
+
+**Diagnosis:** The portal now reports these failures to the gateway. On the next
+reproduction, look for an Error-level entry in the gateway log:
+
+```bash
+grep "Channel error reported" ~/.botnexus/logs/gateway.log
+```
+
+The entry carries the message, stack (where available), URL, and user-agent. You
+can also retrieve recent channel/render errors through the diagnostics API:
+
+```bash
+curl http://localhost:5000/api/diagnostics/log-patterns?hours=1
+```
+
+**Notes:**
+- Reporting is best-effort from the browser; when an API key is configured the
+  unrecoverable-path report may be rejected with 401 (the in-app error boundary
+  still reports through the authenticated client).
+- A hard refresh (Ctrl+Shift+R) clears a stale cached build that can cause these
+  errors after an update.
+
+---
+
 ## Tool Execution Failures
 
 ### Tool Not Found

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Components/GlobalErrorBoundary.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Components/GlobalErrorBoundary.razor
@@ -52,17 +52,41 @@ else
             // JS interop may not be available in all error scenarios.
         }
 
+        var activeAgent = Store.ActiveAgentId is not null ? Store.GetAgent(Store.ActiveAgentId) : null;
+
         var report = new ChannelErrorReportDto
         {
             Message = exception.Message,
             StackTrace = exception.StackTrace,
+            // ErrorBoundary does not expose Blazor's component render stack, so carry
+            // the exception type and inner-exception chain as the closest equivalent
+            // diagnostic context (#1481 stretch goal -- align with the server-logged field).
+            ComponentStack = BuildComponentStack(exception),
             Timestamp = DateTimeOffset.UtcNow,
             AgentId = Store.ActiveAgentId,
+            // Prefer the active conversation's session so logged reports carry the
+            // session the user was actually in when the error surfaced.
+            SessionId = activeAgent?.ActiveConversationSessionId ?? activeAgent?.SessionId,
             Url = url,
             UserAgent = ua,
         };
 
         await ErrorReporter.ReportAsync(report);
+    }
+
+    private static string BuildComponentStack(Exception exception)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append(exception.GetType().FullName);
+        var inner = exception.InnerException;
+        var depth = 0;
+        while (inner is not null && depth < 5)
+        {
+            sb.Append(" -> ").Append(inner.GetType().FullName);
+            inner = inner.InnerException;
+            depth++;
+        }
+        return sb.ToString();
     }
 
     private void ToggleDetail() => _showDetail = !_showDetail;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/index.html
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/index.html
@@ -17,6 +17,7 @@
         </div>
     </div>
     <div id="blazor-error-ui">An error has occurred. <a href="" class="reload">Reload</a> <button type="button" aria-label="Dismiss error" onclick="document.getElementById('blazor-error-ui').style.display='none'">&#x2715;</button></div>
+    <script src="js/errorReporting.js"></script>
     <script src="js/marked.min.js"></script>
     <script src="js/purify.min.js"></script>
     <script src="js/markdown.js"></script>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/js/errorReporting.js
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/js/errorReporting.js
@@ -1,0 +1,130 @@
+// errorReporting.js -- reports unrecoverable portal failures to the gateway.
+//
+// Issue #1481: when Blazor shows the framework "#blazor-error-ui" banner
+// ("An error has occurred" / "An unhandled error has occurred"), the failure
+// is unrecoverable (dead circuit, WASM crash, unhandled JS interop fault). At
+// that point the .NET GlobalErrorBoundary cannot run, so nothing reaches the
+// gateway and operators see no message, count, or stack.
+//
+// This is the only layer that can observe such a failure, so it captures
+// window.onerror / unhandledrejection and the #blazor-error-ui banner becoming
+// visible, then best-effort POSTs a ChannelErrorReport to the diagnostics API.
+// All sends are fire-and-forget and never throw -- the page is already broken.
+(function () {
+    'use strict';
+
+    // The diagnostics endpoint is rooted at the origin, NOT the Blazor <base href>
+    // (which is "/mobile/" on mobile and "/" on desktop). Build an absolute,
+    // origin-relative URL so the report lands at /api/diagnostics/channel-error
+    // regardless of the app's base path.
+    var ENDPOINT;
+    try {
+        ENDPOINT = new URL('/api/diagnostics/channel-error', window.location.origin).toString();
+    } catch (_) {
+        ENDPOINT = '/api/diagnostics/channel-error';
+    }
+
+    // Avoid flooding the gateway: dedupe identical reports and cap the total.
+    var MAX_REPORTS = 20;
+    var sent = 0;
+    var seen = new Set();
+
+    function report(payload) {
+        if (sent >= MAX_REPORTS) {
+            return;
+        }
+        var signature = (payload.message || '') + '|' + (payload.url || '');
+        if (seen.has(signature)) {
+            return;
+        }
+        seen.add(signature);
+        sent++;
+
+        var body;
+        try {
+            body = JSON.stringify({
+                message: payload.message || 'Unrecoverable portal error',
+                stackTrace: payload.stackTrace || null,
+                componentStack: null,
+                url: payload.url || window.location.href,
+                userAgent: navigator.userAgent,
+                timestamp: new Date().toISOString(),
+                sessionId: null,
+                agentId: null
+            });
+        } catch (_) {
+            return;
+        }
+
+        // Best-effort. keepalive lets the request survive an unloading/dying page.
+        try {
+            fetch(ENDPOINT, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: body,
+                keepalive: true,
+                credentials: 'same-origin'
+            }).catch(function () { /* swallow -- page is already broken */ });
+        } catch (_) {
+            /* swallow */
+        }
+    }
+
+    // 1) Uncaught synchronous/async errors.
+    window.addEventListener('error', function (e) {
+        // Resource load errors (img/script) surface here too with no e.error;
+        // only report genuine script errors that carry a message.
+        if (!e || (!e.error && !e.message)) {
+            return;
+        }
+        report({
+            message: e.message || (e.error && e.error.message) || 'Unhandled error',
+            stackTrace: e.error && e.error.stack ? String(e.error.stack) : null,
+            url: e.filename || window.location.href
+        });
+    });
+
+    // 2) Unhandled promise rejections (the common WASM/interop failure shape).
+    window.addEventListener('unhandledrejection', function (e) {
+        var reason = e && e.reason;
+        var message = 'Unhandled promise rejection';
+        var stack = null;
+        if (reason) {
+            if (typeof reason === 'string') {
+                message = reason;
+            } else if (reason.message) {
+                message = reason.message;
+                stack = reason.stack ? String(reason.stack) : null;
+            } else {
+                try { message = JSON.stringify(reason); } catch (_) { /* keep default */ }
+            }
+        }
+        report({ message: message, stackTrace: stack, url: window.location.href });
+    });
+
+    // 3) The unrecoverable case: #blazor-error-ui becomes visible. This catches
+    //    dead-circuit / fatal render failures that never raise a JS error event.
+    function watchErrorBanner() {
+        var banner = document.getElementById('blazor-error-ui');
+        if (!banner) {
+            return;
+        }
+        var observer = new MutationObserver(function () {
+            var visible = window.getComputedStyle(banner).display !== 'none';
+            if (visible) {
+                report({
+                    message: 'Blazor unrecoverable error UI displayed (#blazor-error-ui)',
+                    stackTrace: null,
+                    url: window.location.href
+                });
+            }
+        });
+        observer.observe(banner, { attributes: true, attributeFilter: ['style', 'class'] });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', watchErrorBanner);
+    } else {
+        watchErrorBanner();
+    }
+})();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/index.html
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/index.html
@@ -32,6 +32,7 @@
         <a href="." class="reload">Reload</a>
         <span class="dismiss">X</span>
     </div>
+    <script src="js/errorReporting.js"></script>
     <script src="js/marked.min.js"></script>
     <script src="js/purify.min.js"></script>
     <script src="js/markdown.js"></script>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/js/errorReporting.js
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/js/errorReporting.js
@@ -1,0 +1,130 @@
+// errorReporting.js -- reports unrecoverable portal failures to the gateway.
+//
+// Issue #1481: when Blazor shows the framework "#blazor-error-ui" banner
+// ("An error has occurred" / "An unhandled error has occurred"), the failure
+// is unrecoverable (dead circuit, WASM crash, unhandled JS interop fault). At
+// that point the .NET GlobalErrorBoundary cannot run, so nothing reaches the
+// gateway and operators see no message, count, or stack.
+//
+// This is the only layer that can observe such a failure, so it captures
+// window.onerror / unhandledrejection and the #blazor-error-ui banner becoming
+// visible, then best-effort POSTs a ChannelErrorReport to the diagnostics API.
+// All sends are fire-and-forget and never throw -- the page is already broken.
+(function () {
+    'use strict';
+
+    // The diagnostics endpoint is rooted at the origin, NOT the Blazor <base href>
+    // (which is "/mobile/" on mobile and "/" on desktop). Build an absolute,
+    // origin-relative URL so the report lands at /api/diagnostics/channel-error
+    // regardless of the app's base path.
+    var ENDPOINT;
+    try {
+        ENDPOINT = new URL('/api/diagnostics/channel-error', window.location.origin).toString();
+    } catch (_) {
+        ENDPOINT = '/api/diagnostics/channel-error';
+    }
+
+    // Avoid flooding the gateway: dedupe identical reports and cap the total.
+    var MAX_REPORTS = 20;
+    var sent = 0;
+    var seen = new Set();
+
+    function report(payload) {
+        if (sent >= MAX_REPORTS) {
+            return;
+        }
+        var signature = (payload.message || '') + '|' + (payload.url || '');
+        if (seen.has(signature)) {
+            return;
+        }
+        seen.add(signature);
+        sent++;
+
+        var body;
+        try {
+            body = JSON.stringify({
+                message: payload.message || 'Unrecoverable portal error',
+                stackTrace: payload.stackTrace || null,
+                componentStack: null,
+                url: payload.url || window.location.href,
+                userAgent: navigator.userAgent,
+                timestamp: new Date().toISOString(),
+                sessionId: null,
+                agentId: null
+            });
+        } catch (_) {
+            return;
+        }
+
+        // Best-effort. keepalive lets the request survive an unloading/dying page.
+        try {
+            fetch(ENDPOINT, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: body,
+                keepalive: true,
+                credentials: 'same-origin'
+            }).catch(function () { /* swallow -- page is already broken */ });
+        } catch (_) {
+            /* swallow */
+        }
+    }
+
+    // 1) Uncaught synchronous/async errors.
+    window.addEventListener('error', function (e) {
+        // Resource load errors (img/script) surface here too with no e.error;
+        // only report genuine script errors that carry a message.
+        if (!e || (!e.error && !e.message)) {
+            return;
+        }
+        report({
+            message: e.message || (e.error && e.error.message) || 'Unhandled error',
+            stackTrace: e.error && e.error.stack ? String(e.error.stack) : null,
+            url: e.filename || window.location.href
+        });
+    });
+
+    // 2) Unhandled promise rejections (the common WASM/interop failure shape).
+    window.addEventListener('unhandledrejection', function (e) {
+        var reason = e && e.reason;
+        var message = 'Unhandled promise rejection';
+        var stack = null;
+        if (reason) {
+            if (typeof reason === 'string') {
+                message = reason;
+            } else if (reason.message) {
+                message = reason.message;
+                stack = reason.stack ? String(reason.stack) : null;
+            } else {
+                try { message = JSON.stringify(reason); } catch (_) { /* keep default */ }
+            }
+        }
+        report({ message: message, stackTrace: stack, url: window.location.href });
+    });
+
+    // 3) The unrecoverable case: #blazor-error-ui becomes visible. This catches
+    //    dead-circuit / fatal render failures that never raise a JS error event.
+    function watchErrorBanner() {
+        var banner = document.getElementById('blazor-error-ui');
+        if (!banner) {
+            return;
+        }
+        var observer = new MutationObserver(function () {
+            var visible = window.getComputedStyle(banner).display !== 'none';
+            if (visible) {
+                report({
+                    message: 'Blazor unrecoverable error UI displayed (#blazor-error-ui)',
+                    stackTrace: null,
+                    url: window.location.href
+                });
+            }
+        });
+        observer.observe(banner, { attributes: true, attributeFilter: ['style', 'class'] });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', watchErrorBanner);
+    } else {
+        watchErrorBanner();
+    }
+})();

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileGlobalErrorBoundaryTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileGlobalErrorBoundaryTests.cs
@@ -1,0 +1,89 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Components;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Tests for issue #1481 (stretch criterion): the mobile <c>GlobalErrorBoundary</c>
+/// must populate <see cref="ChannelErrorReportDto.SessionId"/> and
+/// <see cref="ChannelErrorReportDto.ComponentStack"/> so the recoverable-error path
+/// logs full session context (it previously omitted both).
+/// </summary>
+public sealed class MobileGlobalErrorBoundaryTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly IClientStateStore _store = Substitute.For<IClientStateStore>();
+    private readonly IChannelErrorReporter _errorReporter = Substitute.For<IChannelErrorReporter>();
+
+    public MobileGlobalErrorBoundaryTests()
+    {
+        _errorReporter.ReportAsync(Arg.Any<ChannelErrorReportDto>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        _ctx.Services.AddSingleton(_store);
+        _ctx.Services.AddSingleton(_errorReporter);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    [Fact]
+    public void Reported_error_carries_active_session_and_component_stack()
+    {
+        var agent = new AgentState
+        {
+            AgentId = "agent-1",
+            DisplayName = "Alpha",
+            SessionId = "agent-session",
+            ActiveConversationId = "conv-1"
+        };
+        agent.Conversations["conv-1"] = new ConversationState
+        {
+            ConversationId = "conv-1",
+            Title = "C",
+            ActiveSessionId = "conv-session"
+        };
+        _store.ActiveAgentId.Returns("agent-1");
+        _store.GetAgent("agent-1").Returns(agent);
+
+        _ctx.Render<GlobalErrorBoundary>(builder => builder.AddChildContent<ThrowingComponent>());
+
+        // The boundary reports exactly one error with the active conversation's session
+        // (preferred over the agent-level session) and a non-empty component stack.
+        _errorReporter.Received(1).ReportAsync(
+            Arg.Is<ChannelErrorReportDto>(r =>
+                r.AgentId == "agent-1"
+                && r.SessionId == "conv-session"
+                && !string.IsNullOrEmpty(r.ComponentStack)
+                && r.ComponentStack!.Contains("InvalidOperationException")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void Reported_error_falls_back_to_agent_session_when_no_active_conversation()
+    {
+        var agent = new AgentState
+        {
+            AgentId = "agent-1",
+            DisplayName = "Alpha",
+            SessionId = "agent-session"
+        };
+        _store.ActiveAgentId.Returns("agent-1");
+        _store.GetAgent("agent-1").Returns(agent);
+
+        _ctx.Render<GlobalErrorBoundary>(builder => builder.AddChildContent<ThrowingComponent>());
+
+        _errorReporter.Received(1).ReportAsync(
+            Arg.Is<ChannelErrorReportDto>(r => r.SessionId == "agent-session"),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>A component that always throws during rendering for testing the error boundary.</summary>
+    private sealed class ThrowingComponent : Microsoft.AspNetCore.Components.ComponentBase
+    {
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+            => throw new InvalidOperationException("Test error from ThrowingComponent");
+    }
+}


### PR DESCRIPTION
Closes #1481

## Changes
When the portal shows the framework error strip (`#blazor-error-ui` — "An error
has occurred" on mobile, "An unhandled error has occurred" on desktop), the
failure is **unrecoverable** (dead circuit, fatal render fault, unhandled JS
interop). That path has no .NET hook, so the most severe class of portal failure
never reached the gateway: no message, count, or stack in the diagnostics API or
logs. The recoverable in-app `GlobalErrorBoundary` is a different path and
`ErrorBoundary` only catches recoverable render exceptions.

- **`errorReporting.js`** added to both `BlazorClient.Mobile/wwwroot/js/` and
  `BlazorClient/wwwroot/js/`, registered **before** `blazor.webassembly.js` so the
  handlers are live before the app starts. It captures:
  - `window.onerror` (uncaught errors, ignores resource-load noise),
  - `unhandledrejection` (the common WASM/interop failure shape),
  - `#blazor-error-ui` becoming visible via `MutationObserver` (the dead-circuit
    case that raises no JS error event).
  Each fires a best-effort `fetch` POST to `/api/diagnostics/channel-error`
  (built as an **origin-relative** absolute URL so it resolves past the Blazor
  `<base href>` — `/mobile/` vs `/`), with `keepalive` + `credentials:same-origin`,
  deduped by signature and capped at 20 reports. All sends swallow errors — the
  page is already broken.
- **Mobile `GlobalErrorBoundary`** now fills the two fields it previously omitted
  (issue stretch goal): `SessionId` (the active conversation's session, falling
  back to the agent session) and `ComponentStack` (the exception type +
  inner-exception chain, since `ErrorBoundary` does not expose Blazor's render
  stack). Aligns the recoverable-path report with the server-logged fields.
- **Docs:** new "WebUI Shows 'An error has occurred'" troubleshooting subsection
  describing how to find these in the gateway log (`Channel error reported`) and
  via `/api/diagnostics/log-patterns`.

The existing server endpoint/DTO (`POST /api/diagnostics/channel-error` →
`ChannelErrorReport`, logged at Error level) is reused unchanged — no new server
surface.

## Tests
New `MobileGlobalErrorBoundaryTests` (2 cases): the reported DTO carries the
active conversation's `SessionId` and a non-empty `ComponentStack`, and falls
back to the agent session when there is no active conversation. (The JS hook is
browser-only plumbing and is not exercised by bUnit.)

`test-impacted.ps1` green: Architecture 192, Mobile.Tests 47 (+2),
BlazorClient.Tests 580, Conversations 236, Gateway.Tests 3083, Scenarios 29.

## Merge Notes
Touches `Mobile/wwwroot/index.html`, `BlazorClient/wwwroot/index.html`, two new
`errorReporting.js` files, mobile `GlobalErrorBoundary.razor`, a new mobile test,
and a docs page.
- **Disjoint from #1483** (which fixes the mobile `Chat.razor` render *crash* —
  one of the very errors this PR would now surface). Safe to merge in parallel.
- No overlap with the only other open PR, #1170 (GatewayHub.cs).
- Part of the broader #1482 ask_user durability epic only insofar as both improve
  portal robustness; this PR is independent.
