### PR TITLE
fix(gateway): redact secrets for every config section, not just providers

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConfigController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConfigController.cs
@@ -70,8 +70,20 @@ public sealed class ConfigController : ControllerBase
             return NotFound();
 
         var sectionNode = config[section]?.DeepClone();
-        if (section.Equals("providers", StringComparison.OrdinalIgnoreCase) && sectionNode is JsonObject providers)
-            RedactProviderSecrets(providers);
+
+        // Route the section through the SAME redaction logic the whole-config path uses,
+        // not just the providers special case. A per-section read must never expose secrets
+        // the whole-config read (GET /api/config, /api/config/raw) masks -- e.g. the gateway
+        // section carries apiKeys / connection strings / cross-world peer keys. Wrap the section
+        // back into a { [section]: node } object so RedactSecrets keys on the real section name,
+        // redact in place, then unwrap. This covers providers, gateway, and any future
+        // secret-bearing section without per-section special casing (#1516).
+        if (sectionNode is not null)
+        {
+            var wrapper = new JsonObject { [section] = sectionNode };
+            RedactSecrets(wrapper);
+            sectionNode = wrapper[section];
+        }
 
         return Ok(sectionNode);
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/ConfigControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConfigControllerTests.cs
@@ -2,6 +2,8 @@ using BotNexus.Gateway.Api.Controllers;
 using BotNexus.Gateway.Configuration;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using System.IO.Abstractions;
+using System.Text.Json.Nodes;
 
 namespace BotNexus.Gateway.Tests;
 
