### PR TITLE
perf(persistence): bound SQLite session/conversation caches and lock pools

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/BotNexus.Gateway.Contracts.csproj
+++ b/src/gateway/BotNexus.Gateway.Contracts/BotNexus.Gateway.Contracts.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\..\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="BotNexus.Gateway.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/gateway/BotNexus.Gateway.Contracts/Concurrency/BoundedLruCache.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Concurrency/BoundedLruCache.cs
@@ -1,0 +1,139 @@
+namespace BotNexus.Gateway.Abstractions.Concurrency;
+
+/// <summary>
+/// A thread-safe, size-bounded least-recently-used (LRU) cache. When the number of
+/// entries would exceed <see cref="Capacity"/>, the least-recently-used entry is
+/// evicted. Both reads (<see cref="TryGet"/>) and writes (<see cref="Set"/>) mark an
+/// entry as most-recently-used.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This replaces an unbounded <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>
+/// used as a read-through cache, which on a long-running daemon retains every value
+/// ever touched for the process lifetime (e.g. every session's full materialized
+/// history). A bounded cache keeps the hot set in memory while cold entries fall
+/// through to the backing store on the next read, restoring the memory profile a
+/// disk-backed store is supposed to provide.
+/// </para>
+/// <para>
+/// All operations take a single lock. The cache is intended for the gateway store
+/// hot path where the per-entry critical section is a dictionary + linked-list
+/// splice (O(1)); contention is low because writes for a given key are already
+/// serialized upstream by a per-key/striped write lock.
+/// </para>
+/// </remarks>
+/// <typeparam name="TKey">The key type.</typeparam>
+/// <typeparam name="TValue">The cached value type.</typeparam>
+public sealed class BoundedLruCache<TKey, TValue>
+    where TKey : notnull
+{
+    private readonly int _capacity;
+    private readonly Dictionary<TKey, LinkedListNode<Entry>> _map;
+    private readonly LinkedList<Entry> _lru = new();
+    private readonly Lock _gate = new();
+
+    /// <summary>Creates a cache bounded to <paramref name="capacity"/> entries.</summary>
+    /// <param name="capacity">Maximum entries to retain. Must be positive.</param>
+    /// <param name="comparer">Optional key comparer (e.g. ordinal for strings).</param>
+    public BoundedLruCache(int capacity, IEqualityComparer<TKey>? comparer = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+        _capacity = capacity;
+        _map = new Dictionary<TKey, LinkedListNode<Entry>>(comparer);
+    }
+
+    /// <summary>The maximum number of entries retained.</summary>
+    public int Capacity => _capacity;
+
+    /// <summary>The current number of cached entries.</summary>
+    public int Count
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _map.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Attempts to read a cached value. On a hit the entry becomes most-recently-used.
+    /// </summary>
+    public bool TryGet(TKey key, out TValue value)
+    {
+        lock (_gate)
+        {
+            if (_map.TryGetValue(key, out var node))
+            {
+                _lru.Remove(node);
+                _lru.AddFirst(node);
+                value = node.Value.Value;
+                return true;
+            }
+        }
+
+        value = default!;
+        return false;
+    }
+
+    /// <summary>
+    /// Inserts or updates an entry and marks it most-recently-used, evicting the
+    /// least-recently-used entry if the cache is over capacity.
+    /// </summary>
+    public void Set(TKey key, TValue value)
+    {
+        lock (_gate)
+        {
+            if (_map.TryGetValue(key, out var existing))
+            {
+                existing.Value = new Entry(key, value);
+                _lru.Remove(existing);
+                _lru.AddFirst(existing);
+                return;
+            }
+
+            var node = new LinkedListNode<Entry>(new Entry(key, value));
+            _map[key] = node;
+            _lru.AddFirst(node);
+
+            if (_map.Count > _capacity)
+            {
+                var lruNode = _lru.Last;
+                if (lruNode is not null)
+                {
+                    _lru.RemoveLast();
+                    _map.Remove(lruNode.Value.Key);
+                }
+            }
+        }
+    }
+
+    /// <summary>Removes an entry if present. Returns <c>true</c> when one was removed.</summary>
+    public bool Remove(TKey key)
+    {
+        lock (_gate)
+        {
+            if (_map.TryGetValue(key, out var node))
+            {
+                _lru.Remove(node);
+                _map.Remove(key);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Removes all entries.</summary>
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            _map.Clear();
+            _lru.Clear();
+        }
+    }
+
+    private readonly record struct Entry(TKey Key, TValue Value);
+}

--- a/src/gateway/BotNexus.Gateway.Contracts/Concurrency/StripedAsyncLock.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Concurrency/StripedAsyncLock.cs
@@ -1,0 +1,99 @@
+namespace BotNexus.Gateway.Abstractions.Concurrency;
+
+/// <summary>
+/// A fixed-size pool of mutual-exclusion locks ("stripes") keyed by an arbitrary
+/// key. A key is hashed to one of <see cref="StripeCount"/> stripes, so callers
+/// holding locks for two distinct keys that map to the same stripe will serialize,
+/// but the number of underlying <see cref="SemaphoreSlim"/> instances is bounded by
+/// construction and never grows with the number of distinct keys.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This replaces the "one <see cref="SemaphoreSlim"/> per distinct key in a
+/// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>" pattern, which leaks one sync
+/// primitive per key seen for the process lifetime on long-running daemons
+/// (sessions, conversations, cron/sub-agent ids accumulating over days). Because no
+/// per-key entry is ever created or removed, there is also no window in which an
+/// exception/cancellation can strand a per-key lock: the stripe is always released
+/// in the <see cref="IDisposable"/> returned from <see cref="AcquireAsync"/>.
+/// </para>
+/// <para>
+/// Stripe collisions cause occasional false contention between unrelated keys. With
+/// a default of 256 stripes this is negligible for the gateway's access patterns
+/// (independent sessions/conversations rarely write concurrently), and it trades a
+/// tiny, bounded amount of contention for the elimination of an unbounded leak.
+/// </para>
+/// </remarks>
+public sealed class StripedAsyncLock
+{
+    /// <summary>The default number of stripes when none is specified.</summary>
+    public const int DefaultStripeCount = 256;
+
+    private readonly SemaphoreSlim[] _stripes;
+
+    /// <summary>
+    /// Creates a striped lock with <paramref name="stripeCount"/> stripes.
+    /// </summary>
+    /// <param name="stripeCount">
+    /// The fixed number of underlying locks. Must be positive. Defaults to
+    /// <see cref="DefaultStripeCount"/>.
+    /// </param>
+    public StripedAsyncLock(int stripeCount = DefaultStripeCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stripeCount);
+        _stripes = new SemaphoreSlim[stripeCount];
+        for (var i = 0; i < stripeCount; i++)
+        {
+            _stripes[i] = new SemaphoreSlim(1, 1);
+        }
+    }
+
+    /// <summary>The fixed number of stripes in this pool.</summary>
+    public int StripeCount => _stripes.Length;
+
+    /// <summary>
+    /// Acquires the stripe for <paramref name="key"/>, awaiting if another caller
+    /// currently holds the same stripe. Dispose the returned handle (e.g. with
+    /// <c>using</c>) to release the stripe. Release is guaranteed even on exception
+    /// because it happens in the handle's <see cref="IDisposable.Dispose"/>.
+    /// </summary>
+    /// <typeparam name="TKey">The key type. <see cref="object.GetHashCode"/> is used.</typeparam>
+    /// <param name="key">The key whose stripe to acquire. Must not be null.</param>
+    /// <param name="cancellationToken">Cancels the wait.</param>
+    /// <returns>A handle that releases the stripe when disposed.</returns>
+    public async Task<IDisposable> AcquireAsync<TKey>(TKey key, CancellationToken cancellationToken = default)
+        where TKey : notnull
+    {
+        var stripe = GetStripe(key);
+        await stripe.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return new Releaser(stripe);
+    }
+
+    /// <summary>
+    /// Returns the <see cref="SemaphoreSlim"/> a key maps to. Exposed for tests that
+    /// need to assert two keys land on the same or different stripes.
+    /// </summary>
+    internal SemaphoreSlim GetStripe<TKey>(TKey key)
+        where TKey : notnull
+    {
+        // Non-negative, well-distributed index. & with (length-1) is only valid for
+        // power-of-two lengths, so use a modulo on the absolute hash to support any
+        // stripe count. int.MinValue is special-cased because Math.Abs(int.MinValue)
+        // throws.
+        var hash = key.GetHashCode();
+        var index = (hash == int.MinValue ? 0 : Math.Abs(hash)) % _stripes.Length;
+        return _stripes[index];
+    }
+
+    private sealed class Releaser(SemaphoreSlim stripe) : IDisposable
+    {
+        private SemaphoreSlim? _stripe = stripe;
+
+        public void Dispose()
+        {
+            // Guard against double-dispose releasing the semaphore twice.
+            var s = Interlocked.Exchange(ref _stripe, null);
+            s?.Release();
+        }
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -1,8 +1,8 @@
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text.Json;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Concurrency;
 using BotNexus.Gateway.Abstractions.Configuration;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
@@ -29,9 +29,17 @@ public sealed class SqliteConversationStore : IConversationStore
     private readonly ILogger<SqliteConversationStore> _logger;
     private readonly IWorldContext? _worldContext;
     private readonly SemaphoreSlim _initLock = new(1, 1);
-    private readonly ConcurrentDictionary<string, SemaphoreSlim> _conversationLocks = new(StringComparer.Ordinal);
-    private readonly ConcurrentDictionary<string, Conversation> _cache = new(StringComparer.Ordinal);
+    // Striped write locks: a fixed pool hashed by conversation id. Bounds the number
+    // of sync primitives (no per-conversation SemaphoreSlim leak over the process
+    // lifetime) and cannot strand a lock on an exception (the stripe is pool-owned).
+    private readonly StripedAsyncLock _conversationLocks = new();
+    // Bounded read-through cache capped by LRU so a long-running gateway does not
+    // retain every conversation ever touched. Cold reads fall through to SQLite.
+    private readonly BoundedLruCache<string, Conversation> _cache;
     private bool _initialized;
+
+    /// <summary>Default bound for the in-memory conversation cache (entries).</summary>
+    public const int DefaultConversationCacheCapacity = 1000;
 
     /// <summary>
     /// Initialises a new instance of the <see cref="SqliteConversationStore"/> class without
@@ -53,11 +61,17 @@ public sealed class SqliteConversationStore : IConversationStore
     /// <param name="connectionString">The SQLite connection string.</param>
     /// <param name="logger">Logger instance.</param>
     /// <param name="worldContext">Resolves the gateway's current world identity; <c>null</c> disables stamping.</param>
-    public SqliteConversationStore(string connectionString, ILogger<SqliteConversationStore> logger, IWorldContext? worldContext)
+    /// <param name="cacheCapacity">
+    /// Maximum number of conversations retained in the in-memory cache. Older entries are
+    /// evicted by LRU; cold reads fall through to SQLite. Defaults to
+    /// <see cref="DefaultConversationCacheCapacity"/>.
+    /// </param>
+    public SqliteConversationStore(string connectionString, ILogger<SqliteConversationStore> logger, IWorldContext? worldContext, int cacheCapacity = DefaultConversationCacheCapacity)
     {
         _connectionString = connectionString;
         _logger = logger;
         _worldContext = worldContext;
+        _cache = new BoundedLruCache<string, Conversation>(cacheCapacity, StringComparer.Ordinal);
     }
 
     // World-id stamping/back-fill is shared across all three conversation stores — see
@@ -77,22 +91,21 @@ public sealed class SqliteConversationStore : IConversationStore
         activity?.SetTag("botnexus.conversation.id", conversationId.Value);
 
         await EnsureCreatedAsync(ct).ConfigureAwait(false);
-        var conversationLock = GetConversationLock(conversationId.Value);
-        await conversationLock.WaitAsync(ct).ConfigureAwait(false);
+        var conversationLock = await AcquireConversationLockAsync(conversationId.Value, ct).ConfigureAwait(false);
         try
         {
-            if (_cache.TryGetValue(conversationId.Value, out var cached))
+            if (_cache.TryGet(conversationId.Value, out var cached))
                 return BackfillWorldId(CloneConversation(cached));
 
             var loaded = await LoadConversationAsync(conversationId, ct).ConfigureAwait(false);
             if (loaded is not null)
-                _cache[conversationId.Value] = CloneConversation(loaded);
+                _cache.Set(conversationId.Value, CloneConversation(loaded));
 
             return BackfillWorldId(loaded);
         }
         finally
         {
-            conversationLock.Release();
+            conversationLock.Dispose();
         }
     }
 
@@ -120,7 +133,7 @@ public sealed class SqliteConversationStore : IConversationStore
         {
             var id = reader.GetString(0);
             Conversation conversation;
-            if (_cache.TryGetValue(id, out var cached))
+            if (_cache.TryGet(id, out var cached))
             {
                 conversation = CloneConversation(cached);
             }
@@ -128,7 +141,7 @@ public sealed class SqliteConversationStore : IConversationStore
             {
                 conversation = await LoadConversationAsync(connection, ConversationId.From(id), ct).ConfigureAwait(false)
                     ?? throw new InvalidOperationException($"Conversation '{id}' disappeared during enumeration.");
-                _cache[id] = CloneConversation(conversation);
+                _cache.Set(id, CloneConversation(conversation));
             }
 
             conversations.Add(BackfillWorldId(conversation)!);
@@ -178,7 +191,7 @@ public sealed class SqliteConversationStore : IConversationStore
         {
             var id = reader.GetString(0);
             Conversation conversation;
-            if (_cache.TryGetValue(id, out var cached))
+            if (_cache.TryGet(id, out var cached))
             {
                 conversation = CloneConversation(cached);
             }
@@ -186,7 +199,7 @@ public sealed class SqliteConversationStore : IConversationStore
             {
                 conversation = await LoadConversationAsync(connection, ConversationId.From(id), ct).ConfigureAwait(false)
                     ?? throw new InvalidOperationException($"Conversation '{id}' disappeared during enumeration.");
-                _cache[id] = CloneConversation(conversation);
+                _cache.Set(id, CloneConversation(conversation));
             }
 
             conversations.Add(BackfillWorldId(conversation)!);
@@ -213,8 +226,7 @@ public sealed class SqliteConversationStore : IConversationStore
         activity?.SetTag("botnexus.participants.count", snapshot.Count);
 
         await EnsureCreatedAsync(ct).ConfigureAwait(false);
-        var conversationLock = GetConversationLock(conversationId.Value);
-        await conversationLock.WaitAsync(ct).ConfigureAwait(false);
+        var conversationLock = await AcquireConversationLockAsync(conversationId.Value, ct).ConfigureAwait(false);
         try
         {
             await using var connection = CreateConnection();
@@ -247,11 +259,11 @@ public sealed class SqliteConversationStore : IConversationStore
 
             // Invalidate cache entry — the next read will repopulate Participants via the
             // LoadParticipantsAsync join. Cheaper than mutating the cached list in place.
-            _cache.TryRemove(conversationId.Value, out _);
+            _cache.Remove(conversationId.Value);
         }
         finally
         {
-            conversationLock.Release();
+            conversationLock.Dispose();
         }
     }
 
@@ -262,23 +274,22 @@ public sealed class SqliteConversationStore : IConversationStore
         activity?.SetTag("botnexus.agent.id", conversation.AgentId.Value);
 
         await EnsureCreatedAsync(ct).ConfigureAwait(false);
-        var conversationLock = GetConversationLock(conversation.ConversationId.Value);
-        await conversationLock.WaitAsync(ct).ConfigureAwait(false);
+        var conversationLock = await AcquireConversationLockAsync(conversation.ConversationId.Value, ct).ConfigureAwait(false);
         try
         {
-            if (_cache.ContainsKey(conversation.ConversationId.Value))
+            if (_cache.TryGet(conversation.ConversationId.Value, out _))
                 throw new InvalidOperationException($"A conversation with id '{conversation.ConversationId}' already exists.");
 
             StampWorldId(conversation);
             await using var connection = CreateConnection();
             await connection.OpenAsync(ct).ConfigureAwait(false);
             await SaveConversationAsync(connection, conversation, upsert: false, ct).ConfigureAwait(false);
-            _cache[conversation.ConversationId.Value] = CloneConversation(conversation);
+            _cache.Set(conversation.ConversationId.Value, CloneConversation(conversation));
             return CloneConversation(conversation);
         }
         finally
         {
-            conversationLock.Release();
+            conversationLock.Dispose();
         }
     }
 
@@ -290,8 +301,7 @@ public sealed class SqliteConversationStore : IConversationStore
         activity?.SetTag("botnexus.agent.id", conversation.AgentId.Value);
 
         await EnsureCreatedAsync(ct).ConfigureAwait(false);
-        var conversationLock = GetConversationLock(conversation.ConversationId.Value);
-        await conversationLock.WaitAsync(ct).ConfigureAwait(false);
+        var conversationLock = await AcquireConversationLockAsync(conversation.ConversationId.Value, ct).ConfigureAwait(false);
         try
         {
             var updated = CloneConversation(conversation);
@@ -301,11 +311,11 @@ public sealed class SqliteConversationStore : IConversationStore
             await using var connection = CreateConnection();
             await connection.OpenAsync(ct).ConfigureAwait(false);
             await SaveConversationAsync(connection, updated, upsert: true, ct).ConfigureAwait(false);
-            _cache[updated.ConversationId.Value] = CloneConversation(updated);
+            _cache.Set(updated.ConversationId.Value, CloneConversation(updated));
         }
         finally
         {
-            conversationLock.Release();
+            conversationLock.Dispose();
         }
     }
 
