### PR TITLE
fix(cli): align port-availability probe with the gateway wildcard bind

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/ServeCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ServeCommand.cs
@@ -409,14 +409,27 @@ internal sealed class ServeCommand
     }
 
     /// <summary>
-    /// Checks if a TCP port is available for binding.
-    /// Public to allow GatewayCommand to use it.
+    /// Checks if a TCP port is available for binding on the interface the gateway
+    /// will actually bind. The gateway binds a wildcard address by default
+    /// (<c>http://0.0.0.0:5005</c>, see <see cref="InitCommand"/>), so the probe
+    /// defaults to <see cref="System.Net.IPAddress.Any"/> rather than loopback.
+    /// Probing the wildcard address detects an occupant on <em>any</em> interface
+    /// (loopback included); a loopback-only probe missed wildcard/non-loopback
+    /// occupants and could report a confusing late Kestrel <c>EADDRINUSE</c>
+    /// (issue #1536). Public so <see cref="GatewayCommand"/> and
+    /// <see cref="UpdateCommand"/> can share one aligned probe.
     /// </summary>
-    public static bool IsPortAvailable(int port)
+    /// <param name="port">The TCP port to probe.</param>
+    /// <param name="bindAddress">
+    /// The interface the caller intends to bind. Defaults to
+    /// <see cref="System.Net.IPAddress.Any"/> (the gateway's wildcard bind) when
+    /// not specified, keeping the probe interface aligned with the bind interface.
+    /// </param>
+    public static bool IsPortAvailable(int port, System.Net.IPAddress? bindAddress = null)
     {
         try
         {
-            using var listener = new TcpListener(System.Net.IPAddress.Loopback, port);
+            using var listener = new TcpListener(bindAddress ?? System.Net.IPAddress.Any, port);
             listener.Server.ExclusiveAddressUse = true;
             listener.Start();
             listener.Stop();

--- a/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
@@ -1,6 +1,5 @@
 using System.CommandLine;
 using System.Diagnostics;
-using System.Net.Sockets;
 using System.Reflection;
 using System.Xml.Linq;
 using BotNexus.Cli.Services;
@@ -713,10 +712,6 @@ internal class UpdateCommand
     }
 
     /// <summary>
-    /// Checks if a TCP port is available for binding. Mirrors ServeCommand.IsPortAvailable.
-    /// Used to verify the port is free before starting the new gateway process.
-    /// </summary>
-    /// <summary>
     /// Waits until the given port is available (process released it) or timeout elapses.
     /// Polls every 250ms for up to 15 seconds.
     /// </summary>
@@ -732,21 +727,13 @@ internal class UpdateCommand
         // If still not free, proceed anyway — build may still succeed if it's a different process
     }
 