@@ -155,6 +157,129 @@ public sealed class ConfigControllerTests
             var payload = ok.Value.ShouldBeOfType<ConfigValidationResponse>();
             payload.IsValid.ShouldBeFalse();
             payload.Errors.ShouldContain(error => error.Contains("Invalid JSON in config file", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // GetSection secret redaction (#1516)
+    // The per-section read must mask EVERY secret-bearing section, not just providers.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task GetSection_GatewaySection_RedactsApiKeysConnectionStringsAndCrossWorldSecrets()
+    {
+        const string raw = """
+        {
+          "gateway": {
+            "listenUrl": "http://localhost:5000",
+            "apiKeys": { "tenant-a": { "apiKey": "super-secret-key" } },
+            "sessionStore": { "connectionString": "Data Source=secret.db;Password=hunter2" },
+            "locations": { "primary": { "connectionString": "Server=db;Password=loc-secret" } },
+            "crossWorld": {
+              "peers": { "peer-1": { "apiKey": "peer-secret" } },
+              "inbound": { "apiKeys": { "inbound-1": "inbound-secret" } }
+            }
+          }
+        }
+        """;
+
+        await WithConfigFileAsync(raw, async (controller, writer) =>
+        {
+            var result = await controller.GetSection("gateway", writer, CancellationToken.None);
+            var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+            var gateway = ok.Value.ShouldBeOfType<JsonObject>();
+
+            // Non-secret values are preserved.
+            gateway["listenUrl"]!.GetValue<string>().ShouldBe("http://localhost:5000");
+
+            // Every secret-bearing field is masked.
+            gateway["apiKeys"]!["tenant-a"]!["apiKey"]!.GetValue<string>().ShouldBe("***");
+            gateway["sessionStore"]!["connectionString"]!.GetValue<string>().ShouldBe("***");
+            gateway["locations"]!["primary"]!["connectionString"]!.GetValue<string>().ShouldBe("***");
+            gateway["crossWorld"]!["peers"]!["peer-1"]!["apiKey"]!.GetValue<string>().ShouldBe("***");
+            gateway["crossWorld"]!["inbound"]!["apiKeys"]!["inbound-1"]!.GetValue<string>().ShouldBe("***");
+
+            // The plaintext secrets must not appear anywhere in the serialized payload.
+            var serialized = gateway.ToJsonString();
+            serialized.ShouldNotContain("super-secret-key");
+            serialized.ShouldNotContain("hunter2");
+            serialized.ShouldNotContain("loc-secret");
+            serialized.ShouldNotContain("peer-secret");
+            serialized.ShouldNotContain("inbound-secret");
+        });
+    }
+
+    [Fact]
+    public async Task GetSection_ProvidersSection_StillRedactsApiKeys()
+    {
+        const string raw = """
+        {
+          "providers": {
+            "openai": { "apiKey": "sk-provider-secret", "model": "gpt-4.1" }
+          }
+        }
+        """;
+
+        await WithConfigFileAsync(raw, async (controller, writer) =>
+        {
+            var result = await controller.GetSection("providers", writer, CancellationToken.None);
+            var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+            var providers = ok.Value.ShouldBeOfType<JsonObject>();
+
+            providers["openai"]!["apiKey"]!.GetValue<string>().ShouldBe("***");
+            providers["openai"]!["model"]!.GetValue<string>().ShouldBe("gpt-4.1");
+            providers.ToJsonString().ShouldNotContain("sk-provider-secret");
+        });
+    }
+
+    [Fact]
+    public async Task GetSection_NonSecretSection_ReturnsContentUnchanged()
+    {
+        const string raw = """
+        {
+          "channels": { "signalr": { "enabled": true } }
+        }
+        """;
+
+        await WithConfigFileAsync(raw, async (controller, writer) =>
+        {
+            var result = await controller.GetSection("channels", writer, CancellationToken.None);
+            var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+            var channels = ok.Value.ShouldBeOfType<JsonObject>();
+
+            channels["signalr"]!["enabled"]!.GetValue<bool>().ShouldBeTrue();
+        });
+    }
+
+    [Fact]
+    public async Task GetSection_MissingSection_ReturnsNotFound()
+    {
+        const string raw = """{ "gateway": { "listenUrl": "http://localhost:5000" } }""";
+
+        await WithConfigFileAsync(raw, async (controller, writer) =>
+        {
+            var result = await controller.GetSection("does-not-exist", writer, CancellationToken.None);
+            result.Result.ShouldBeOfType<NotFoundResult>();
+        });
+    }
+
+    private static async Task WithConfigFileAsync(
+        string rawJson,
+        Func<ConfigController, PlatformConfigWriter, Task> body)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "botnexus-config-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var path = Path.Combine(root, "config.json");
+        try
+        {
+            await File.WriteAllTextAsync(path, rawJson);
+            var controller = new ConfigController();
+            var writer = new PlatformConfigWriter(path, new FileSystem());
+            await body(controller, writer);
         }
         finally
         {


### PR DESCRIPTION
Closes #1516

## Problem (HIGH severity, secret leak)
`GET /api/config/{section}` (`ConfigController.GetSection`) only redacted secrets when
`section == "providers"`. Every other section was returned **unredacted**, including the
`gateway` section, which carries live credentials. So `GET /api/config/gateway` returned
api keys / connection strings in plaintext while `GET /api/config` (whole config) and
`GET /api/config/raw` mask them via `RedactSecrets`. A per-section read silently bypassed the
redaction the whole-config read applies -- the same sibling-surface leak class as #1494.

`RedactSecrets` masks three areas, not just providers:
- `providers[*].apiKey`
- top-level `apiKey`
- the whole `gateway` section: `gateway.apiKeys[*].apiKey`, `gateway.sessionStore.connectionString`,
  `gateway.locations[*].connectionString`, `gateway.crossWorld.peers[*].apiKey`,
  `gateway.crossWorld.inbound.apiKeys[*]`.

## Fix
Route `GetSection` through the SAME redaction logic the whole-config path uses. The section node
is wrapped back into a `{ [section]: node }` object so `RedactSecrets` keys on the real section
name, redacted in place, then unwrapped. This covers `providers`, `gateway`, and any future
secret-bearing section without per-section special casing -- no new redactor, reuses the existing
one that the whole-config path already trusts.

## Changes
- `ConfigController.GetSection`: wrap-redact-unwrap the section through `RedactSecrets` instead of
  the providers-only special case.
- `ConfigControllerTests`: 4 new tests
  - `gateway` section masks apiKeys / connection strings / cross-world peer + inbound keys, and the
    plaintext secrets do not appear anywhere in the serialized payload (non-secret values preserved).
  - `providers` section still redacts apiKeys (regression guard).
  - a non-secret section (`channels`) is returned unchanged.
  - a missing section still returns 404.

## Verification
- Full solution `dotnet build BotNexus.slnx --no-incremental -warnaserror`: 0 warnings, 0 errors.
- test-impacted.ps1 green: Architecture 192, Scenarios 29, Gateway.Tests 3091 (+4) / 1 skip,
  Gateway.Conversations.Tests 236.

## Merge Notes
Touches only `ConfigController.cs` + its test. Disjoint from all other open PRs (#1513/#1514/#1515/#1517).
Safe to merge in any order. The #1502 redaction fence (open PR #1515) could be tightened later to
also assert `GetSection` redacts beyond providers, but that is independent of this behavioral fix.