@@ -316,8 +326,7 @@ public sealed class SqliteConversationStore : IConversationStore
         activity?.SetTag("botnexus.conversation.id", conversationId.Value);
 
         await EnsureCreatedAsync(ct).ConfigureAwait(false);
-        var conversationLock = GetConversationLock(conversationId.Value);
-        await conversationLock.WaitAsync(ct).ConfigureAwait(false);
+        var conversationLock = await AcquireConversationLockAsync(conversationId.Value, ct).ConfigureAwait(false);
         try
         {
             await using var connection = CreateConnection();
@@ -337,18 +346,18 @@ public sealed class SqliteConversationStore : IConversationStore
             command.Parameters.AddWithValue("$id", conversationId.Value);
             await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
-            if (_cache.TryGetValue(conversationId.Value, out var cached))
+            if (_cache.TryGet(conversationId.Value, out var cached))
             {
                 var archived = CloneConversation(cached);
                 archived.Status = ConversationStatus.Archived;
                 archived.ActiveSessionId = null;
                 archived.UpdatedAt = updatedAt;
-                _cache[conversationId.Value] = archived;
+                _cache.Set(conversationId.Value, archived);
             }
         }
         finally
         {
-            conversationLock.Release();
+            conversationLock.Dispose();
         }
     }
 
