### PR TITLE
fix(cron): defer scheduled heartbeat while an agent run is active

### DIFF
--- a/src/gateway/BotNexus.Cron/Actions/HeartbeatAction.cs
+++ b/src/gateway/BotNexus.Cron/Actions/HeartbeatAction.cs
@@ -59,6 +59,20 @@ public sealed class HeartbeatAction : ICronAction
         if (string.IsNullOrWhiteSpace(prompt))
             throw new InvalidOperationException("Heartbeat cron job must define a message prompt.");
 
+        // Pre-flight: defer a SCHEDULED heartbeat while the agent already has a run in flight.
+        // A background heartbeat firing mid-turn injects a redundant wake (or competes with the
+        // active run), so it is deferred until the next schedule when the agent is busy. Manual /
+        // immediate wakes keep their existing semantics and always fire. This is the
+        // "defer-when-active-run" behavior (#1500); the authoritative busy signal is the agent
+        // handle's IsRunning, which reflects the per-turn AgentStatus (not handle liveness).
+        if (context.TriggerType == CronTriggerType.Scheduled && HasActiveRun(context.Services, agentId))
+        {
+            logger?.LogDebug(
+                "Deferring scheduled heartbeat for agent '{AgentId}' \u2014 a run is currently active.",
+                agentId);
+            return;
+        }
+
         var trigger = ResolveHeartbeatTrigger(context.Services, descriptor);
 
         var sessionId = await trigger
@@ -77,6 +91,32 @@ public sealed class HeartbeatAction : ICronAction
             .ConfigureAwait(false);
 
         context.RecordSessionId(sessionId);
