### PR TITLE
refactor(gateway): extract PrepareTurnAsync from ProcessAsync

### DIFF
--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -390,65 +390,14 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
             // target conversation doesn't exist, so this MUST follow the first SaveAsync.
             await EnsureCallerParticipantAsync(session, message.Sender, cancellationToken).ConfigureAwait(false);
 
-            if (_compactor.ShouldCompact(session.Session, _compactionOptions.CurrentValue))
-            {
-                _logger.LogInformation("Auto-compacting session {SessionId}", sessionId);
-                try
-                {
-                    var outcome = await _compactionCoordinator.CompactAsync(session.AgentId, session, cancellationToken).ConfigureAwait(false);
-                    if (outcome.Applied)
-                    {
-                        await _compactionCoordinator.TrySendChannelNotificationAsync(
-                            outcome,
-                            message.ChannelType,
-                            message.ChannelAddress,
-                            sessionId,
-                            cancellationToken).ConfigureAwait(false);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Auto-compaction failed for session {SessionId}, continuing without compaction", sessionId);
-                }
-            }
-
-            // Abandoned turn detection (#790): before starting the new turn, check if
-            // the previous turn stalled mid-tool-execution. If so, destroy the existing
-            // agent handle (forces fresh context on recreate) and notify the user.
-            var abandonedTurnResult = SessionContextProjector.DetectAbandonedTurn(session.History);
-            if (abandonedTurnResult.HasAbandonedTurn)
-            {
-                _logger.LogWarning(
-                    "Abandoned turn detected for session '{SessionId}': {Count} dangling tool call(s). " +
-                    "Destroying stale agent handle to prevent context replay.",
-                    sessionId, abandonedTurnResult.AbandonedEntryCount);
-
-                // Kill the existing handle so the supervisor creates a fresh one with
-                // clean context from ProjectForResume (which drops tool entries).
-                var stopTask = _supervisor.StopAsync(typedAgentId, typedSessionId, cancellationToken);
-                if (stopTask is not null)
-                    await stopTask;
-
-                // Add a notification entry so the user knows the prior turn was incomplete.
-                session.AddEntry(new SessionEntry
-                {
-                    Role = MessageRole.Notification,
-                    Content = $"[Previous turn did not complete — {abandonedTurnResult.AbandonedEntryCount} tool call(s) were abandoned. Starting fresh.]"
-                });
-                await _sessions.SaveAsync(session, cancellationToken);
-            }
-
-            // Write-ahead Layer 2: crash sentinel written before the LLM call.
-            // If the gateway restarts mid-turn, this sentinel survives in the session store,
-            // showing an interrupted-turn marker to the user rather than a silent gap (#363).
-            var crashSentinel = new SessionEntry
-            {
-                Role = MessageRole.System,
-                Content = "[agent turn in progress — gateway restarted if visible]",
-                IsCrashSentinel = true
-            };
-            session.AddEntry(crashSentinel);
-            await _sessions.SaveAsync(session, cancellationToken);
+            // #1503 (increment 2, follow-up to #1381): the pre-execution "prepare turn"
+            // concern -- auto-compaction, abandoned-turn detection (#790), and the
+            // write-ahead crash sentinel (#363) -- is extracted into PrepareTurnAsync so
+            // ProcessAsync no longer inlines it. The method mutates+persists the session in
+            // the exact prior order (compaction -> abandoned-turn handle-stop+notify ->
+            // crash sentinel save); none of its locals escape into the execution path below,
+            // so applying it here preserves the prior control flow and side-effect ordering.
+            await PrepareTurnAsync(session, message, typedAgentId, typedSessionId, sessionId, cancellationToken);
 
             try
             {
@@ -908,6 +857,86 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
         ChannelSource ResolvedSource,
         InboundMessage Message,
         DispatchResult? Dispatch);
+
+    /// <summary>
+    /// Runs the pre-execution "prepare turn" steps for a single agent dispatch, extracted from
+    /// <see cref="ProcessAsync"/> (#1503 increment 2, follow-up to #1381). In strict order:
+    /// (1) auto-compaction when <see cref="ISessionCompactor.ShouldCompact"/> is true (best-effort:
+    /// a compaction failure is logged and swallowed so the turn still proceeds, #363/#602),
+    /// (2) abandoned-turn detection (#790) -- if the previous turn stalled mid-tool, stop the stale
+    /// handle so the supervisor rebuilds clean context and append a user-visible notification, and
+    /// (3) the write-ahead crash sentinel (#363) persisted before the LLM call. Every step mutates
+    /// and persists <paramref name="session"/> exactly as the inlined block did; no value produced
+    /// here is consumed by the caller, so the extraction is behaviour-preserving.
+    /// </summary>
+    private async Task PrepareTurnAsync(
+        GatewaySession session,
+        InboundMessage message,
+        AgentId typedAgentId,
+        SessionId typedSessionId,
+        string sessionId,
+        CancellationToken cancellationToken)
+    {
+        if (_compactor.ShouldCompact(session.Session, _compactionOptions.CurrentValue))
+        {
+            _logger.LogInformation("Auto-compacting session {SessionId}", sessionId);
+            try
+            {
+                var outcome = await _compactionCoordinator.CompactAsync(session.AgentId, session, cancellationToken).ConfigureAwait(false);
+                if (outcome.Applied)
+                {
+                    await _compactionCoordinator.TrySendChannelNotificationAsync(
+                        outcome,
+                        message.ChannelType,
+                        message.ChannelAddress,
+                        sessionId,
+                        cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Auto-compaction failed for session {SessionId}, continuing without compaction", sessionId);
+            }
+        }
+
+        // Abandoned turn detection (#790): before starting the new turn, check if
+        // the previous turn stalled mid-tool-execution. If so, destroy the existing
+        // agent handle (forces fresh context on recreate) and notify the user.
+        var abandonedTurnResult = SessionContextProjector.DetectAbandonedTurn(session.History);
+        if (abandonedTurnResult.HasAbandonedTurn)
+        {
+            _logger.LogWarning(
+                "Abandoned turn detected for session '{SessionId}': {Count} dangling tool call(s). " +
+                "Destroying stale agent handle to prevent context replay.",
+                sessionId, abandonedTurnResult.AbandonedEntryCount);
+
+            // Kill the existing handle so the supervisor creates a fresh one with
+            // clean context from ProjectForResume (which drops tool entries).
+            var stopTask = _supervisor.StopAsync(typedAgentId, typedSessionId, cancellationToken);
+            if (stopTask is not null)
+                await stopTask;
+
+            // Add a notification entry so the user knows the prior turn was incomplete.
+            session.AddEntry(new SessionEntry
+            {
+                Role = MessageRole.Notification,
+                Content = $"[Previous turn did not complete — {abandonedTurnResult.AbandonedEntryCount} tool call(s) were abandoned. Starting fresh.]"
+            });
+            await _sessions.SaveAsync(session, cancellationToken);
+        }
+
+        // Write-ahead Layer 2: crash sentinel written before the LLM call.
+        // If the gateway restarts mid-turn, this sentinel survives in the session store,
+        // showing an interrupted-turn marker to the user rather than a silent gap (#363).
+        var crashSentinel = new SessionEntry
+        {
+            Role = MessageRole.System,
+            Content = "[agent turn in progress — gateway restarted if visible]",
+            IsCrashSentinel = true
+        };
+        session.AddEntry(crashSentinel);
+        await _sessions.SaveAsync(session, cancellationToken);
+    }
 
     private async Task SendSessionStatusRejectedAsync(
         InboundMessage message,

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -1795,6 +1795,59 @@ public sealed class GatewayHostTests
     }
 
     [Fact]
+    public async Task DispatchAsync_WhenPreviousTurnAbandonedMidTool_StopsHandleAndNotifiesUser()
+    {
+        // Arrange: a session whose history ends with a dangling ToolStart (no matching ToolEnd)
+        // from a prior user turn. When the new inbound message arrives, PrepareTurnAsync's
+        // abandoned-turn detection (#790) must fire: stop the stale handle and add a
+        // Notification entry so the user knows the previous turn did not complete.
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-abandon"]);
+
+        var handle = CreatePromptHandle("agent-abandon", "session-abandon", "response");
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+            BotNexus.Domain.Primitives.AgentId.From("agent-abandon"),
+            BotNexus.Domain.Primitives.SessionId.From("session-abandon"),
+            It.IsAny<CancellationToken>())).ReturnsAsync(handle.Object);
+
+        var session = new GatewaySession
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("session-abandon"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-abandon")
+        };
+        // Seed a previous user turn that stalled mid-tool: a User entry followed by a
+        // ToolStart (ToolArgs set) with no matching ToolEnd.
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "do the thing" });
+        session.AddEntry(new SessionEntry { Role = MessageRole.Tool, Content = "some_tool", ToolCallId = "call-1", ToolArgs = "{}" });
+
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetOrCreateAsync(
+            BotNexus.Domain.Primitives.SessionId.From("session-abandon"),
+            BotNexus.Domain.Primitives.AgentId.From("agent-abandon"),
+            It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        await using var host = CreateHost(supervisor.Object, router.Object, sessions.Object, new RecordingActivityBroadcaster(), CreateChannelManager(channel.Object));
+
+        // Act
+        await host.DispatchAsync(CreateMessage("second message", sessionId: "session-abandon"));
+
+        // Assert: the stale handle was stopped (forces fresh context on recreate) and a
+        // Notification entry describing the abandoned turn was added to history.
+        supervisor.Verify(s => s.StopAsync(
+            BotNexus.Domain.Primitives.AgentId.From("agent-abandon"),
+            BotNexus.Domain.Primitives.SessionId.From("session-abandon"),
+            It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        session.History.ShouldContain(
+            e => e.Role.Equals(MessageRole.Notification) && e.Content != null && e.Content.Contains("did not complete"),
+            "abandoned-turn detection must add a notification entry when a prior turn stalled mid-tool (#790)");
+    }
+
+    [Fact]
     public async Task StreamEvents_FanOutToSignalRObserverBindings_WhenOriginatingChannelIsNotSignalR()
     {
         // Arrange: telegram message with a SignalR observer binding on the conversation


### PR DESCRIPTION
Part of #1503
## Summary
Extracts the pre-execution "prepare turn" block out of the 589-line `GatewayHost.ProcessAsync` god method into a focused `private async Task PrepareTurnAsync(...)`. This is increment 2 of the #1381 decomposition spec (increment 1 = `ResolveConversationSessionAsync`, already shipped). The issue documents this exact extraction as step 1 ("sentinels + compaction + abandoned-turn detection -- pure-ish, easiest next slice").

## Changes
- New `PrepareTurnAsync(session, message, typedAgentId, typedSessionId, sessionId, ct)` containing, in the exact prior order:
  1. auto-compaction (`_compactor.ShouldCompact` -> `CompactAsync` + best-effort channel notification; failures logged and swallowed)
  2. abandoned-turn detection (#790) -- stop the stale handle + append a user-visible Notification
  3. write-ahead crash sentinel (#363) persisted before the LLM call
- `ProcessAsync` now calls `PrepareTurnAsync(...)` in place of the inlined block.
- This is a pure, behaviour-preserving move: no value produced by the block is consumed downstream (the locals `outcome`, `abandonedTurnResult`, `crashSentinel` were all fully contained; the sentinel is later removed via `session.RemoveCrashSentinels()` which reads `session.History`, not the local).

## Tests
- Added `DispatchAsync_WhenPreviousTurnAbandonedMidTool_StopsHandleAndNotifiesUser` -- the abandoned-turn path through `ProcessAsync` had no dedicated test; this seeds a session whose history ends in a dangling ToolStart, dispatches a new message, and asserts the stale handle is stopped and a "did not complete" Notification is appended. It passes against both pre- and post-extraction code (a regression lock for the slice).
- The existing GatewayHostTests already cover the slice's behaviour (`GatewayHost_AutoCompaction_*` x3, `DispatchAsync_RemovesCrashSentinelFromHistoryOnSuccess`, `DispatchAsync_WhenCompactedSessionHasMarkedHistoryAndSummary_DoesNotStopExistingHandle`). All 47 GatewayHostTests pass.
- Full `dotnet build BotNexus.slnx --no-incremental -warnaserror`: 0 warnings, 0 errors. test-impacted.ps1 green: Gateway.Tests 3114/1 skip, Scenarios.Tests 29, Architecture.Tests.

## Scope note
This is one bounded slice. The remaining #1503 increments (StreamEventRouter extraction, StreamingTurnExecutor/PromptTurnExecutor split behind IExecuteTurnStrategy, FinalizeTurnAsync) stay as follow-ups, one extraction per PR as the issue recommends. #1503 remains open after this merges (it tracks the full decomposition).

## Merge Notes
Touches only `src/gateway/BotNexus.Gateway/GatewayHost.cs` + its test. No overlap with the other open PRs (#1529 .github CI guard, #1530 SQLite cache stores). Safe to merge in any order.