@@ -359,8 +368,7 @@ public sealed class SqliteConversationStore : IConversationStore
         activity?.SetTag("botnexus.conversation.id", conversationId.Value);
 
         await EnsureCreatedAsync(ct).ConfigureAwait(false);
-        var conversationLock = GetConversationLock(conversationId.Value);
-        await conversationLock.WaitAsync(ct).ConfigureAwait(false);
+        var conversationLock = await AcquireConversationLockAsync(conversationId.Value, ct).ConfigureAwait(false);
         try
         {
             var updatedAt = DateTimeOffset.UtcNow;
@@ -379,16 +387,16 @@ public sealed class SqliteConversationStore : IConversationStore
 
             // Keep the in-memory cache consistent so subsequent GetAsync / ListAsync
             // calls return the updated timestamp without a disk round-trip.
-            if (_cache.TryGetValue(conversationId.Value, out var cached))
+            if (_cache.TryGet(conversationId.Value, out var cached))
             {
                 var touched = CloneConversation(cached);
                 touched.UpdatedAt = updatedAt;
-                _cache[conversationId.Value] = touched;
+                _cache.Set(conversationId.Value, touched);
             }
         }
         finally
         {
-            conversationLock.Release();
+            conversationLock.Dispose();
         }
     }
 
@@ -400,8 +408,7 @@ public sealed class SqliteConversationStore : IConversationStore
         activity?.SetTag("botnexus.conversation.pin", pin);
 
         await EnsureCreatedAsync(ct).ConfigureAwait(false);
