### PR TITLE
feat(security): add SecurityEvent model and trusted ring-buffer sink

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/Security/ISecurityEventSink.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Security/ISecurityEventSink.cs
@@ -1,0 +1,41 @@
+namespace BotNexus.Gateway.Abstractions.Security;
+
+/// <summary>
+/// A trusted-only sink for <see cref="SecurityEvent"/> records emitted at the gateway's
+/// security enforcement boundaries.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Step 1/5 of the security-event taxonomy (#1532, part of #1526). Implementations record
+/// security events to a <strong>trusted</strong> store -- these events are deliberately kept
+/// OFF the public activity/diagnostic stream so that an untrusted consumer cannot read who
+/// was denied, which secrets were referenced, or how authorization decisions were made.
+/// A future trusted-only diagnostics surface (Step 5) reads back recent events via
+/// <see cref="Snapshot"/>.
+/// </para>
+/// <para>
+/// Implementations must be safe to call concurrently from any enforcement-path thread.
+/// Recording must never throw for benign back-pressure -- a full sink evicts rather than blocks.
+/// </para>
+/// </remarks>
+public interface ISecurityEventSink
+{
+    /// <summary>
+    /// Records a security event. Thread-safe; must not block on back-pressure
+    /// (a bounded implementation evicts the oldest event instead).
+    /// </summary>
+    /// <param name="securityEvent">The event to record. Must not be null.</param>
+    void Record(SecurityEvent securityEvent);
+
+    /// <summary>
+    /// Returns a point-in-time snapshot of the retained events, most-recent first.
+    /// The returned list is a copy and is safe to enumerate without further locking.
+    /// </summary>
+    IReadOnlyList<SecurityEvent> Snapshot();
+
+    /// <summary>The number of events currently retained.</summary>
+    int Count { get; }
+
+    /// <summary>Removes all retained events.</summary>
+    void Clear();
+}