-    internal static bool IsPortAvailable(int port)
-    {
-        try
-        {
-            using var listener = new TcpListener(System.Net.IPAddress.Loopback, port);
-            listener.Server.ExclusiveAddressUse = true;
-            listener.Start();
-            listener.Stop();
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
-    }
+    /// <summary>
+    /// Checks if a TCP port is available for binding before starting the new
+    /// gateway process. Delegates to <see cref="ServeCommand.IsPortAvailable(int, System.Net.IPAddress?)"/>
+    /// so the probe interface stays aligned with the gateway's wildcard bind
+    /// (issue #1536) and all CLI call sites share one implementation.
+    /// </summary>
+    internal static bool IsPortAvailable(int port) => ServeCommand.IsPortAvailable(port);
 
     internal readonly record struct GitPullResult(int ExitCode, string? FailureDetail, bool WasCanceled);
     internal readonly record struct GitCommandResult(int ExitCode, string? FailureDetail, bool WasCanceled);

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/PortAvailabilityProbeTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/PortAvailabilityProbeTests.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using System.Net.Sockets;
+using BotNexus.Cli.Commands;
+using Shouldly;
+
+namespace BotNexus.Cli.Tests.Commands;
+
+/// <summary>
+/// Tests for the CLI port-availability probe (issue #1536).
+///
+/// The gateway binds a wildcard address by default (http://0.0.0.0:5005, see
+/// InitCommand.ListenUrl), so the availability probe must scope to the same
+/// interface it will actually bind. A loopback-only probe (127.0.0.1) mis-detects
+/// occupants that hold the port on the wildcard address or a non-loopback NIC,
+/// producing either a confusing late Kestrel EADDRINUSE or a false "in use".
+/// The probe therefore defaults to the wildcard address (IPAddress.Any) so it
+/// detects an occupant on any interface.
+/// </summary>
+public sealed class PortAvailabilityProbeTests
+{
+    /// <summary>
+    /// Reserve a free TCP port by binding to port 0, capture the assigned port,
+    /// then release it so the probe can be exercised against a known-free port.
+    /// </summary>
+    private static int ReserveFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    [Fact]
+    public void IsPortAvailable_ReturnsTrue_WhenPortIsFree()
+    {
+        var port = ReserveFreePort();
+
+        ServeCommand.IsPortAvailable(port).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsPortAvailable_ReturnsFalse_WhenPortHeldOnWildcardAddress()
+    {
+        var port = ReserveFreePort();
+        using var occupant = new TcpListener(IPAddress.Any, port);
+        occupant.Start();
+
+        try
+        {
+            ServeCommand.IsPortAvailable(port).ShouldBeFalse();
+        }
+        finally
+        {
+            occupant.Stop();
+        }
+    }
+
+    [Fact]
+    public void IsPortAvailable_ReturnsFalse_WhenPortHeldOnLoopbackAddress()
+    {
+        // Regression for #1536: an occupant on 127.0.0.1 must be detected by the
+        // default wildcard probe. A wildcard bind (IPAddress.Any) cannot succeed
+        // while any interface (including loopback) holds the port.
+        var port = ReserveFreePort();
+        using var occupant = new TcpListener(IPAddress.Loopback, port);
+        occupant.Server.ExclusiveAddressUse = true;
+        occupant.Start();
+
+        try
+        {
+            ServeCommand.IsPortAvailable(port).ShouldBeFalse();
+        }
+        finally
+        {
+            occupant.Stop();
+        }
+    }
+
+    [Fact]
+    public void IsPortAvailable_WithExplicitLoopback_ScopesProbeToThatInterface()
+    {
+        // A caller may scope the probe to a specific interface. Probing loopback
+        // while the port is held only on loopback must report "in use".
+        var port = ReserveFreePort();
+        using var occupant = new TcpListener(IPAddress.Loopback, port);
+        occupant.Server.ExclusiveAddressUse = true;
+        occupant.Start();
+
+        try
+        {
+            ServeCommand.IsPortAvailable(port, IPAddress.Loopback).ShouldBeFalse();
+        }
+        finally
+        {
+            occupant.Stop();
+        }
+    }
+
+    [Fact]
+    public void IsPortAvailable_WithExplicitBindAddress_ReturnsTrue_WhenPortIsFree()
+    {
+        var port = ReserveFreePort();
+
+        ServeCommand.IsPortAvailable(port, IPAddress.Any).ShouldBeTrue();
+        ServeCommand.IsPortAvailable(port, IPAddress.Loopback).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void UpdateCommand_IsPortAvailable_DelegatesToAlignedWildcardProbe()
+    {
+        // UpdateCommand previously carried a duplicate loopback-only probe.
+        // It must now share the same wildcard-aligned probe so all three call
+        // sites (ServeCommand, GatewayCommand, UpdateCommand) agree.
+        var port = ReserveFreePort();
+        using var occupant = new TcpListener(IPAddress.Any, port);
+        occupant.Start();
+
+        try
+        {
+            UpdateCommand.IsPortAvailable(port).ShouldBeFalse();
+        }
+        finally
+        {
+            occupant.Stop();
+        }
+    }
+
+    [Fact]
+    public void UpdateCommand_IsPortAvailable_ReturnsTrue_WhenPortIsFree()
+    {
+        var port = ReserveFreePort();
+
+        UpdateCommand.IsPortAvailable(port).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Closes #1536

## Problem

The CLI port-availability probe (`ServeCommand.IsPortAvailable`) bound a
listener on the **loopback** interface (`127.0.0.1`) while the gateway binds a
**wildcard** address by default (`http://0.0.0.0:5005`, see `InitCommand`).
Because the probe interface did not match the bind interface, the check could
mis-detect whether the port was actually free:

- a process holding the port on the wildcard address (or a non-loopback NIC)
  was missed -> the probe returned "available", then the real Kestrel bind
  failed later with a confusing `EADDRINUSE` instead of the intended early
  friendly "Port X is already in use" message; and
- `ExclusiveAddressUse = true` on a loopback probe could false-positive "in
  use" against a wildcard occupant.

`UpdateCommand` carried a duplicate copy of the same loopback-only probe
(comment: "Mirrors ServeCommand.IsPortAvailable"), and `GatewayCommand` reused
`ServeCommand.IsPortAvailable` -- so all three CLI call sites shared the same
mismatch.

This is the inverse of OpenClaw `4ec9d4a2b511` (probe interface != bind
interface).

## Changes

- `ServeCommand.IsPortAvailable(int port, IPAddress? bindAddress = null)` now
  defaults to probing `IPAddress.Any` (the gateway's wildcard bind) instead of
  loopback. A wildcard probe with `ExclusiveAddressUse = true` cannot bind while
  **any** interface (loopback included) holds the port, so it detects every
  occupant the previous loopback-only probe missed. Callers may still scope the
  probe to a specific interface via the optional `bindAddress` parameter.
- `UpdateCommand.IsPortAvailable` now delegates to
  `ServeCommand.IsPortAvailable(port)` instead of duplicating the probe, so the
  `ServeCommand`, `GatewayCommand`, and `UpdateCommand` call sites all share one
  aligned implementation. Removed the now-unused `System.Net.Sockets` using and
  a stray duplicated doc-comment in `UpdateCommand`.

## Tests

New `PortAvailabilityProbeTests` (7 tests, `BotNexus.Cli.Tests`):

- free port -> available (default and explicit-bind-address overloads);
- occupant on the wildcard address -> reported in use;
- occupant on the loopback address -> reported in use (regression for the
  missed-occupant case);
- explicit `IPAddress.Loopback` scopes the probe to that interface;
- `UpdateCommand.IsPortAvailable` reports in use for a wildcard occupant and
  available for a free port (delegation parity).

Tests reserve a free ephemeral port (bind to port 0, capture the assigned port,
release) so they are deterministic and do not collide with real services.

Full-solution `dotnet build BotNexus.slnx --no-incremental -warnaserror` is
clean (0/0). `test-impacted.ps1` green: Cli 305 (was 298 + 7 new), Gateway
3113/1 skip, Architecture 198, Scenarios 29.

## Merge Notes

Self-contained CLI-only change. Touches only
`src/gateway/BotNexus.Cli/Commands/ServeCommand.cs`,
`src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs`, and a new test file --
no overlap with any of the currently open PRs (#1529 `.github`/docs, #1530
SQLite stores, #1531 `GatewayHost.cs`, #1533 security model, #1534 docs).
Safe to merge in any order.