-        var conversationLock = GetConversationLock(conversationId.Value);
-        await conversationLock.WaitAsync(ct).ConfigureAwait(false);
+        var conversationLock = await AcquireConversationLockAsync(conversationId.Value, ct).ConfigureAwait(false);
         try
         {
             var now = DateTimeOffset.UtcNow;
@@ -424,18 +431,18 @@ public sealed class SqliteConversationStore : IConversationStore
             command.Parameters.AddWithValue("$id", conversationId.Value);
             await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
-            if (_cache.TryGetValue(conversationId.Value, out var cached))
+            if (_cache.TryGet(conversationId.Value, out var cached))
             {
                 var updated = CloneConversation(cached);
                 updated.IsPinned = pin;
                 updated.PinnedAt = pinnedAt;
                 updated.UpdatedAt = now;
-                _cache[conversationId.Value] = updated;
+                _cache.Set(conversationId.Value, updated);
             }
         }
         finally
         {
-            conversationLock.Release();
+            conversationLock.Dispose();
         }
     }
 
@@ -685,8 +692,8 @@ public sealed class SqliteConversationStore : IConversationStore
         }
     }
 
-    private SemaphoreSlim GetConversationLock(string conversationId)
-        => _conversationLocks.GetOrAdd(conversationId, static _ => new SemaphoreSlim(1, 1));
+    private Task<IDisposable> AcquireConversationLockAsync(string conversationId, CancellationToken cancellationToken)
+        => _conversationLocks.AcquireAsync(conversationId, cancellationToken);
 
     private static async Task EnsurePurposeColumnAsync(SqliteConnection connection, CancellationToken ct)
     {

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -14,7 +14,7 @@ using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Abstractions.Sessions;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
-using System.Collections.Concurrent;
+using BotNexus.Gateway.Abstractions.Concurrency;
 
 namespace BotNexus.Gateway.Sessions;
 
@@ -28,10 +28,21 @@ namespace BotNexus.Gateway.Sessions;
 public sealed class SqliteSessionStore : SessionStoreBase
 {
     private static readonly ActivitySource ActivitySource = new("BotNexus.Gateway");
+
+    /// <summary>Default bound for the in-memory session cache (entries).</summary>
+    public const int DefaultSessionCacheCapacity = 500;
+
     private readonly string _connectionString;
     private readonly SemaphoreSlim _initLock = new(1, 1);
-    private readonly ConcurrentDictionary<SessionId, SemaphoreSlim> _sessionLocks = new();
-    private readonly ConcurrentDictionary<SessionId, GatewaySession> _cache = new();
+    // Striped write locks: a fixed pool hashed by session id. This bounds the number
+    // of sync primitives (no per-session SemaphoreSlim leak across the process
+    // lifetime) and never strands a lock on an exception, since the stripe is the
+    // pool's, not a per-key entry that must be removed.
+    private readonly StripedAsyncLock _sessionLocks = new();
+    // Bounded read-through cache: holds the hot set of materialized sessions (each
+    // carries its full history) capped by LRU so a long-running gateway does not
+    // retain every session ever touched. Cold reads fall through to SQLite.
+    private readonly BoundedLruCache<SessionId, GatewaySession> _cache;
     private bool _initialized;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -41,7 +52,10 @@ public sealed class SqliteSessionStore : SessionStoreBase
 
     private readonly IConversationStore _conversationStore;
     private readonly LegacyConversationResolver _legacyResolver;
-    private readonly ConcurrentDictionary<ConversationId, AgentId> _agentIdCache = new();
+    // Bounded conversation -> agent id cache (shared by hydration + stats). Same LRU
+    // bound as the session cache so it cannot grow unbounded across distinct
+    // conversations over the process lifetime.
+    private readonly BoundedLruCache<ConversationId, AgentId> _agentIdCache;
     private readonly ILogger<SqliteSessionStore> _logger;
     private readonly ISecretRedactor? _redactor;
 
@@ -61,11 +75,17 @@ public sealed class SqliteSessionStore : SessionStoreBase
     /// <see cref="Session.ConversationId"/> defensively at save time.
     /// </param>
     /// <param name="redactor">When provided, secrets in content are redacted before storage.</param>
+    /// <param name="cacheCapacity">
+    /// Maximum number of sessions (and conversation->agent mappings) retained in the
+    /// in-memory caches. Older entries are evicted by LRU; cold reads fall through to
+    /// SQLite. Defaults to <see cref="DefaultSessionCacheCapacity"/>.
+    /// </param>
     public SqliteSessionStore(
         string connectionString,
         ILogger<SqliteSessionStore> logger,
         IConversationStore conversationStore,
-        ISecretRedactor? redactor = null)
+        ISecretRedactor? redactor = null,
+        int cacheCapacity = DefaultSessionCacheCapacity)
         : base(conversationStore)
     {
         _connectionString = connectionString;
@@ -73,6 +93,8 @@ public sealed class SqliteSessionStore : SessionStoreBase
         _conversationStore = conversationStore ?? throw new ArgumentNullException(nameof(conversationStore));
         _legacyResolver = new LegacyConversationResolver(conversationStore, logger: null);
         _redactor = redactor;
+        _cache = new BoundedLruCache<SessionId, GatewaySession>(cacheCapacity);
+        _agentIdCache = new BoundedLruCache<ConversationId, AgentId>(cacheCapacity);
     }
 
     /// <inheritdoc />
@@ -82,20 +104,15 @@ public sealed class SqliteSessionStore : SessionStoreBase
         activity?.SetTag("botnexus.session.id", sessionId);
 
         await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
-        var sessionLock = GetSessionLock(sessionId);
-        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            if (_cache.TryGetValue(sessionId, out var cached))
-                return cached;
+        using var sessionLock = await AcquireSessionLockAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        if (_cache.TryGet(sessionId, out var cached))
+            return cached;
 
-            var loaded = await LoadSessionAsync(sessionId, cancellationToken).ConfigureAwait(false);
-            if (loaded is not null)
-                _cache[sessionId] = loaded;
+        var loaded = await LoadSessionAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        if (loaded is not null)
+            _cache.Set(sessionId, loaded);
 
-            return loaded;
-        }
-        finally { sessionLock.Release(); }
+        return loaded;
     }
 
     /// <inheritdoc />
@@ -106,25 +123,20 @@ public sealed class SqliteSessionStore : SessionStoreBase
         activity?.SetTag("botnexus.agent.id", agentId);
 
         await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