--- a/src/gateway/BotNexus.Gateway.Contracts/Security/RingBufferSecurityEventSink.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Security/RingBufferSecurityEventSink.cs
@@ -1,0 +1,92 @@
+namespace BotNexus.Gateway.Abstractions.Security;
+
+/// <summary>
+/// A bounded, thread-safe, in-memory <see cref="ISecurityEventSink"/> backed by a fixed-size
+/// circular buffer. When the buffer is full, recording a new event evicts the oldest one
+/// (it never blocks). <see cref="Snapshot"/> returns the retained events most-recent first.
+/// </summary>
+/// <remarks>
+/// Step 1/5 of the security-event taxonomy (#1532, part of #1526). This is the default trusted
+/// sink: it keeps a recent window of security events for the (future) trusted diagnostics surface
+/// without unbounded memory growth on a long-running gateway. It is intentionally separate from
+/// the public <c>LogDiagnosticsRingBuffer</c> so trusted security events never leak onto the
+/// public diagnostic stream.
+/// </remarks>
+public sealed class RingBufferSecurityEventSink : ISecurityEventSink
+{
+    private readonly SecurityEvent[] _buffer;
+    private readonly Lock _gate = new();
+
+    // Index of the next write slot. _count tracks how many slots are populated.
+    private int _next;
+    private int _count;
+
+    /// <summary>
+    /// Creates a new ring-buffer sink.
+    /// </summary>
+    /// <param name="capacity">Maximum number of events to retain. Must be positive.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="capacity"/> is not positive.</exception>
+    public RingBufferSecurityEventSink(int capacity = 512)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+        _buffer = new SecurityEvent[capacity];
+    }
+
+    /// <inheritdoc />
+    public void Record(SecurityEvent securityEvent)
+    {
+        ArgumentNullException.ThrowIfNull(securityEvent);
+
+        lock (_gate)
+        {
+            _buffer[_next] = securityEvent;
+            _next = (_next + 1) % _buffer.Length;
+            if (_count < _buffer.Length)
+                _count++;
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SecurityEvent> Snapshot()
+    {
+        lock (_gate)
+        {
+            var result = new SecurityEvent[_count];
+            // Walk backwards from the most recently written slot so the result is most-recent first.
+            // The most recent write landed at (_next - 1); older entries precede it (wrapping).
+            var idx = _next - 1;
+            for (var i = 0; i < _count; i++)
+            {
+                if (idx < 0)
+                    idx += _buffer.Length;
+                result[i] = _buffer[idx];
+                idx--;
+            }
+
+            return result;
+        }
+    }
+
+    /// <inheritdoc />
+    public int Count
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _count;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            Array.Clear(_buffer, 0, _buffer.Length);
+            _next = 0;
+            _count = 0;
+        }
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Contracts/Security/SecurityEvent.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Security/SecurityEvent.cs
@@ -1,0 +1,242 @@
+namespace BotNexus.Gateway.Abstractions.Security;
+
+/// <summary>
+/// The broad classification of a security-relevant event. Each value maps to a
+/// distinct area of the gateway's security posture so that events can be filtered
+/// and aggregated by concern (e.g. all <see cref="Approval"/> decisions, or every
+/// <see cref="Auth"/> handshake outcome).
+/// </summary>
+/// <remarks>
+/// Part of the security-event taxonomy (#1526). This is an internal observability
+/// vocabulary: it records who did what, under which control, and with what outcome,
+/// at the gateway's enforcement boundaries. It is intentionally NOT placed on the
+/// public activity/diagnostic stream -- see <see cref="ISecurityEventSink"/>.
+/// </remarks>
+public enum SecurityEventCategory
+{
+    /// <summary>Authentication: identity handshakes and credential validation.</summary>
+    Auth,
+    /// <summary>Authorization: access/scope checks on a known identity.</summary>
+    Authorization,
+    /// <summary>Approval: human-in-the-loop allow/deny/ask decisions (e.g. exec approval).</summary>
+    Approval,
+    /// <summary>Tool execution boundary events (requested, blocked, vetoed).</summary>
+    Tool,
+    /// <summary>Plugin / extension lifecycle (install, load, enable).</summary>
+    Plugin,
+    /// <summary>Secret handling (redaction triggers, secret-reference access).</summary>
+    Secret,
+    /// <summary>Channel boundary events (inbound/outbound message trust decisions).</summary>
+    Channel,
+    /// <summary>Configuration access or change with a security dimension.</summary>
+    Config,
+    /// <summary>General audit records that do not fit a more specific category.</summary>
+    Audit,
+    /// <summary>Telemetry/observability-internal events about the security pipeline itself.</summary>
+    Telemetry
+}
+
+/// <summary>
+/// The result of the action that produced a <see cref="SecurityEvent"/>.
+/// </summary>
+public enum SecurityEventOutcome
+{
+    /// <summary>The action completed and was permitted.</summary>
+    Success,
+    /// <summary>The action failed for a non-policy reason (e.g. a handshake error).</summary>
+    Failure,
+    /// <summary>The action was explicitly denied by a control/policy.</summary>
+    Denied,
+    /// <summary>The action errored unexpectedly (an exceptional condition).</summary>
+    Error
+}
+
+/// <summary>
+/// The relative importance of a <see cref="SecurityEvent"/> for triage and alerting.
+/// </summary>
+public enum SecurityEventSeverity
+{
+    /// <summary>Informational; routine, expected security activity.</summary>
+    Info,
+    /// <summary>Low: minor, rarely actionable on its own.</summary>
+    Low,
+    /// <summary>Medium: worth review (e.g. a denied approval).</summary>
+    Medium,
+    /// <summary>High: a likely security-relevant failure (e.g. a failed auth handshake).</summary>
+    High,
+    /// <summary>Critical: an event that demands immediate attention.</summary>
+    Critical
+}
+
+/// <summary>
+/// The decision a control rendered, when the event represents a policy evaluation.
+/// </summary>
+public enum SecurityPolicyDecision
+{
+    /// <summary>No policy decision applies to this event.</summary>
+    None,
+    /// <summary>The control permitted the action.</summary>
+    Allow,
+    /// <summary>The control rejected the action.</summary>
+    Deny,
+    /// <summary>The control deferred to a human (allow-with-approval).</summary>
+    Ask
+}
+
+/// <summary>
+/// The control family responsible for the event -- which kind of security mechanism
+/// produced or evaluated it.
+/// </summary>
+public enum SecurityControlFamily
+{
+    /// <summary>No specific control family.</summary>
+    None,
+    /// <summary>Authentication controls.</summary>
+    Auth,
+    /// <summary>Authorization / scope controls.</summary>
+    Authorization,
+    /// <summary>Human-in-the-loop approval controls.</summary>
+    Approval,
+    /// <summary>Sandboxing / isolation controls.</summary>
+    Sandbox,
+    /// <summary>Secret-handling controls (redaction, vaulting).</summary>
+    Secret,
+    /// <summary>Supply-chain controls (plugin/extension integrity).</summary>
+    SupplyChain
+}
+
+/// <summary>The kind of principal that initiated a security event.</summary>
+public enum SecurityActorKind
+{
+    /// <summary>A human operator (e.g. Jon approving an exec command).</summary>
+    Operator,
+    /// <summary>A satellite/remote node.</summary>
+    Node,
+    /// <summary>An agent acting within the gateway.</summary>
+    Agent,
+    /// <summary>A plugin / extension.</summary>
+    Plugin,
+    /// <summary>A channel sender (inbound message origin).</summary>
+    ChannelSender,
+    /// <summary>The system itself (no external principal).</summary>
+    System
+}
+
+/// <summary>The kind of resource a security event acted upon.</summary>
+public enum SecurityTargetKind
+{
+    /// <summary>The gateway process / host.</summary>
+    Gateway,
+    /// <summary>A paired device.</summary>
+    Device,
+    /// <summary>A tool invocation.</summary>
+    Tool,
+    /// <summary>A reference to a secret (never the secret value itself).</summary>
+    SecretRef,
+    /// <summary>A configuration section or key.</summary>
+    Config,
+    /// <summary>A session.</summary>
+    Session
+}
+
+/// <summary>
+/// The principal that initiated a <see cref="SecurityEvent"/>.
+/// </summary>
+/// <param name="Kind">The category of principal.</param>
+/// <param name="Id">
+/// An opaque or already-hashed identifier for the principal. Callers are responsible
+/// for hashing/anonymising before construction -- this record never stores a raw secret
+/// or reverses an id.
+/// </param>
+public sealed record SecurityEventActor(SecurityActorKind Kind, string Id);
+
+/// <summary>
+/// The resource a <see cref="SecurityEvent"/> acted upon.
+/// </summary>
+/// <param name="Kind">The category of target.</param>
+/// <param name="Reference">
+/// A non-sensitive reference to the target (e.g. a tool name, a config section name,
+/// or a secret <em>reference</em> -- never a secret value).
+/// </param>
+public sealed record SecurityEventTarget(SecurityTargetKind Kind, string Reference);
+
+/// <summary>
+/// A canonical, typed record of a security-relevant event observed at a gateway
+/// enforcement boundary. Captures who (<see cref="Actor"/>) did what (<see cref="Action"/>)
+/// to what (<see cref="Target"/>), under which control (<see cref="Control"/>), with what
+/// policy decision (<see cref="Policy"/>) and outcome (<see cref="Outcome"/>).
+/// </summary>
+/// <remarks>
+/// Step 1/5 of the security-event taxonomy (#1532, part of #1526). These events are
+/// emitted only via a trusted <see cref="ISecurityEventSink"/> and are deliberately kept
+/// off the public activity/diagnostic stream. Enforcement-point wiring is added in
+/// follow-up steps; this type and its sink are the foundational primitives.
+/// </remarks>
+/// <param name="Category">The broad classification of the event.</param>
+/// <param name="Action">
+/// A dotted, stable action identifier (e.g. <c>tool.execution.blocked</c>,
+/// <c>gateway.auth.failed</c>) describing precisely what happened.
+/// </param>
+/// <param name="Outcome">The result of the action.</param>
+/// <param name="Severity">The triage importance of the event.</param>
+/// <param name="Actor">The initiating principal, if known.</param>
+/// <param name="Target">The acted-upon resource, if applicable.</param>
+/// <param name="Policy">The control's decision, if the event is a policy evaluation.</param>
+/// <param name="Control">The control family responsible for the event.</param>
+public sealed record SecurityEvent(
+    SecurityEventCategory Category,
+    string Action,
+    SecurityEventOutcome Outcome,
+    SecurityEventSeverity Severity,
+    SecurityEventActor? Actor = null,
+    SecurityEventTarget? Target = null,
+    SecurityPolicyDecision Policy = SecurityPolicyDecision.None,
+    SecurityControlFamily Control = SecurityControlFamily.None)
+{
+    /// <summary>
+    /// When the event occurred (UTC). Defaults to the construction time; set explicitly via an
+    /// object initializer (e.g. <c>new SecurityEvent(...) { TimestampUtc = ts }</c>) when replaying.
+    /// </summary>
+    public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Builds an <see cref="SecurityEventCategory.Approval"/> event for a human-in-the-loop
+    /// allow/deny/ask decision. The <paramref name="decision"/> drives the outcome:
+    /// <see cref="SecurityPolicyDecision.Allow"/> -> <see cref="SecurityEventOutcome.Success"/>,
+    /// <see cref="SecurityPolicyDecision.Deny"/> -> <see cref="SecurityEventOutcome.Denied"/>,
+    /// anything else -> <see cref="SecurityEventOutcome.Success"/> (an ask that was satisfied).
+    /// </summary>
+    public static SecurityEvent ApprovalDecision(
+        string action,
+        SecurityPolicyDecision decision,
+        SecurityEventActor? actor = null,
+        SecurityEventTarget? target = null,
+        SecurityEventSeverity severity = SecurityEventSeverity.Medium) =>
+        new(
+            SecurityEventCategory.Approval,
+            action,
+            decision == SecurityPolicyDecision.Deny ? SecurityEventOutcome.Denied : SecurityEventOutcome.Success,
+            severity,
+            Actor: actor,
+            Target: target,
+            Policy: decision,
+            Control: SecurityControlFamily.Approval);
+
+    /// <summary>
+    /// Builds an <see cref="SecurityEventCategory.Auth"/> event for an authentication
+    /// handshake outcome. A failure defaults to <see cref="SecurityEventSeverity.High"/>;
+    /// a success defaults to <see cref="SecurityEventSeverity.Info"/> unless overridden.
+    /// </summary>
+    public static SecurityEvent AuthOutcome(
+        string action,
+        bool success,
+        SecurityEventActor? actor = null,
+        SecurityEventSeverity? severity = null) =>
+        new(
+            SecurityEventCategory.Auth,
+            action,
+            success ? SecurityEventOutcome.Success : SecurityEventOutcome.Failure,
+            severity ?? (success ? SecurityEventSeverity.Info : SecurityEventSeverity.High),
+            Actor: actor,
+            Control: SecurityControlFamily.Auth);
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Security/RingBufferSecurityEventSinkTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Security/RingBufferSecurityEventSinkTests.cs
@@ -1,0 +1,134 @@
+using BotNexus.Gateway.Abstractions.Security;
+
+namespace BotNexus.Gateway.Tests.Security;
+
+/// <summary>
+/// Tests for <see cref="RingBufferSecurityEventSink"/> -- the bounded, thread-safe,
+/// trusted-only in-memory sink (Step 1/5 of the security-event taxonomy, issue #1532 / #1526).
+/// </summary>
+public sealed class RingBufferSecurityEventSinkTests
+{
+    private static SecurityEvent Event(string action, SecurityEventSeverity severity = SecurityEventSeverity.Info) =>
+        new(SecurityEventCategory.Audit, action, SecurityEventOutcome.Success, severity);
+
+    [Fact]
+    public void Record_ThenSnapshot_RoundTripsTheEvent()
+    {
+        var sink = new RingBufferSecurityEventSink(capacity: 8);
+        var evt = Event("audit.test.one");
+
+        sink.Record(evt);
+
+        var snapshot = sink.Snapshot();
+        snapshot.Count.ShouldBe(1);
+        snapshot[0].ShouldBe(evt);
+        sink.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Snapshot_ReturnsMostRecentFirst()
+    {
+        var sink = new RingBufferSecurityEventSink(capacity: 8);
+        sink.Record(Event("first"));
+        sink.Record(Event("second"));
+        sink.Record(Event("third"));
+
+        var snapshot = sink.Snapshot();
+
+        snapshot.Count.ShouldBe(3);
+        snapshot[0].Action.ShouldBe("third");
+        snapshot[1].Action.ShouldBe("second");
+        snapshot[2].Action.ShouldBe("first");
+    }
+
+    [Fact]
+    public void Record_PastCapacity_EvictsOldestFirst()
+    {
+        var sink = new RingBufferSecurityEventSink(capacity: 3);
+
+        sink.Record(Event("e1"));
+        sink.Record(Event("e2"));
+        sink.Record(Event("e3"));
+        sink.Record(Event("e4")); // evicts e1
+        sink.Record(Event("e5")); // evicts e2
+
+        sink.Count.ShouldBe(3);
+        var actions = sink.Snapshot().Select(e => e.Action).ToList();
+        actions.ShouldBe(new[] { "e5", "e4", "e3" });
+        actions.ShouldNotContain("e1");
+        actions.ShouldNotContain("e2");
+    }
+
+    [Fact]
+    public void Count_NeverExceedsCapacity()
+    {
+        var sink = new RingBufferSecurityEventSink(capacity: 5);
+        for (var i = 0; i < 50; i++)
+            sink.Record(Event($"e{i}"));
+
+        sink.Count.ShouldBe(5);
+        sink.Snapshot().Count.ShouldBe(5);
+        // The five most recent survive, most-recent-first.
+        sink.Snapshot().Select(e => e.Action).ShouldBe(new[] { "e49", "e48", "e47", "e46", "e45" });
+    }
+
+    [Fact]
+    public void Clear_EmptiesTheBuffer()
+    {
+        var sink = new RingBufferSecurityEventSink(capacity: 4);
+        sink.Record(Event("a"));
+        sink.Record(Event("b"));
+
+        sink.Clear();
+
+        sink.Count.ShouldBe(0);
+        sink.Snapshot().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Constructor_RejectsNonPositiveCapacity()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new RingBufferSecurityEventSink(capacity: 0));
+        Should.Throw<ArgumentOutOfRangeException>(() => new RingBufferSecurityEventSink(capacity: -1));
+    }
+
+    [Fact]
+    public void Record_RejectsNullEvent()
+    {
+        var sink = new RingBufferSecurityEventSink(capacity: 4);
+        Should.Throw<ArgumentNullException>(() => sink.Record(null!));
+    }
+
+    [Fact]
+    public async Task ConcurrentWrites_DoNotCorruptOrExceedCapacity()
+    {
+        const int capacity = 64;
+        const int writers = 16;
+        const int perWriter = 500;
+        var sink = new RingBufferSecurityEventSink(capacity);
+
+        var tasks = Enumerable.Range(0, writers).Select(w => Task.Run(() =>
+        {
+            for (var i = 0; i < perWriter; i++)
+                sink.Record(Event($"w{w}-i{i}"));
+        }));
+
+        await Task.WhenAll(tasks);
+
+        // Buffer must be exactly full and internally consistent (no torn entries).
+        sink.Count.ShouldBe(capacity);
+        var snapshot = sink.Snapshot();
+        snapshot.Count.ShouldBe(capacity);
+        snapshot.ShouldAllBe(e => e != null);
+        // Total writes far exceeded capacity, so the buffer is saturated with valid events.
+        snapshot.Select(e => e.Action).Distinct().Count().ShouldBe(capacity);
+    }
+
+    [Fact]
+    public void ImplementsISecurityEventSink()
+    {
+        ISecurityEventSink sink = new RingBufferSecurityEventSink(capacity: 4);
+        sink.Record(Event("via-interface"));
+        sink.Snapshot()[0].Action.ShouldBe("via-interface");
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Security/SecurityEventTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Security/SecurityEventTests.cs
@@ -1,0 +1,136 @@
+using BotNexus.Gateway.Abstractions.Security;
+
+namespace BotNexus.Gateway.Tests.Security;
+
+/// <summary>
+/// Tests for the <see cref="SecurityEvent"/> canonical security-observability record
+/// and its factory helpers (Step 1/5 of the security-event taxonomy, issue #1532 / #1526).
+/// </summary>
+public sealed class SecurityEventTests
+{
+    [Fact]
+    public void Constructor_DefaultsTimestampToUtcNow()
+    {
+        var before = DateTimeOffset.UtcNow;
+
+        var evt = new SecurityEvent(
+            SecurityEventCategory.Approval,
+            "tool.execution.blocked",
+            SecurityEventOutcome.Denied,
+            SecurityEventSeverity.High);
+
+        var after = DateTimeOffset.UtcNow;
+
+        evt.TimestampUtc.ShouldBeGreaterThanOrEqualTo(before);
+        evt.TimestampUtc.ShouldBeLessThanOrEqualTo(after);
+        evt.TimestampUtc.Offset.ShouldBe(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void Constructor_RetainsAllProvidedFields()
+    {
+        var actor = new SecurityEventActor(SecurityActorKind.Operator, "hash-abc");
+        var target = new SecurityEventTarget(SecurityTargetKind.Tool, "exec");
+        var ts = new DateTimeOffset(2026, 6, 18, 7, 0, 0, TimeSpan.Zero);
+
+        var evt = new SecurityEvent(
+            Category: SecurityEventCategory.Tool,
+            Action: "tool.execution.requested",
+            Outcome: SecurityEventOutcome.Success,
+            Severity: SecurityEventSeverity.Info,
+            Actor: actor,
+            Target: target,
+            Policy: SecurityPolicyDecision.Allow,
+            Control: SecurityControlFamily.Approval)
+        {
+            TimestampUtc = ts
+        };
+
+        evt.Category.ShouldBe(SecurityEventCategory.Tool);
+        evt.Action.ShouldBe("tool.execution.requested");
+        evt.Outcome.ShouldBe(SecurityEventOutcome.Success);
+        evt.Severity.ShouldBe(SecurityEventSeverity.Info);
+        evt.Actor.ShouldBe(actor);
+        evt.Target.ShouldBe(target);
+        evt.Policy.ShouldBe(SecurityPolicyDecision.Allow);
+        evt.Control.ShouldBe(SecurityControlFamily.Approval);
+        evt.TimestampUtc.ShouldBe(ts);
+    }
+
+    [Fact]
+    public void OptionalFields_DefaultToNullOrNone()
+    {
+        var evt = new SecurityEvent(
+            SecurityEventCategory.Auth,
+            "gateway.auth.failed",
+            SecurityEventOutcome.Failure,
+            SecurityEventSeverity.Medium);
+
+        evt.Actor.ShouldBeNull();
+        evt.Target.ShouldBeNull();
+        evt.Policy.ShouldBe(SecurityPolicyDecision.None);
+        evt.Control.ShouldBe(SecurityControlFamily.None);
+    }
+
+    [Fact]
+    public void ApprovalDecision_FactoryProducesDeniedApprovalEvent()
+    {
+        var actor = new SecurityEventActor(SecurityActorKind.ChannelSender, "hash-sender");
+
+        var evt = SecurityEvent.ApprovalDecision(
+            action: "exec.approval.denied",
+            decision: SecurityPolicyDecision.Deny,
+            actor: actor,
+            target: new SecurityEventTarget(SecurityTargetKind.Tool, "exec"));
+
+        evt.Category.ShouldBe(SecurityEventCategory.Approval);
+        evt.Control.ShouldBe(SecurityControlFamily.Approval);
+        evt.Policy.ShouldBe(SecurityPolicyDecision.Deny);
+        evt.Outcome.ShouldBe(SecurityEventOutcome.Denied);
+        evt.Severity.ShouldBe(SecurityEventSeverity.Medium);
+        evt.Actor.ShouldBe(actor);
+    }
+
+    [Fact]
+    public void ApprovalDecision_AllowDecisionMapsToSuccessOutcome()
+    {
+        var evt = SecurityEvent.ApprovalDecision(
+            action: "exec.approval.granted",
+            decision: SecurityPolicyDecision.Allow,
+            actor: null,
+            target: null);
+
+        evt.Policy.ShouldBe(SecurityPolicyDecision.Allow);
+        evt.Outcome.ShouldBe(SecurityEventOutcome.Success);
+    }
+
+    [Fact]
+    public void AuthOutcome_FactoryProducesAuthCategoryEvent()
+    {
+        var actor = new SecurityEventActor(SecurityActorKind.ChannelSender, "hash-x");
+
+        var fail = SecurityEvent.AuthOutcome(
+            action: "gateway.auth.failed",
+            success: false,
+            actor: actor,
+            severity: SecurityEventSeverity.High);
+
+        fail.Category.ShouldBe(SecurityEventCategory.Auth);
+        fail.Control.ShouldBe(SecurityControlFamily.Auth);
+        fail.Outcome.ShouldBe(SecurityEventOutcome.Failure);
+        fail.Severity.ShouldBe(SecurityEventSeverity.High);
+
+        var ok = SecurityEvent.AuthOutcome("gateway.auth.succeeded", success: true, actor: actor);
+        ok.Outcome.ShouldBe(SecurityEventOutcome.Success);
+        ok.Severity.ShouldBe(SecurityEventSeverity.Info);
+    }
+
+    [Fact]
+    public void Actor_HashedIdIsRetainedVerbatim()
+    {
+        // The model does not hash; callers pass already-opaque/hashed ids.
+        var actor = new SecurityEventActor(SecurityActorKind.Agent, "sha256:deadbeef");
+        actor.Kind.ShouldBe(SecurityActorKind.Agent);
+        actor.Id.ShouldBe("sha256:deadbeef");
+    }
+}


### PR DESCRIPTION
Closes #1532

Part of the security-event taxonomy epic (#1526). Step 1/5: the foundational, additive primitives only -- **no enforcement-point wiring** (Steps 2-5 add the emit sites). This gives the epic something concrete to build on and lets the taxonomy shape be reviewed before any boundary code changes.

## Changes

Three new primitives in `src/gateway/BotNexus.Gateway.Contracts/Security/` (namespace `BotNexus.Gateway.Abstractions.Security`, matching the existing convention in that folder alongside `IExecApprovalManager`, `IGatewayAuthHandler`, `ToolPolicy`):

- **`SecurityEvent`** -- a canonical typed record capturing who (`Actor`) did what (`Action`) to what (`Target`), under which control (`Control`), with what policy decision (`Policy`) and outcome (`Outcome`), at a chosen `Severity`, plus a UTC timestamp defaulted at construction. Enums: `SecurityEventCategory` (Auth/Authorization/Approval/Tool/Plugin/Secret/Channel/Config/Audit/Telemetry), `SecurityEventOutcome`, `SecurityEventSeverity`, `SecurityPolicyDecision`, `SecurityControlFamily`, `SecurityActorKind`, `SecurityTargetKind`. Two factory helpers (`ApprovalDecision`, `AuthOutcome`) keep the common call shapes terse and map the decision/success to the right outcome+severity defaults.
- **`ISecurityEventSink`** -- a trusted-only sink abstraction (`Record` / `Snapshot` / `Count` / `Clear`), documented as deliberately kept OFF the public activity/diagnostic stream.
- **`RingBufferSecurityEventSink`** -- a bounded, thread-safe circular-buffer implementation (default capacity 512). Recording never blocks: a full buffer evicts the oldest event. `Snapshot()` returns a copy, most-recent first.

`Actor.Id` and `Target.Reference` are documented as opaque/non-sensitive: callers hash/anonymise before construction; the model never stores a raw secret value.

## Tests (16 new, all green)

`tests/gateway/BotNexus.Gateway.Tests/Security/`:
- `SecurityEventTests` (8): timestamp defaulting to UtcNow, full-field retention, optional-field defaults (null actor/target, Policy.None, Control.None), `ApprovalDecision` deny->Denied + allow->Success, `AuthOutcome` fail->Failure/High + success->Success/Info, actor id retained verbatim.
- `RingBufferSecurityEventSinkTests` (8): record/snapshot round-trip, most-recent-first ordering, oldest-evicted-first past capacity, count never exceeds capacity under heavy load, clear empties, ctor rejects non-positive capacity, record rejects null, and a 16-writer x 500-event concurrency test asserting the buffer stays exactly full, internally consistent (no torn entries), and saturated with distinct valid events.

## Verification

- `dotnet build BotNexus.slnx --no-incremental -warnaserror` -> 0 warnings, 0 errors.
- `scripts/repo/test-impacted.ps1` -> all impacted projects green, including Architecture (198), Scenarios (29), Gateway.Tests (3129/1 skip, +16 new).

## Merge Notes

Pure addition of new files in `BotNexus.Gateway.Contracts/Security/` + a new test folder -- no overlap with any open PR. #1530 touches `Contracts/Concurrency/` (different folder), #1531 touches `GatewayHost.cs`, #1529 touches `.github/`. Safe to merge in any order relative to all three. The enforcement-point wiring (Steps 2-5 of #1526) depends on this landing first.
