### PR TITLE
ci(security): add a guard for security-sensitive boundary files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# CODEOWNERS -- security-sensitive boundary files
+#
+# These paths govern the security posture of the repository (what secret files
+# are ignored, what CI runs, who can change the guards). Changes to them require
+# review from the maintainer. This is enforced together with the
+# "Security: Sensitive File Guard" workflow, which additionally requires a
+# head-SHA-bound `/allow-security-sensitive-change` ack on the PR.
+#
+# Syntax: <path-pattern> <owner ...>
+# Later matching rules take precedence over earlier ones.
+
+# Default: no global owner (only the sensitive paths below are guarded).
+
+# Secret-file ignore rules -- un-ignoring `.env` / key files here is a real
+# accidental-secret-commit risk.
+/.gitignore        @Sytone
+/.gitattributes    @Sytone
+
+# CI workflows and the security guards themselves.
+/.github/workflows/                                  @Sytone
+/.github/scripts/security-sensitive-guard.mjs        @Sytone
+/.github/CODEOWNERS                                  @Sytone

--- a/.github/scripts/security-sensitive-guard.mjs
+++ b/.github/scripts/security-sensitive-guard.mjs
@@ -1,0 +1,213 @@
+// @ts-check
+/**
+ * Security-sensitive boundary-file guard.
+ *
+ * Blocks a pull request that modifies any file on the curated sensitive list
+ * (e.g. `.gitignore`, which governs whether `.env` / secret files are ignored
+ * before they can be accidentally committed) unless an authorized maintainer
+ * posts a head-SHA-bound `/allow-security-sensitive-change <sha>` approval.
+ *
+ * SAFETY MODEL (why this is safe to run on `pull_request_target`):
+ *   - The workflow checks out ONLY the trusted base-branch copy of this script
+ *     (`ref: base.sha`, `persist-credentials: false`). It never executes any
+ *     code from the PR head, so an attacker cannot rewrite the guard in their PR.
+ *   - The set of changed files is read from the GitHub API (compare base..head),
+ *     not from a working tree, so no PR-head content is sourced.
+ *   - Approval is bound to the CURRENT head SHA. A later push to the PR
+ *     invalidates a prior approval (no approve-then-sneak-a-commit).
+ *   - Approval is only honored from users with `admin`, `maintain`, or `write`
+ *     repository permission.
+ *
+ * This module exports a single `run({ github, context, core })` function so it
+ * can be invoked from `actions/github-script` and unit-tested in isolation.
+ */
+
+/**
+ * Files (exact paths) and path-prefixes considered security-sensitive boundary
+ * surfaces. A PR touching any of these requires an explicit maintainer ack.
+ */
+export const SENSITIVE_EXACT = Object.freeze([
+  ".gitignore",
+  ".gitattributes",
+  ".github/CODEOWNERS",
+  ".github/scripts/security-sensitive-guard.mjs",
+  ".github/workflows/security-sensitive-guard.yml",
+]);
+
+/**
+ * Path prefixes considered security-sensitive. Any changed file whose path
+ * starts with one of these requires the maintainer ack.
+ */
+export const SENSITIVE_PREFIXES = Object.freeze([
+  ".github/workflows/",
+]);
+
+/** The comment command an authorized maintainer posts to approve. */
+export const APPROVE_COMMAND = "/allow-security-sensitive-change";
+
+/** Repository permission levels allowed to approve a sensitive change. */
+const APPROVER_PERMISSIONS = Object.freeze(["admin", "maintain", "write"]);
+
+/**
+ * Returns the subset of changed paths that are security-sensitive.
+ * @param {string[]} changedPaths
+ * @returns {string[]}
+ */
+export function matchSensitivePaths(changedPaths) {
+  const matched = [];
+  for (const path of changedPaths) {
+    const normalized = path.replace(/\\/g, "/").replace(/^\.\//, "");
+    if (SENSITIVE_EXACT.includes(normalized)) {
+      matched.push(normalized);
+      continue;
+    }
+    if (SENSITIVE_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
+      matched.push(normalized);
+    }
+  }
+  // De-duplicate while preserving order.
+  return [...new Set(matched)];
+}
+
+/**
+ * Parses an approval comment body for a head-SHA-bound approval token.
+ * Accepts `/allow-security-sensitive-change <sha>` where `<sha>` is a 7-40 char
+ * hex prefix of the head SHA. The command must appear at the start of a line.
+ * @param {string} body
+ * @returns {string | null} the lowercased SHA token, or null if absent/malformed
+ */
+export function parseApprovalSha(body) {
+  if (typeof body !== "string" || body.length === 0) {
+    return null;
+  }
+  // Anchor to a line start so the command cannot be smuggled inside prose.
+  const re = new RegExp(
+    `(?:^|\\n)\\s*${APPROVE_COMMAND.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s+([0-9a-fA-F]{7,40})\\b`
+  );
+  const match = re.exec(body);
+  return match ? match[1].toLowerCase() : null;
+}
+
+/**
+ * True when `candidate` is a valid hex prefix of (or equal to) `headSha`.
+ * @param {string} candidate lowercased hex prefix from the approval comment
+ * @param {string} headSha the current PR head SHA (full, lowercased)
+ * @returns {boolean}
+ */
+export function shaMatchesHead(candidate, headSha) {
+  if (!candidate || !headSha) {
+    return false;
+  }
+  const head = headSha.toLowerCase();
+  return head === candidate || head.startsWith(candidate);
+}
+
+/**
+ * Main entry point invoked by actions/github-script.
+ * @param {{ github: any, context: any, core: any }} args
+ * @returns {Promise<void>}
+ */
+export async function run({ github, context, core }) {
+  const pr = context.payload.pull_request;
+  if (!pr) {
+    core.info("No pull_request payload present; nothing to guard.");
+    return;
+  }
+
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const prNumber = pr.number;
+  const headSha = String(pr.head?.sha ?? "").toLowerCase();
+
+  // 1. Compute the set of files this PR changes (via the API, never the tree).
+  const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: prNumber,
+    per_page: 100,
+  });
+  const changedPaths = changedFiles.map((f) => f.filename);
+  const sensitive = matchSensitivePaths(changedPaths);
+
+  if (sensitive.length === 0) {
+    core.info("No security-sensitive boundary files changed. Guard passes.");
+    return;
+  }
+
+  core.info(
+    `PR #${prNumber} touches ${sensitive.length} security-sensitive file(s): ${sensitive.join(", ")}`
+  );
+
+  // 2. Look for a head-SHA-bound approval from an authorized maintainer.
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: prNumber,
+    per_page: 100,
+  });
+
+  let approved = false;
+  let approver = null;
+  for (const comment of comments) {
+    const candidate = parseApprovalSha(comment.body);
+    if (!candidate || !shaMatchesHead(candidate, headSha)) {
+      continue;
+    }
+    const login = comment.user?.login;
+    if (!login) {
+      continue;
+    }
+    // Verify the commenter currently has approver-level repo permission.
+    let permission = "none";
+    try {
+      const res = await github.rest.repos.getCollaboratorPermissionLevel({
+        owner,
+        repo,
+        username: login,
+      });
+      permission = res.data?.permission ?? "none";
+    } catch (err) {
+      core.warning(`Could not resolve permission for ${login}: ${err}`);
+      continue;
+    }
+    if (APPROVER_PERMISSIONS.includes(permission)) {
+      approved = true;
+      approver = login;
+      break;
+    }
+    core.info(
+      `${login} posted an approval but has '${permission}' permission (need admin/maintain/write).`
+    );
+  }
+
+  // 3. Surface the result. Fail the check when not approved.
+  const fileList = sensitive.map((f) => `- \`${f}\``).join("\n");
+  if (approved) {
+    core.notice(
+      `Security-sensitive change approved by @${approver} for head ${headSha.slice(0, 12)}.`
+    );
+    core.summary
+      .addHeading("Security-sensitive file guard: APPROVED", 3)
+      .addRaw(`Approved by @${approver} (head \`${headSha.slice(0, 12)}\`).\n\n`)
+      .addRaw(`Sensitive files changed:\n${fileList}\n`);
+    await core.summary.write();
+    return;
+  }
+
+  const instructions =
+    `This PR modifies security-sensitive boundary files:\n${fileList}\n\n` +
+    `These files (e.g. \`.gitignore\`, which controls whether secret/\`.env\` files are ` +
+    `ignored, and the CI workflows themselves) require an explicit maintainer ack.\n\n` +
+    `An authorized maintainer (admin/maintain/write) must comment:\n\n` +
+    `    ${APPROVE_COMMAND} ${headSha}\n\n` +
+    `The approval is bound to the current head SHA \`${headSha.slice(0, 12)}\` — ` +
+    `pushing a new commit invalidates it and requires a fresh ack.`;
+
+  core.summary
+    .addHeading("Security-sensitive file guard: BLOCKED", 3)
+    .addRaw(instructions.replace(/\n/g, "\n\n"));
+  await core.summary.write();
+  core.setFailed(instructions);
+}
+
+export default run;