-        var sessionLock = GetSessionLock(sessionId);
-        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        using var sessionLock = await AcquireSessionLockAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        if (_cache.TryGet(sessionId, out var cached))
+            return cached;
+
+        var loaded = await LoadSessionAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        if (loaded is not null)
         {
-            if (_cache.TryGetValue(sessionId, out var cached))
-                return cached;
-
-            var loaded = await LoadSessionAsync(sessionId, cancellationToken).ConfigureAwait(false);
-            if (loaded is not null)
-            {
-                _cache[sessionId] = loaded;
-                return loaded;
-            }
-
-            var session = CreateSession(sessionId, agentId, null, _redactor);
-            _cache[sessionId] = session;
-            return session;
+            _cache.Set(sessionId, loaded);
+            return loaded;
         }
-        finally { sessionLock.Release(); }
+
+        var session = CreateSession(sessionId, agentId, null, _redactor);
+        _cache.Set(sessionId, session);
+        return session;
     }
 
     /// <inheritdoc />
@@ -140,11 +152,10 @@ public sealed class SqliteSessionStore : SessionStoreBase
         // does not interleave with concurrent saves of the same session.
         await EnsureConversationIdStampedAsync(session, cancellationToken).ConfigureAwait(false);
 
-        var sessionLock = GetSessionLock(session.SessionId);
-        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var sessionLock = await AcquireSessionLockAsync(session.SessionId, cancellationToken).ConfigureAwait(false);
         try
         {
-            _cache[session.SessionId] = session;
+            _cache.Set(session.SessionId, session);
             await RetryOnTransientAsync(async () =>
             {
                 await using var connection = CreateConnection();
@@ -153,7 +164,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
                 await ReplaceHistoryAsync(connection, session, cancellationToken).ConfigureAwait(false);
             }, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
-        finally { sessionLock.Release(); }
+        finally { sessionLock.Dispose(); }
     }
 
     /// <inheritdoc />
@@ -163,55 +174,45 @@ public sealed class SqliteSessionStore : SessionStoreBase
         activity?.SetTag("botnexus.session.id", sessionId);
 
         await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
-        var sessionLock = GetSessionLock(sessionId);
-        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            _cache.TryRemove(sessionId, out _);
+        using var sessionLock = await AcquireSessionLockAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        _cache.Remove(sessionId);
 
-            await using var connection = CreateConnection();
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-            await using var deleteHistory = connection.CreateCommand();
-            deleteHistory.CommandText = "DELETE FROM session_history WHERE session_id = $sessionId";
-            deleteHistory.Parameters.AddWithValue("$sessionId", sessionId.Value);
-            await deleteHistory.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        await using var deleteHistory = connection.CreateCommand();
+        deleteHistory.CommandText = "DELETE FROM session_history WHERE session_id = $sessionId";
+        deleteHistory.Parameters.AddWithValue("$sessionId", sessionId.Value);
+        await deleteHistory.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
-            await using var deleteSession = connection.CreateCommand();
-            deleteSession.CommandText = "DELETE FROM sessions WHERE id = $sessionId";
-            deleteSession.Parameters.AddWithValue("$sessionId", sessionId.Value);
-            await deleteSession.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            _sessionLocks.TryRemove(sessionId, out _);
-        }
-        finally { sessionLock.Release(); }
+        await using var deleteSession = connection.CreateCommand();
+        deleteSession.CommandText = "DELETE FROM sessions WHERE id = $sessionId";
+        deleteSession.Parameters.AddWithValue("$sessionId", sessionId.Value);
+        await deleteSession.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        // No per-session lock entry to remove: the striped lock pool is fixed-size.
     }
 
     /// <inheritdoc />
     public override async Task ArchiveAsync(SessionId sessionId, CancellationToken cancellationToken = default)
     {
         await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
-        var sessionLock = GetSessionLock(sessionId);
-        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            _cache.TryRemove(sessionId, out _);
+        using var sessionLock = await AcquireSessionLockAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        _cache.Remove(sessionId);
 
-            var session = await LoadSessionAsync(sessionId, cancellationToken).ConfigureAwait(false);
-            if (session is not null)
+        var session = await LoadSessionAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        if (session is not null)
+        {
+            session.Status = SessionStatus.Sealed;
+            session.UpdatedAt = DateTimeOffset.UtcNow;
+            _cache.Set(sessionId, session);
+            await RetryOnTransientAsync(async () =>
             {
-                session.Status = SessionStatus.Sealed;
-                session.UpdatedAt = DateTimeOffset.UtcNow;
-                _cache[sessionId] = session;
-                await RetryOnTransientAsync(async () =>
-                {
-                    await using var connection = CreateConnection();
-                    await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-                    await UpsertSessionAsync(connection, session, cancellationToken).ConfigureAwait(false);
-                    await ReplaceHistoryAsync(connection, session, cancellationToken).ConfigureAwait(false);
-                }, cancellationToken: cancellationToken).ConfigureAwait(false);
-            }
+                await using var connection = CreateConnection();
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                await UpsertSessionAsync(connection, session, cancellationToken).ConfigureAwait(false);
+                await ReplaceHistoryAsync(connection, session, cancellationToken).ConfigureAwait(false);
+            }, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
-        finally { sessionLock.Release(); }
     }
 
     protected override Task<IReadOnlyList<GatewaySession>> EnumerateSessionsAsync(CancellationToken cancellationToken)
@@ -234,11 +235,11 @@ public sealed class SqliteSessionStore : SessionStoreBase
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
             var sessionId = SessionId.From(reader.GetString(0));
-            var session = _cache.GetValueOrDefault(sessionId)
+            var session = (_cache.TryGet(sessionId, out var c1) ? c1 : null)
                 ?? await LoadSessionAsync(connection, sessionId, cancellationToken).ConfigureAwait(false);
             if (session is not null)
             {
-                _cache[sessionId] = session;
+                _cache.Set(sessionId, session);
                 sessions.Add(session);
             }
         }
@@ -283,11 +284,11 @@ public sealed class SqliteSessionStore : SessionStoreBase
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
             var sessionId = SessionId.From(reader.GetString(0));
-            var session = _cache.GetValueOrDefault(sessionId)
+            var session = (_cache.TryGet(sessionId, out var c2) ? c2 : null)
                 ?? await LoadSessionAsync(connection, sessionId, cancellationToken).ConfigureAwait(false);
             if (session is not null)
             {
-                _cache[sessionId] = session;
+                _cache.Set(sessionId, session);
                 if (agentId is null || session.AgentId == agentId)
                     sessions.Add(session);
             }
@@ -403,8 +404,8 @@ public sealed class SqliteSessionStore : SessionStoreBase
         finally { _initLock.Release(); }
     }
 