+    }
+
+    /// <summary>
+    /// Returns true when the agent has at least one live instance whose handle is currently
+    /// processing a turn. Used to defer scheduled heartbeats while a run is in flight (#1500).
+    /// Returns false when no supervisor is registered (e.g. minimal hosts) so heartbeats still fire.
+    /// </summary>
+    private static bool HasActiveRun(IServiceProvider services, AgentId agentId)
+    {
+        var supervisor = services.GetService<IAgentSupervisor>();
+        if (supervisor is null)
+            return false;
+
+        foreach (var instance in supervisor.GetAllInstances())
+        {
+            if (!instance.AgentId.Equals(agentId))
+                continue;
+
+            // GetHandle returns the live handle whose IsRunning reflects the agent's per-turn
+            // status; AgentInstance.Status is not transitioned per-turn, so it cannot be used here.
+            var handle = supervisor.GetHandle(instance.AgentId, instance.SessionId);
+            if (handle is { IsRunning: true })
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/gateway/BotNexus.Cron.Tests/HeartbeatActionTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/HeartbeatActionTests.cs
@@ -259,6 +259,153 @@ public sealed class HeartbeatActionTests
     }
 
     // -----------------------------------------------------------------
+    // Defer-when-active-run (#1500)
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task ExecuteAsync_ScheduledHeartbeat_DefersWhenAgentRunIsActive()
+    {
+        var action = new HeartbeatAction();
+        var trigger = new Mock<IInternalTrigger>();
+        var registry = new Mock<IAgentRegistry>();
+        var supervisor = BuildSupervisorWithInstance("agent-a", isRunning: true);
+
+        trigger.SetupGet(v => v.Type).Returns(TriggerType.Heartbeat);
+        registry.Setup(v => v.Get(AgentId.From("agent-a"))).Returns((AgentDescriptor?)null);
+
+        var services = new ServiceCollection()
+            .AddSingleton(registry.Object)
+            .AddSingleton<IInternalTrigger>(trigger.Object)
+            .AddSingleton(supervisor.Object)
+            .BuildServiceProvider();
+        var context = CreateContext(services, triggerType: CronTriggerType.Scheduled);
+
+        await action.ExecuteAsync(context);
+
+        trigger.Verify(v => v.CreateSessionAsync(
+            It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()),
+            Times.Never);
+        context.SessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ScheduledHeartbeat_FiresWhenAgentRunIsIdle()
+    {
+        var action = new HeartbeatAction();
+        var trigger = new Mock<IInternalTrigger>();
+        var registry = new Mock<IAgentRegistry>();
+        var sessionId = SessionId.From("heartbeat:agent-a:20260101000000:idleidle");
+        var supervisor = BuildSupervisorWithInstance("agent-a", isRunning: false);
+
+        trigger.SetupGet(v => v.Type).Returns(TriggerType.Heartbeat);
+        trigger.Setup(v => v.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
+            .ReturnsAsync(sessionId);
+        registry.Setup(v => v.Get(AgentId.From("agent-a"))).Returns((AgentDescriptor?)null);
+
+        var services = new ServiceCollection()
+            .AddSingleton(registry.Object)
+            .AddSingleton<IInternalTrigger>(trigger.Object)
+            .AddSingleton(supervisor.Object)
+            .BuildServiceProvider();
+        var context = CreateContext(services, triggerType: CronTriggerType.Scheduled);
+
+        await action.ExecuteAsync(context);
+
+        trigger.Verify(v => v.CreateSessionAsync(
+            It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()),
+            Times.Once);
+        context.SessionId!.Value.ShouldBe(sessionId);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ManualWake_FiresEvenWhenAgentRunIsActive()
+    {
+        // Manual / immediate wakes must keep their existing semantics and never defer.
+        var action = new HeartbeatAction();
+        var trigger = new Mock<IInternalTrigger>();
+        var registry = new Mock<IAgentRegistry>();
+        var sessionId = SessionId.From("heartbeat:agent-a:20260101000000:manualww");
+        var supervisor = BuildSupervisorWithInstance("agent-a", isRunning: true);
+
+        trigger.SetupGet(v => v.Type).Returns(TriggerType.Heartbeat);
+        trigger.Setup(v => v.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
+            .ReturnsAsync(sessionId);
+        registry.Setup(v => v.Get(AgentId.From("agent-a"))).Returns((AgentDescriptor?)null);
+
+        var services = new ServiceCollection()
+            .AddSingleton(registry.Object)
+            .AddSingleton<IInternalTrigger>(trigger.Object)
+            .AddSingleton(supervisor.Object)
+            .BuildServiceProvider();
+        var context = CreateContext(services, triggerType: CronTriggerType.Manual);
+
+        await action.ExecuteAsync(context);
+
+        trigger.Verify(v => v.CreateSessionAsync(
+            It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()),
+            Times.Once);
+        context.SessionId!.Value.ShouldBe(sessionId);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ScheduledHeartbeat_FiresWhenNoSupervisorRegistered()
+    {
+        // No IAgentSupervisor (minimal host) -> heartbeats must still fire, not silently skip.
+        var action = new HeartbeatAction();
+        var trigger = new Mock<IInternalTrigger>();
+        var registry = new Mock<IAgentRegistry>();
+        var sessionId = SessionId.From("heartbeat:agent-a:20260101000000:nosuperv");
+
+        trigger.SetupGet(v => v.Type).Returns(TriggerType.Heartbeat);
+        trigger.Setup(v => v.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
+            .ReturnsAsync(sessionId);
+        registry.Setup(v => v.Get(AgentId.From("agent-a"))).Returns((AgentDescriptor?)null);
+
+        var services = new ServiceCollection()
+            .AddSingleton(registry.Object)
+            .AddSingleton<IInternalTrigger>(trigger.Object)
+            // no IAgentSupervisor registered
+            .BuildServiceProvider();
+        var context = CreateContext(services, triggerType: CronTriggerType.Scheduled);
+
+        await action.ExecuteAsync(context);
+
+        trigger.Verify(v => v.CreateSessionAsync(
+            It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ScheduledHeartbeat_FiresWhenOnlyAnotherAgentRunIsActive()
+    {
+        // A running instance belonging to a DIFFERENT agent must not defer this agent's heartbeat.
+        var action = new HeartbeatAction();
+        var trigger = new Mock<IInternalTrigger>();
+        var registry = new Mock<IAgentRegistry>();
+        var sessionId = SessionId.From("heartbeat:agent-a:20260101000000:otheragn");
+        var supervisor = BuildSupervisorWithInstance("agent-b", isRunning: true);
+
+        trigger.SetupGet(v => v.Type).Returns(TriggerType.Heartbeat);
+        trigger.Setup(v => v.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
+            .ReturnsAsync(sessionId);
+        registry.Setup(v => v.Get(AgentId.From("agent-a"))).Returns((AgentDescriptor?)null);
+
+        var services = new ServiceCollection()
+            .AddSingleton(registry.Object)
+            .AddSingleton<IInternalTrigger>(trigger.Object)
+            .AddSingleton(supervisor.Object)
+            .BuildServiceProvider();
+        var context = CreateContext(services, triggerType: CronTriggerType.Scheduled);
+
+        await action.ExecuteAsync(context);
+
+        trigger.Verify(v => v.CreateSessionAsync(
+            It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()),
+            Times.Once);
+        context.SessionId!.Value.ShouldBe(sessionId);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 4: HEARTBEAT.md pre-check — IsEffectivelyEmpty
     // -----------------------------------------------------------------
 
@@ -413,7 +560,8 @@ public sealed class HeartbeatActionTests
     private static CronExecutionContext CreateContext(
         IServiceProvider services,
         string? agentId = "agent-a",
-        string? message = "Heartbeat ping")
+        string? message = "Heartbeat ping",
+        CronTriggerType triggerType = CronTriggerType.Scheduled)
         => new()
         {
             Job = new CronJob
@@ -431,9 +579,33 @@ public sealed class HeartbeatActionTests
             },
             RunId = RunId.From("run-1"),
             TriggeredAt = DateTimeOffset.UtcNow,
-            TriggerType = CronTriggerType.Scheduled,
+            TriggerType = triggerType,
             Services = services
         };
+
+    /// <summary>
+    /// Builds a mock <see cref="IAgentSupervisor"/> holding a single live instance for the given
+    /// agent, with a handle whose <c>IsRunning</c> reflects <paramref name="isRunning"/>.
+    /// </summary>
+    private static Mock<IAgentSupervisor> BuildSupervisorWithInstance(string agentId, bool isRunning)
+    {
+        var id = AgentId.From(agentId);
+        var sessionId = SessionId.From($"chat:{agentId}:20260101000000:sessabcd");
+        var instance = new AgentInstance
+        {
+            InstanceId = $"{agentId}:{sessionId.Value}",
+            AgentId = id,
+            SessionId = sessionId,
+            IsolationStrategy = "in-process"
+        };
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.IsRunning).Returns(isRunning);
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetAllInstances()).Returns([instance]);
+        supervisor.Setup(s => s.GetHandle(id, sessionId)).Returns(handle.Object);
+        return supervisor;
+    }
 
     private static AgentDescriptor CreateDescriptorWithQuietHours(QuietHoursConfig quietHours)
         => new()


### PR DESCRIPTION
Closes #1500

## Problem
A scheduled (background) heartbeat could fire while the agent already had a run/turn in flight,
injecting a redundant wake that competes with the active run. `HeartbeatAction.ExecuteAsync` had
quiet-hours and HEARTBEAT.md-emptiness pre-checks but no "defer-when-active-run" gate. This mirrors
the OpenClaw heartbeat fix (`2196ea29304a`) that broadened the defer check to any active run for the
agent while leaving immediate/manual wakes unchanged.

## Fix
Before resolving the trigger, a SCHEDULED heartbeat now defers (skips) when the agent has at least
one live instance whose handle is currently processing a turn. Manual wakes
(`CronTriggerType.Manual`) keep their existing semantics and always fire.

### Why `IAgentHandle.IsRunning` (not `AgentInstance.Status`)
The authoritative per-turn busy signal is `IAgentHandle.IsRunning`, which reflects
`AgentStatus.Running` (set at turn start, reset to `Idle` in the turn's finally -- verified in
`Agent.cs`). `AgentInstance.Status` is created as `Idle` and only transitions to
`Stopping`/`Stopped` (never per-turn), so it cannot be used as the active-run signal. The new
`HasActiveRun` helper resolves `IAgentSupervisor`, walks `GetAllInstances()` for the agent, and
checks each handle's `IsRunning` via `GetHandle(...)`.

When no `IAgentSupervisor` is registered (minimal hosts) the check returns false so heartbeats
still reliably fire -- addressing the "silently fails to fire" half of the issue (never silently skip).

## Changes
- `HeartbeatAction.ExecuteAsync`: defer a scheduled heartbeat when `HasActiveRun(agentId)` is true.
- `HeartbeatAction.HasActiveRun`: new private helper using `IAgentSupervisor` + per-handle `IsRunning`.
- `HeartbeatActionTests`: 5 new tests
  - scheduled + agent run active -> deferred (no session created).
  - scheduled + agent run idle -> fires.
  - manual wake + agent run active -> fires (never defers).
  - scheduled + no supervisor registered -> fires (graceful fallback, no silent skip).
  - scheduled + only ANOTHER agent's run active -> fires (only this agent's run defers).

## Verification
- Full solution `dotnet build BotNexus.slnx --no-incremental -warnaserror`: 0 warnings, 0 errors.
- test-impacted.ps1 green: Architecture 192, Scenarios 29, Cron.Tests 201 (+5), Cli.Tests 298,
  Gateway.Tests 3087 / 1 skip, Gateway.Conversations.Tests 236, Mcp.Tests 186.

## Merge Notes
Touches only `HeartbeatAction.cs` + its test. Disjoint from all other open PRs
(#1513/#1514/#1515/#1517). Safe to merge in any order.