--- a/.github/scripts/security-sensitive-guard.test.mjs
+++ b/.github/scripts/security-sensitive-guard.test.mjs
@@ -167,7 +167,10 @@ test("run blocks when a sensitive file changed and there is no approval", async 
   await run(h);
   assert.ok(h.state.failed, "should setFailed");
   assert.match(h.state.failed, /\.gitignore/);
-  assert.match(h.state.failed, new RegExp(APPROVE_COMMAND.replace(/[/]/g, "\\/")));
+  assert.match(
+    h.state.failed,
+    new RegExp(APPROVE_COMMAND.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  );
 });
 
 test("run approves when an admin posts a head-SHA-bound ack", async () => {

--- a/.github/scripts/security-sensitive-guard.test.mjs
+++ b/.github/scripts/security-sensitive-guard.test.mjs
@@ -1,0 +1,207 @@
+// @ts-check
+/**
+ * Unit tests for the security-sensitive boundary-file guard.
+ * Run with:  node --test .github/scripts/security-sensitive-guard.test.mjs
+ *
+ * These cover the security-critical pure logic: which paths are sensitive,
+ * how the head-SHA-bound approval token is parsed, and SHA matching. The
+ * `run()` orchestration is exercised with a stubbed `github`/`context`/`core`
+ * to assert the block/approve decision and the permission gate.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  matchSensitivePaths,
+  parseApprovalSha,
+  shaMatchesHead,
+  run,
+  APPROVE_COMMAND,
+} from "./security-sensitive-guard.mjs";
+
+test("matchSensitivePaths flags .gitignore and .gitattributes", () => {
+  assert.deepEqual(matchSensitivePaths([".gitignore"]), [".gitignore"]);
+  assert.deepEqual(matchSensitivePaths([".gitattributes"]), [".gitattributes"]);
+});
+
+test("matchSensitivePaths flags any workflow file via prefix", () => {
+  assert.deepEqual(
+    matchSensitivePaths([".github/workflows/ci-build-test.yml"]),
+    [".github/workflows/ci-build-test.yml"]
+  );
+});
+
+test("matchSensitivePaths flags CODEOWNERS and the guard script/workflow", () => {
+  assert.deepEqual(matchSensitivePaths([".github/CODEOWNERS"]), [".github/CODEOWNERS"]);
+  assert.deepEqual(
+    matchSensitivePaths([".github/scripts/security-sensitive-guard.mjs"]),
+    [".github/scripts/security-sensitive-guard.mjs"]
+  );
+});
+
+test("matchSensitivePaths ignores ordinary source/doc files", () => {
+  assert.deepEqual(
+    matchSensitivePaths([
+      "src/gateway/BotNexus.Gateway/GatewayHost.cs",
+      "docs/index.md",
+      "README.md",
+    ]),
+    []
+  );
+});
+
+test("matchSensitivePaths normalizes backslashes and ./ prefix", () => {
+  assert.deepEqual(matchSensitivePaths(["./.gitignore"]), [".gitignore"]);
+  assert.deepEqual(
+    matchSensitivePaths([".github\\workflows\\release-cli.yml"]),
+    [".github/workflows/release-cli.yml"]
+  );
+});
+
+test("matchSensitivePaths de-duplicates", () => {
+  assert.deepEqual(
+    matchSensitivePaths([".gitignore", "./.gitignore", ".gitignore"]),
+    [".gitignore"]
+  );
+});
+
+test("parseApprovalSha extracts a line-anchored SHA token", () => {
+  assert.equal(
+    parseApprovalSha(`${APPROVE_COMMAND} abc1234`),
+    "abc1234"
+  );
+  assert.equal(
+    parseApprovalSha(`please proceed\n${APPROVE_COMMAND} DEADBEEFCAFE`),
+    "deadbeefcafe"
+  );
+});
+
+test("parseApprovalSha rejects command smuggled mid-line (not line-anchored)", () => {
+  assert.equal(
+    parseApprovalSha(`nonsense ${APPROVE_COMMAND} abc1234`),
+    null,
+    "command must start a line"
+  );
+});
+
+test("parseApprovalSha rejects missing/short/non-hex tokens", () => {
+  assert.equal(parseApprovalSha(`${APPROVE_COMMAND}`), null);
+  assert.equal(parseApprovalSha(`${APPROVE_COMMAND} 12345`), null, "too short (<7)");
+  assert.equal(parseApprovalSha(`${APPROVE_COMMAND} zzzzzzz`), null, "non-hex");
+  assert.equal(parseApprovalSha(""), null);
+  assert.equal(parseApprovalSha(null), null);
+});
+
+test("shaMatchesHead accepts a hex prefix and the full SHA, rejects mismatch", () => {
+  const head = "abc1234def5678901234567890abcdef12345678";
+  assert.equal(shaMatchesHead("abc1234", head), true);
+  assert.equal(shaMatchesHead(head, head), true);
+  assert.equal(shaMatchesHead("abc1235", head), false);
+  assert.equal(shaMatchesHead("", head), false);
+  assert.equal(shaMatchesHead("abc1234", ""), false);
+});
+
+// --- run() orchestration with stubs -----------------------------------------
+
+/**
+ * Builds a stub github/context/core trio for run().
+ * @param {object} opts
+ * @param {string[]} opts.changedPaths
+ * @param {Array<{body:string, login:string}>} [opts.comments]
+ * @param {Record<string,string>} [opts.permissions] login -> permission
+ * @param {string} [opts.headSha]
+ */
+function makeHarness(opts) {
+  const headSha = opts.headSha ?? "abc1234def5678901234567890abcdef12345678";
+  const comments = opts.comments ?? [];
+  const permissions = opts.permissions ?? {};
+  const state = { failed: null, notices: [], summaryRaw: [] };
+
+  const github = {
+    paginate: async (fn, params) => fn(params),
+    rest: {
+      pulls: {
+        listFiles: async () => opts.changedPaths.map((filename) => ({ filename })),
+      },
+      issues: {
+        listComments: async () =>
+          comments.map((c) => ({ body: c.body, user: { login: c.login } })),
+      },
+      repos: {
+        getCollaboratorPermissionLevel: async ({ username }) => ({
+          data: { permission: permissions[username] ?? "none" },
+        }),
+      },
+    },
+  };
+
+  const context = {
+    repo: { owner: "Sytone", repo: "botnexus" },
+    payload: { pull_request: { number: 7, head: { sha: headSha } } },
+  };
+
+  const summary = {
+    addHeading() { return summary; },
+    addRaw(s) { state.summaryRaw.push(s); return summary; },
+    write: async () => {},
+  };
+  const core = {
+    info() {},
+    warning() {},
+    notice(m) { state.notices.push(m); },
+    setFailed(m) { state.failed = m; },
+    summary,
+  };
+
+  return { github, context, core, state };
+}
+
+test("run passes silently when no sensitive files changed", async () => {
+  const h = makeHarness({ changedPaths: ["src/Foo.cs", "docs/x.md"] });
+  await run(h);
+  assert.equal(h.state.failed, null);
+});
+
+test("run blocks when a sensitive file changed and there is no approval", async () => {
+  const h = makeHarness({ changedPaths: [".gitignore"] });
+  await run(h);
+  assert.ok(h.state.failed, "should setFailed");
+  assert.match(h.state.failed, /\.gitignore/);
+  assert.match(h.state.failed, new RegExp(APPROVE_COMMAND.replace(/[/]/g, "\\/")));
+});
+
+test("run approves when an admin posts a head-SHA-bound ack", async () => {
+  const headSha = "abc1234def5678901234567890abcdef12345678";
+  const h = makeHarness({
+    changedPaths: [".github/workflows/ci-build-test.yml"],
+    comments: [{ body: `${APPROVE_COMMAND} ${headSha}`, login: "Sytone" }],
+    permissions: { Sytone: "admin" },
+    headSha,
+  });
+  await run(h);
+  assert.equal(h.state.failed, null, "should not fail when approved");
+  assert.ok(h.state.notices.some((n) => /approved by @Sytone/i.test(n)));
+});
+
+test("run rejects an approval from a non-maintainer (read permission)", async () => {
+  const headSha = "abc1234def5678901234567890abcdef12345678";
+  const h = makeHarness({
+    changedPaths: [".gitignore"],
+    comments: [{ body: `${APPROVE_COMMAND} ${headSha}`, login: "drive-by" }],
+    permissions: { "drive-by": "read" },
+    headSha,
+  });
+  await run(h);
+  assert.ok(h.state.failed, "read-permission approval must not unblock");
+});
+
+test("run rejects an approval bound to a stale (different) head SHA", async () => {
+  const h = makeHarness({
+    changedPaths: [".gitignore"],
+    comments: [{ body: `${APPROVE_COMMAND} 0000000`, login: "Sytone" }],
+    permissions: { Sytone: "admin" },
+    headSha: "abc1234def5678901234567890abcdef12345678",
+  });
+  await run(h);
+  assert.ok(h.state.failed, "approval for a different SHA must not unblock");
+});

--- a/.github/workflows/security-sensitive-guard.yml
+++ b/.github/workflows/security-sensitive-guard.yml
@@ -1,0 +1,74 @@
+name: "Security: Sensitive File Guard"
+
+# Blocks PRs that modify security-sensitive boundary files (.gitignore, the CI
+# workflows themselves, CODEOWNERS, this guard) unless an authorized maintainer
+# posts a head-SHA-bound `/allow-security-sensitive-change <sha>` approval.
+#
+# SAFETY: this runs on `pull_request_target` (so it has repo context for the
+# check), but it checks out ONLY the TRUSTED BASE copy of the guard script
+# (`ref: github.event.pull_request.base.sha`, `persist-credentials: false`).
+# It never executes any code from the PR head. The changed-file set is read from
+# the API, not a working tree. Approval is bound to the current head SHA, so a
+# later push invalidates it. See .github/scripts/security-sensitive-guard.mjs.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: sensitive-file-guard-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Sensitive File Guard
+    runs-on: ubuntu-latest
+    # On comment events, only run for PR comments that contain the approval command.
+    if: >
+      github.event_name == 'pull_request_target' ||
+      (github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '/allow-security-sensitive-change'))
+    steps:
+      - name: Resolve PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const number = context.eventName === 'pull_request_target'
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+            core.setOutput('number', String(number));
+
+      - name: Check out trusted base guard script only
+        uses: actions/checkout@v4
+        with:
+          # Trusted base ref. For pull_request_target this is the merge target
+          # branch tip; never the PR head. For comment events we take the default
+          # branch (the comment cannot change which script runs).
+          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: |
+            .github/scripts/security-sensitive-guard.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Run sensitive file guard
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number('${{ steps.pr.outputs.number }}');
+            // Hydrate a pull_request payload regardless of event type so the
+            // guard module sees a uniform context shape.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            context.payload.pull_request = pr;
+            const { run } = await import('${{ github.workspace }}/.github/scripts/security-sensitive-guard.mjs');
+            await run({ github, context, core });

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -144,6 +144,7 @@ export default defineConfig({
           { text: 'E2E Tests', link: '/development/e2e-tests' },
           { text: 'Triggers and Federation', link: '/development/triggers-and-federation' },
           { text: 'WebUI Connection', link: '/development/webui-connection' },
+          { text: 'Security-Sensitive File Guard', link: '/development/security-sensitive-file-guard' },
         ],
       },
       {

--- a/docs/development/security-sensitive-file-guard.md
+++ b/docs/development/security-sensitive-file-guard.md
@@ -1,0 +1,70 @@
+# Security-Sensitive File Guard
+
+A small CI guard blocks pull requests that modify **security-sensitive boundary
+files** unless an authorized maintainer explicitly approves the change.
+
+## Why
+
+A handful of files govern the repository's security posture. A PR that quietly
+weakens them is a real supply-chain / accidental-secret-commit risk, and there
+was previously no gate on it. The most important is `.gitignore`: it controls
+whether local secret files (`.env`, key/cert files, `secrets.json`) are ignored
+**before** they can be accidentally committed. Un-ignoring one of those, or
+weakening a CI workflow or the guard itself, should require a deliberate ack.
+
+## What is guarded
+
+The guard's sensitive list lives in
+`.github/scripts/security-sensitive-guard.mjs`:
+
+| Path | Why |
+| --- | --- |
+| `.gitignore` | Controls which secret/`.env` files are ignored |
+| `.gitattributes` | Controls line-ending / filter behaviour |
+| `.github/workflows/**` | The CI itself (build, security scans, releases) |
+| `.github/CODEOWNERS` | Who must review sensitive paths |
+| `.github/scripts/security-sensitive-guard.mjs` | The guard's own logic |
+
+The same paths are also routed to the maintainer in `.github/CODEOWNERS`, so
+branch protection requires a maintainer review on top of the CI check.
+
+## How approval works
+
+When a PR touches any guarded file, the **Security: Sensitive File Guard** check
+fails with instructions. An authorized maintainer (repository `admin`,
+`maintain`, or `write` permission) unblocks it by commenting:
+
+```
+/allow-security-sensitive-change <head-sha>
+```
+
+where `<head-sha>` is the PR's current head commit SHA (a 7-40 character hex
+prefix is accepted). Posting the comment re-triggers the check, which passes.
+
+The approval is **bound to that head SHA**. Pushing a new commit changes the head
+SHA and invalidates the prior approval, so a maintainer cannot approve a PR and
+then have an attacker sneak in a later commit. A fresh ack is required after each
+push to a guarded file.
+
+## Safety model
+
+The workflow runs on `pull_request_target` (so it has repository context even
+for fork PRs), but it is written to be safe against PR-head tampering:
+
+- It checks out **only the trusted base copy** of the guard script
+  (`ref: base.sha`, `persist-credentials: false`). It never executes any code
+  from the PR head, so an attacker cannot rewrite the guard inside their own PR.
+- The set of changed files is read from the GitHub API (`pulls.listFiles`), not
+  from a working tree, so no PR-head content is sourced.
+- Approval is honored only from users whose **current** repository permission is
+  `admin`, `maintain`, or `write`, and only when bound to the current head SHA.
+
+## Tests
+
+The guard's pure logic (sensitive-path matching, approval parsing, SHA binding,
+and the block/approve decision including the permission gate) is unit-tested in
+`.github/scripts/security-sensitive-guard.test.mjs`:
+
+```
+node --test .github/scripts/security-sensitive-guard.test.mjs
+```