-    private SemaphoreSlim GetSessionLock(SessionId sessionId)
-        => _sessionLocks.GetOrAdd(sessionId, static _ => new SemaphoreSlim(1, 1));
+    private Task<IDisposable> AcquireSessionLockAsync(SessionId sessionId, CancellationToken cancellationToken)
+        => _sessionLocks.AcquireAsync(sessionId, cancellationToken);
 
     /// <summary>
     /// Returns <c>true</c> when the named column exists on the given SQLite table.
@@ -798,7 +799,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
     /// session).
     /// </summary>
     /// <remarks>
-    /// Uses a positive-only <see cref="ConcurrentDictionary{TKey,TValue}"/> cache keyed by
+    /// Uses a positive-only <see cref="BoundedLruCache{TKey,TValue}"/> cache keyed by
     /// <see cref="ConversationId"/>. The cache is safe because <see cref="Conversation.AgentId"/>
     /// is init-only (verified by <c>ConversationAgentIdImmutabilityArchitectureTests</c>).
     /// Negative results are not cached so a create-then-resolve race never observes a
@@ -816,7 +817,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
                 "inspect SqliteSessionStore logs at startup.");
         }
 
-        if (_agentIdCache.TryGetValue(session.ConversationId, out var cached))
+        if (_agentIdCache.TryGet(session.ConversationId, out var cached))
         {
             session.HydrateAgentId(cached);
             return;
@@ -832,7 +833,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
                 "the session is unrecoverable.");
         }
 
-        _agentIdCache[session.ConversationId] = conversation.AgentId;
+        _agentIdCache.Set(session.ConversationId, conversation.AgentId);
         session.HydrateAgentId(conversation.AgentId);
     }
 
@@ -1345,7 +1346,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
         }
 
         var convId = ConversationId.From(conversationId);
-        if (_agentIdCache.TryGetValue(convId, out var cached))
+        if (_agentIdCache.TryGet(convId, out var cached))
         {
             return cached.Value;
         }
@@ -1356,7 +1357,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
             return null;
         }
 
-        _agentIdCache[convId] = conversation.AgentId;
+        _agentIdCache.Set(convId, conversation.AgentId);
         return conversation.AgentId.Value;
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreTests.cs
@@ -35,6 +35,37 @@ public sealed class SqliteConversationStoreTests
     }
 
     [Fact]