### PR DESCRIPTION
Closes #1525

## Summary
Adds a CI guard that blocks pull requests modifying security-sensitive boundary
files unless an authorized maintainer posts a head-SHA-bound approval. Ports the
OpenClaw `5d9c010628ea` pattern (`fix(ci): add security-sensitive file guard`)
to BotNexus's GitHub Actions setup, adapted to `actions/github-script`.

The primary protected file is `.gitignore`: a PR that quietly un-ignores `.env`,
a secrets directory, or a key file is a real accidental-secret-commit / supply
chain risk that previously had no gate.

## Changes
- `.github/scripts/security-sensitive-guard.mjs` -- the guard logic (pure,
  testable). Sensitive list: `.gitignore`, `.gitattributes`,
  `.github/workflows/**`, `.github/CODEOWNERS`, the guard script itself.
- `.github/workflows/security-sensitive-guard.yml` -- a `pull_request_target`
  workflow (+ `issue_comment` re-trigger) that runs the guard. Checks out ONLY
  the trusted base copy of the script (`ref: base.sha`,
  `persist-credentials: false`), reads changed files from the API, never
  executes PR-head code.
- `.github/CODEOWNERS` -- routes the same sensitive paths to `@Sytone` for a
  required review (defence in depth alongside the CI check).
- `.github/scripts/security-sensitive-guard.test.mjs` -- 15 unit tests
  (`node --test`) covering path matching, approval parsing, SHA binding, and the
  block/approve decision incl. the permission gate.
- `docs/development/security-sensitive-file-guard.md` + sidebar entry.

## Safety model
- Runs on `pull_request_target` for repo context, but checks out only the
  trusted base script and never the PR head -- an attacker cannot rewrite the
  guard inside their own PR.
- Approval is bound to the current head SHA via
  `/allow-security-sensitive-change <sha>`; a later push invalidates it.
- Approval is honored only from users with current `admin`/`maintain`/`write`
  repository permission.

## Validation
- `node --test .github/scripts/security-sensitive-guard.test.mjs` -- 15/15 pass.
- Workflow YAML parses cleanly (no tabs, valid schema).
- `npm run docs:build` -- green (new sidebar link resolves).

## Merge Notes
Independent of any open PR -- touches only `.github/` and docs, no source code or
test-project files. Note: this PR itself modifies guarded files, but the guard
does not exist on `main` yet, so it does not run on this PR (no chicken-and-egg).
Once merged, subsequent PRs touching these files will require the maintainer ack.
Safe to merge in parallel with #1504 (gateway persistence -- fully disjoint).