+    public async Task Cache_IsBounded_ColdConversationsStillReadableViaFallThrough()
+    {
+        // The in-memory conversation cache is bounded by LRU: inserting far more
+        // distinct conversations than the cap must not retain them all in memory, yet
+        // every conversation must remain correctly readable (cold reads fall through
+        // to SQLite). Regression guard for the unbounded-cache leak (#1504).
+        using var fixture = new StoreFixture();
+        const int cap = 8;
+        const int total = 40;
+        var store = fixture.CreateStore(cacheCapacity: cap);
+
+        var ids = new List<ConversationId>();
+        for (var i = 0; i < total; i++)
+        {
+            var conversation = CreateConversation(Agent("agent-a"), $"conv-{i}", CreateBinding("telegram", $"{i}"));
+            await store.CreateAsync(conversation);
+            ids.Add(conversation.ConversationId);
+        }
+
+        // Every conversation — including the earliest ones long since evicted from the
+        // bounded cache — is still retrievable with its persisted state intact.
+        for (var i = 0; i < total; i++)
+        {
+            var loaded = await store.GetAsync(ids[i]);
+            loaded.ShouldNotBeNull();
+            loaded!.Title.ShouldBe($"conv-{i}");
+            loaded.ChannelBindings.Count.ShouldBe(1);
+        }
+    }
+
+    [Fact]
     public async Task ListAsync_FiltersByAgentId()
     {
         using var fixture = new StoreFixture();

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/StoreFixture.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/StoreFixture.cs
@@ -24,6 +24,9 @@ internal sealed class StoreFixture : IDisposable
     public SqliteConversationStore CreateStore(IWorldContext worldContext)
         => new(ConnectionString, NullLogger<SqliteConversationStore>.Instance, worldContext);
 
+    public SqliteConversationStore CreateStore(int cacheCapacity)
+        => new(ConnectionString, NullLogger<SqliteConversationStore>.Instance, worldContext: null, cacheCapacity: cacheCapacity);
+
     public void Dispose()
     {
         if (File.Exists(DatabasePath))

--- a/tests/gateway/BotNexus.Gateway.Tests/Concurrency/BoundedLruCacheTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Concurrency/BoundedLruCacheTests.cs
@@ -1,0 +1,142 @@
+using BotNexus.Gateway.Abstractions.Concurrency;
+
+namespace BotNexus.Gateway.Tests.Concurrency;
+
+public sealed class BoundedLruCacheTests
+{
+    [Fact]
+    public void Set_BeyondCapacity_EvictsLeastRecentlyUsed()
+    {
+        var cache = new BoundedLruCache<int, string>(capacity: 2);
+
+        cache.Set(1, "a");
+        cache.Set(2, "b");
+        cache.Set(3, "c"); // evicts key 1 (LRU)
+
+        cache.Count.ShouldBe(2);
+        cache.TryGet(1, out _).ShouldBeFalse();
+        cache.TryGet(2, out var b).ShouldBeTrue();
+        b.ShouldBe("b");
+        cache.TryGet(3, out var c).ShouldBeTrue();
+        c.ShouldBe("c");
+    }
+
+    [Fact]
+    public void TryGet_PromotesEntry_SoItSurvivesEviction()
+    {
+        var cache = new BoundedLruCache<int, string>(capacity: 2);
+
+        cache.Set(1, "a");
+        cache.Set(2, "b");
+        // Touch key 1 so it becomes most-recently-used; key 2 is now the LRU.
+        cache.TryGet(1, out _).ShouldBeTrue();
+        cache.Set(3, "c"); // should evict key 2, not key 1
+
+        cache.TryGet(1, out _).ShouldBeTrue();
+        cache.TryGet(2, out _).ShouldBeFalse();
+        cache.TryGet(3, out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Set_ExistingKey_UpdatesValueAndPromotes_WithoutGrowing()
+    {
+        var cache = new BoundedLruCache<int, string>(capacity: 2);
+
+        cache.Set(1, "a");
+        cache.Set(2, "b");
+        cache.Set(1, "a2"); // update + promote, count stays 2
+        cache.Set(3, "c");  // evicts key 2 (LRU), key 1 survives
+
+        cache.Count.ShouldBe(2);
+        cache.TryGet(1, out var v).ShouldBeTrue();
+        v.ShouldBe("a2");
+        cache.TryGet(2, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Count_NeverExceedsCapacity_AcrossManyDistinctKeys()
+    {
+        var cache = new BoundedLruCache<int, int>(capacity: 50);
+
+        for (var i = 0; i < 5000; i++)
+        {
+            cache.Set(i, i);
+            cache.Count.ShouldBeLessThanOrEqualTo(50);
+        }
+
+        cache.Count.ShouldBe(50);
+        // The most recent 50 keys are retained; older ones evicted.
+        cache.TryGet(4999, out _).ShouldBeTrue();
+        cache.TryGet(0, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Remove_DeletesEntry_AndReportsWhetherPresent()
+    {
+        var cache = new BoundedLruCache<int, string>(capacity: 4);
+        cache.Set(1, "a");
+
+        cache.Remove(1).ShouldBeTrue();
+        cache.Remove(1).ShouldBeFalse();
+        cache.TryGet(1, out _).ShouldBeFalse();
+        cache.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Clear_RemovesAllEntries()
+    {
+        var cache = new BoundedLruCache<int, string>(capacity: 4);
+        cache.Set(1, "a");
+        cache.Set(2, "b");
+
+        cache.Clear();
+
+        cache.Count.ShouldBe(0);
+        cache.TryGet(1, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryGet_Miss_ReturnsFalseAndDefault()
+    {
+        var cache = new BoundedLruCache<string, string>(capacity: 4);
+
+        cache.TryGet("nope", out var value).ShouldBeFalse();
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Constructor_RejectsNonPositiveCapacity()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new BoundedLruCache<int, int>(0));
+        Should.Throw<ArgumentOutOfRangeException>(() => new BoundedLruCache<int, int>(-1));
+    }
+
+    [Fact]
+    public void HonorsCustomKeyComparer()
+    {
+        var cache = new BoundedLruCache<string, int>(capacity: 4, StringComparer.OrdinalIgnoreCase);
+
+        cache.Set("Key", 1);
+        cache.TryGet("KEY", out var v).ShouldBeTrue();
+        v.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ConcurrentSetAndGet_StaysBounded_AndDoesNotThrow()
+    {
+        var cache = new BoundedLruCache<int, int>(capacity: 100);
+
+        var writers = Enumerable.Range(0, 8).Select(w => Task.Run(() =>
+        {
+            for (var i = 0; i < 2000; i++)
+            {
+                cache.Set((w * 2000) + i, i);
+                cache.TryGet((w * 2000) + i, out _);
+            }
+        }));
+
+        await Task.WhenAll(writers);
+
+        cache.Count.ShouldBeLessThanOrEqualTo(100);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Concurrency/StripedAsyncLockTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Concurrency/StripedAsyncLockTests.cs
@@ -1,0 +1,151 @@
+using BotNexus.Gateway.Abstractions.Concurrency;
+
+namespace BotNexus.Gateway.Tests.Concurrency;
+
+public sealed class StripedAsyncLockTests
+{
+    [Fact]
+    public void StripeCount_IsFixed_AndDoesNotGrowWithDistinctKeys()
+    {
+        var locks = new StripedAsyncLock(stripeCount: 16);
+        locks.StripeCount.ShouldBe(16);
+
+        // Touching thousands of distinct keys must not change the stripe count:
+        // the whole point is a bounded, fixed pool (no per-key leak).
+        for (var i = 0; i < 10_000; i++)
+        {
+            _ = locks.GetStripe(i);
+        }
+
+        locks.StripeCount.ShouldBe(16);
+    }
+
+    [Fact]
+    public void GetStripe_IsStableForSameKey()
+    {
+        var locks = new StripedAsyncLock(stripeCount: 64);
+
+        var a = locks.GetStripe("session-1");
+        var b = locks.GetStripe("session-1");
+
+        a.ShouldBeSameAs(b);
+    }
+
+    [Fact]
+    public async Task AcquireAsync_SerializesCallersOnTheSameStripe()
+    {
+        // A single stripe forces every key to contend, making the mutual-exclusion
+        // guarantee observable without depending on hash collisions.
+        var locks = new StripedAsyncLock(stripeCount: 1);
+        var inside = 0;
+        var maxConcurrent = 0;
+
+        async Task Worker()
+        {
+            using (await locks.AcquireAsync("any-key"))
+            {
+                var now = Interlocked.Increment(ref inside);
+                InterlockedMax(ref maxConcurrent, now);
+                await Task.Delay(5);
+                Interlocked.Decrement(ref inside);
+            }
+        }
+
+        await Task.WhenAll(Enumerable.Range(0, 10).Select(_ => Worker()));
+
+        maxConcurrent.ShouldBe(1, "the stripe must enforce mutual exclusion");
+    }
+
+    [Fact]
+    public async Task AcquireAsync_AllowsConcurrency_AcrossDifferentStripes()
+    {
+        var locks = new StripedAsyncLock(stripeCount: 256);
+
+        // int.GetHashCode() is the value itself, so non-negative key i maps to stripe
+        // (i % StripeCount). Keys 0 and 1 are therefore on distinct stripes.
+        using var first = await locks.AcquireAsync(0);
+
+        var acquireSecond = locks.AcquireAsync(1);
+        var completed = await Task.WhenAny(acquireSecond, Task.Delay(1000));
+
+        completed.ShouldBe((Task)acquireSecond, "a different stripe must not block");
+        (await acquireSecond).Dispose();
+    }
+
+    [Fact]
+    public async Task ReleasingHandle_FreesTheStripe_ForTheNextCaller()
+    {
+        var locks = new StripedAsyncLock(stripeCount: 1);
+
+        var handle = await locks.AcquireAsync("k");
+        // A second acquire cannot complete while the first is held.
+        var second = locks.AcquireAsync("k");
+        (await Task.WhenAny(second, Task.Delay(100))).ShouldNotBe((Task)second);
+
+        handle.Dispose(); // release
+
+        var done = await Task.WhenAny(second, Task.Delay(1000));
+        done.ShouldBe((Task)second, "releasing the stripe must unblock the waiter");
+        (await second).Dispose();
+    }
+
+    [Fact]
+    public async Task Stripe_IsReleased_EvenWhenBodyThrows()
+    {
+        var locks = new StripedAsyncLock(stripeCount: 1);
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            using (await locks.AcquireAsync("k"))
+            {
+                throw new InvalidOperationException("boom");
+            }
+        });
+
+        // If the stripe had been stranded, this acquire would deadlock.
+        var reacquire = locks.AcquireAsync("k");
+        var done = await Task.WhenAny(reacquire, Task.Delay(1000));
+        done.ShouldBe((Task)reacquire, "an exception in the body must still release the stripe");
+        (await reacquire).Dispose();
+    }
+
+    [Fact]
+    public async Task DoubleDispose_DoesNotOverRelease()
+    {
+        var locks = new StripedAsyncLock(stripeCount: 1);
+
+        var handle = await locks.AcquireAsync("k");
+        handle.Dispose();
+        handle.Dispose(); // second dispose must be a no-op (no extra Release)
+
+        // The stripe should hold at most one permit: a fresh acquire succeeds, but a
+        // SECOND concurrent acquire must still block (proving the count was not
+        // corrupted to 2 by a double release).
+        using var a = await locks.AcquireAsync("k");
+        var b = locks.AcquireAsync("k");
+        (await Task.WhenAny(b, Task.Delay(100))).ShouldNotBe((Task)b);
+        a.Dispose();
+        (await b).Dispose();
+    }
+
+    [Fact]
+    public void Constructor_RejectsNonPositiveStripeCount()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new StripedAsyncLock(0));
+        Should.Throw<ArgumentOutOfRangeException>(() => new StripedAsyncLock(-4));
+    }
+
+    private static void InterlockedMax(ref int target, int value)
+    {
+        int snapshot;
+        do
+        {
+            snapshot = Volatile.Read(ref target);
+            if (value <= snapshot)
+            {
+                return;
+            }
+        }
+        while (Interlocked.CompareExchange(ref target, value, snapshot) != snapshot);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
@@ -55,6 +55,36 @@ public sealed class SqliteSessionStoreTests
     }
 
     [Fact]
+    public async Task Cache_IsBounded_ColdSessionsStillReadableViaFallThrough()
+    {
+        // The in-memory cache is intentionally bounded: inserting far more distinct
+        // sessions than the cap must not retain them all in memory, yet every session
+        // must remain correctly readable (cold reads fall through to SQLite). This is
+        // the regression guard for the unbounded-cache leak (#1504).
+        using var fixture = new StoreFixture();
+        const int cap = 8;
+        const int total = 40;
+        var store = fixture.CreateStore(cacheCapacity: cap);
+
+        for (var i = 0; i < total; i++)
+        {
+            var session = await store.GetOrCreateAsync(SessionId.From($"s{i}"), AgentId.From("agent-a"));
+            session.History.Add(new SessionEntry { Role = MessageRole.User, Content = $"msg-{i}" });
+            await store.SaveAsync(session);
+        }
+
+        // Every session — including the earliest ones long since evicted from the
+        // bounded cache — is still retrievable with its persisted history intact.
+        for (var i = 0; i < total; i++)
+        {
+            var reloaded = await store.GetAsync(SessionId.From($"s{i}"));
+            reloaded.ShouldNotBeNull();
+            reloaded!.SessionId.Value.ShouldBe($"s{i}");
+            reloaded.History.Where(e => e.Content == $"msg-{i}").ShouldHaveSingleItem();
+        }
+    }
+
+    [Fact]
     public async Task SaveAsync_UpdatesExistingSessionAndMetadata()
     {
         using var fixture = new StoreFixture();
@@ -1163,6 +1193,9 @@ public sealed class SqliteSessionStoreTests
 
         public SqliteSessionStore CreateStore(IConversationStore? conversationStore = null)
             => new(ConnectionString, NullLogger<SqliteSessionStore>.Instance, conversationStore ?? Conversations);
+
+        public SqliteSessionStore CreateStore(int cacheCapacity, IConversationStore? conversationStore = null)
+            => new(ConnectionString, NullLogger<SqliteSessionStore>.Instance, conversationStore ?? Conversations, redactor: null, cacheCapacity: cacheCapacity);
 
         public void Dispose()
         {


### PR DESCRIPTION
Closes #1504

## Summary
`SqliteSessionStore` and `SqliteConversationStore` kept unbounded in-memory caches
and per-key lock dictionaries that only shrank on explicit delete/archive. On a
long-running gateway these grew for the entire process lifetime -- the session
cache retained every touched session's full materialized history, and one
`SemaphoreSlim` leaked per distinct session/conversation id ever seen. This
replaces both with bounded primitives. Same leak class as the closed #1333
(ProcessManager) and #1166 (webhook retention); complements the already-shipped
query-layer fix (#1379), which explicitly did not touch the cache layer.

## Changes
Two new shared concurrency primitives (in `BotNexus.Gateway.Contracts`, namespace
`BotNexus.Gateway.Abstractions.Concurrency`):
- **`BoundedLruCache<TKey,TValue>`** -- thread-safe, size-capped LRU. Reads and
  writes promote to most-recently-used; over-capacity inserts evict the LRU entry.
  Replaces the unbounded read-through `ConcurrentDictionary` caches.
- **`StripedAsyncLock`** -- a fixed pool of `SemaphoreSlim` stripes hashed by key
  (default 256). Bounds the number of sync primitives (no per-key leak) and, because
  no per-key entry is ever created or removed, cannot strand a lock on an exception
  (the stripe is released in the `IDisposable` returned from `AcquireAsync`).

Wired into both stores:
- `SqliteSessionStore`: `_cache` -> `BoundedLruCache<SessionId, GatewaySession>`,
  `_agentIdCache` -> `BoundedLruCache<ConversationId, AgentId>`, `_sessionLocks`
  -> `StripedAsyncLock`. New optional `cacheCapacity` ctor arg
  (default `DefaultSessionCacheCapacity = 500`).
- `SqliteConversationStore`: `_cache` -> `BoundedLruCache<string, Conversation>`,
  `_conversationLocks` -> `StripedAsyncLock`. New optional `cacheCapacity` ctor arg
  (default `DefaultConversationCacheCapacity = 1000`).

The on-disk SQLite remains the source of truth; cold reads fall through to it (the
existing load path), so eviction only drops memory, never data.

## Tests
- `BoundedLruCacheTests` (10) -- eviction order, promote-on-read, update-in-place,
  bound never exceeded across 5000 distinct keys, remove/clear, custom comparer,
  concurrent access.
- `StripedAsyncLockTests` (9) -- fixed stripe count across 10k keys, mutual
  exclusion on a shared stripe, concurrency across distinct stripes, release frees
  the next caller, **release even when the body throws**, double-dispose is a no-op.
- `SqliteSessionStoreTests.Cache_IsBounded_ColdSessionsStillReadableViaFallThrough`
  and the conversation-store equivalent -- insert 40 sessions/conversations with a
  cap of 8, assert every one (including long-evicted) is still readable with intact
  state.
- The existing `*StoreParityTests` / `*StoreContractTests` (run against all three
  store implementations) guard behavioral equivalence across the change.

## Validation
- `dotnet build BotNexus.slnx --no-incremental -warnaserror` -- 0 warnings, 0 errors.
- `scripts/repo/test-impacted.ps1` -- green (Architecture 198, Scenarios 29,
  Gateway 3132/+1 skip, Conversations 251, Sessions 61, Cron 201, Cli 298, all
  extensions).

## Merge Notes
Touches only the two SQLite store classes, the Contracts project, and their tests
-- disjoint from #1529 (CI/CODEOWNERS) and from the open ask_user durability work
(which lives in different files). Safe to merge in any order.

Note: the `StripedAsyncLock` "release on every branch" discipline also covers the
concern raised in #1518/#1522 for these two stores' write locks (a fixed pool has
no per-key entry to strand), though those issues remain open for their own
finalizer/takeover scenarios.
