### PR TITLE
fix(ci): unblock main restore on unpatchable SQLite advisory and repair security auto-issue

### DIFF
--- a/.github/workflows/security-secrets-deps.yml
+++ b/.github/workflows/security-secrets-deps.yml
@@ -242,18 +242,27 @@ jobs:
 
       - name: Create or update security issue
         uses: actions/github-script@v7
+        env:
+          # Pass dynamic values via env (read with process.env) instead of ${{ }} interpolation
+          # directly into the script. The summary body contains Markdown that can include
+          # backticks (e.g. `dotnet add package ...`), which would prematurely terminate a JS
+          # template literal and break the script (SyntaxError) — and is also a script-injection
+          # vector. process.env keeps the value as inert data.
+          SCAN_BODY: ${{ steps.summary.outputs.body }}
+          EXISTING_ISSUE_NUMBER: ${{ steps.find-issue.outputs.result }}
         with:
           script: |
-            const body = `${{ steps.summary.outputs.body }}`;
-            const title = `🔐 Daily Security Scan — Findings on ${new Date().toISOString().slice(0,10)}`;
-            const existingIssueNumber = ${{ steps.find-issue.outputs.result }};
+            const body = process.env.SCAN_BODY || '';
+            const title = `\u{1F510} Daily Security Scan \u2014 Findings on ${new Date().toISOString().slice(0,10)}`;
+            const existingRaw = process.env.EXISTING_ISSUE_NUMBER;
+            const existingIssueNumber = existingRaw && existingRaw !== 'null' ? Number(existingRaw) : null;
 
             if (existingIssueNumber) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: existingIssueNumber,
-                body: `### 🔄 Updated scan results\n\n${body}`
+                body: `### \u{1F504} Updated scan results\n\n${body}`
               });
               core.info(`Updated existing security issue #${existingIssueNumber}`);
             } else {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,20 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!--
+      Suppress GHSA-2m69-gcr7-jv3q on the transitive SQLitePCLRaw.lib.e_sqlite3 native package
+      (pulled in via Microsoft.Data.Sqlite). This advisory's affected range is `<= 2.1.11` with
+      NO firstPatchedVersion published yet (2.1.11 is the latest release and is still flagged),
+      so there is nowhere to bump to. NuGetAudit promotes it to NU1903 and TreatWarningsAsErrors
+      breaks `dotnet restore` on every SQLite-referencing project, turning main CI red.
+      This suppression is advisory-scoped (NOT a blanket NU1903 NoWarn) so any other/future
+      vulnerable package still fails the build. REMOVE this once a patched native lib ships
+      (track GHSA-2m69-gcr7-jv3q / a SQLitePCLRaw.lib.e_sqlite3 > 2.1.11 release). See #1538.
+    -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Test infrastructure -->
     <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />

--- a/tests/architecture/BotNexus.Architecture.Tests/SecurityWorkflowAndAuditSuppressionArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SecurityWorkflowAndAuditSuppressionArchitectureTests.cs
@@ -1,0 +1,190 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions guarding the two fixes in #1538 (main-branch CI red on the
+/// "Security: Secrets &amp; Dependencies" workflow).
+///
+/// <para><b>Part 1 - the unpatchable transitive advisory.</b> <c>Microsoft.Data.Sqlite</c> pulls in
+/// the native <c>SQLitePCLRaw.lib.e_sqlite3</c> package, which carries the HIGH-severity advisory
+/// <c>GHSA-2m69-gcr7-jv3q</c>. At the time of #1538 that advisory's affected range was <c>&lt;= 2.1.11</c>
+/// with <b>no published patched version</b> (2.1.11 was the latest release and was still flagged), so
+/// there was nowhere to bump to. .NET 10's <c>NuGetAudit</c> promotes the finding to <c>NU1903</c>, and
+/// with <c>TreatWarningsAsErrors=true</c> this fails <c>dotnet restore</c> on every SQLite-referencing
+/// project, turning <c>main</c> CI red. The fix is an <b>advisory-scoped</b>
+/// <c>&lt;NuGetAuditSuppress&gt;</c> entry in <c>Directory.Packages.props</c> - NOT a blanket
+/// <c>NoWarn NU1903</c>, so any other/future vulnerable package still breaks the build, and the
+/// finding stays visible to <c>dotnet list package --vulnerable</c>. This fence pins the suppression
+/// so the main-CI-red regression cannot silently reappear, and asserts it is advisory-scoped.
+///
+/// <para><b>Part 2 - the broken auto-issue github-script.</b> The workflow's own failure reporter
+/// (a <c>github-script</c> step) built its issue body by interpolating
+/// <c>const body = `${{ steps.summary.outputs.body }}`;</c> directly into a JavaScript template
+/// literal. The summary body contains Markdown including an inline-code backtick
+/// (<c>`dotnet add package ...`</c>), which prematurely terminates the template literal and breaks the
+/// script with <c>SyntaxError: Unexpected identifier 'dotnet'</c> - so every security-scan failure was
+/// silently un-reported. It is also a script-injection vector. The fix passes the value via an
+/// environment variable read with <c>process.env</c>. This fence forbids reintroducing the
+/// <c>${{ ... }}</c>-into-a-JS-template-literal antipattern for the summary body.
+///
+/// Both checks are text fitness functions over the committed repo files (zero runtime dependency),
+/// matching the existing repo-config fences (e.g. <see cref="SqliteBusyTimeoutArchitectureTests"/>,
+/// DockerHealthcheckArchitectureTests).
+/// </summary>
+public sealed class SecurityWorkflowAndAuditSuppressionArchitectureTests
+{
+    private static string RepoRoot => FindRepoRoot();
+
+    private const string AdvisoryId = "GHSA-2m69-gcr7-jv3q";
+    private const string AdvisoryUrl = "https://github.com/advisories/" + AdvisoryId;
+
+    private static readonly string PackagesPropsPath =
+        Path.Combine(RepoRoot, "Directory.Packages.props");
+
+    private static readonly string SecurityWorkflowPath = Path.Combine(
+        RepoRoot, ".github", "workflows", "security-secrets-deps.yml");
+
+    // Matches a NuGetAuditSuppress item for the specific advisory (URL or bare GHSA id).
+    private static readonly Regex AdvisorySuppress = new(
+        @"<NuGetAuditSuppress\b[^>]*Include\s*=\s*""[^""]*GHSA-2m69-gcr7-jv3q[^""]*""",
+        RegexOptions.IgnoreCase);
+
+    // The antipattern: const body = `${{ steps.summary.outputs.body }}`; (interpolating the body
+    // into a JS template literal). Allow arbitrary whitespace around tokens.
+    private static readonly Regex BodyTemplateLiteralInterpolation = new(
+        @"const\s+body\s*=\s*`\$\{\{\s*steps\.summary\.outputs\.body\s*\}\}`",
+        RegexOptions.IgnoreCase);
+
+    [Fact]
+    public void GuardedFiles_Exist()
+    {
+        File.Exists(PackagesPropsPath).ShouldBeTrue(
+            $"Expected central package management file not found: {PackagesPropsPath}");
+        File.Exists(SecurityWorkflowPath).ShouldBeTrue(
+            $"Expected security workflow not found: {SecurityWorkflowPath}");
+    }
+
+    [Fact]
+    public void PackagesProps_SuppressesTheUnpatchableSqliteAdvisory()
+    {
+        var props = File.ReadAllText(PackagesPropsPath);
+
+        AdvisorySuppress.IsMatch(props).ShouldBeTrue(
+            $"Directory.Packages.props must contain a <NuGetAuditSuppress Include=\"...{AdvisoryId}...\" /> " +
+            "entry. Without it, NuGetAudit promotes the unpatchable SQLitePCLRaw.lib.e_sqlite3 advisory " +
+            "to NU1903 and TreatWarningsAsErrors fails `dotnet restore` on every SQLite project, turning " +
+            "main CI red. Remove this suppression only once a patched native lib (> 2.1.11) ships. See #1538.");
+
+        // It must reference the advisory by its stable URL, not a fragile package+version pin.
+        props.ShouldContain(AdvisoryUrl,
+            customMessage: "The audit suppression should reference the advisory by its canonical URL " +
+            $"({AdvisoryUrl}) so it survives version bumps and is greppable. See #1538.");
+    }
+
+    [Fact]
+    public void PackagesProps_DoesNotBlanketSuppressNu1903()
+    {
+        var props = File.ReadAllText(PackagesPropsPath);
+
+        // A blanket NoWarn/NoWarning of NU1903 would hide ALL high-severity vuln findings, defeating
+        // the audit. The fix must be advisory-scoped only.
+        Regex.IsMatch(props, @"<(NoWarn|WarningsNotAsErrors|MSBuildWarningsAsMessages)>[^<]*NU1903",
+            RegexOptions.IgnoreCase).ShouldBeFalse(
+            "Directory.Packages.props must NOT blanket-suppress NU1903 (that would hide every future " +
+            "high-severity vulnerable package). Suppress only the specific advisory via " +
+            "<NuGetAuditSuppress>. See #1538.");
+    }
+
+    [Fact]
+    public void SecurityWorkflow_DoesNotInterpolateBodyIntoJsTemplateLiteral()
+    {
+        var workflow = File.ReadAllText(SecurityWorkflowPath);
+
+        BodyTemplateLiteralInterpolation.IsMatch(workflow).ShouldBeFalse(
+            "security-secrets-deps.yml must NOT build the issue body as " +
+            "`const body = `${{ steps.summary.outputs.body }}`;`. The summary body contains Markdown " +
+            "with inline-code backticks (e.g. `dotnet add package ...`) that prematurely terminate the " +
+            "JS template literal, breaking the github-script step with " +
+            "'SyntaxError: Unexpected identifier' so failures go silently unreported. Pass the value via " +
+            "an env var and read it with process.env instead. See #1538.");
+    }
+
+    [Fact]
+    public void SecurityWorkflow_ReadsSummaryBodyFromProcessEnv()
+    {
+        var workflow = File.ReadAllText(SecurityWorkflowPath);
+
+        // Positive pin: the fixed shape reads the body from process.env (inert data, no template-literal
+        // break and no script injection).
+        workflow.ShouldContain("process.env.SCAN_BODY",
+            customMessage: "The 'Create or update security issue' github-script step should read the " +
+            "summary body from process.env.SCAN_BODY (set in the step's env: block) rather than " +
+            "interpolating ${{ steps.summary.outputs.body }} into the script. See #1538.");
+
+        Regex.IsMatch(workflow, @"SCAN_BODY:\s*\$\{\{\s*steps\.summary\.outputs\.body\s*\}\}").ShouldBeTrue(
+            "The github-script step must pass steps.summary.outputs.body into an env var named SCAN_BODY " +
+            "(SCAN_BODY: ${{ steps.summary.outputs.body }}). See #1538.");
+    }
+
+    [Fact]
+    public void AdvisorySuppressDetector_IsNotVacuous()
+    {
+        // Vacuity guard: the detector must NOT match a file that lacks the advisory suppression, and
+        // must match one that has it. If either fails the fence passes/locks vacuously.
+        const string withoutSuppress = """
+            <Project>
+              <ItemGroup>
+                <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.0-preview.3.25171.6" />
+              </ItemGroup>
+            </Project>
+            """;
+        const string withSuppress = """
+            <Project>
+              <ItemGroup>
+                <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        AdvisorySuppress.IsMatch(withoutSuppress).ShouldBeFalse(
+            "Vacuity guard: detector must report the advisory suppression is ABSENT when it is missing.");
+        AdvisorySuppress.IsMatch(withSuppress).ShouldBeTrue(
+            "Vacuity guard: detector must recognise the advisory suppression when it is present.");
+    }
+
+    [Fact]
+    public void TemplateLiteralAntipatternDetector_IsNotVacuous()
+    {
+        // Vacuity guard for the github-script fence: the detector must flag the broken shape and accept
+        // the fixed (process.env) shape.
+        const string brokenShape = """
+            script: |
+              const body = `${{ steps.summary.outputs.body }}`;
+            """;
+        const string fixedShape = """
+            env:
+              SCAN_BODY: ${{ steps.summary.outputs.body }}
+            script: |
+              const body = process.env.SCAN_BODY || '';
+            """;
+
+        BodyTemplateLiteralInterpolation.IsMatch(brokenShape).ShouldBeTrue(
+            "Vacuity guard: detector must flag the broken template-literal interpolation shape.");
+        BodyTemplateLiteralInterpolation.IsMatch(fixedShape).ShouldBeFalse(
+            "Vacuity guard: detector must accept the fixed process.env shape.");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        current.ShouldNotBeNull("Could not locate repo root (BotNexus.slnx) from " + AppContext.BaseDirectory);
+        return current!.FullName;
+    }
+}


### PR DESCRIPTION
Closes #1538

## Summary
The **Security: Secrets & Dependencies** workflow went red on `main` (run 27812803233, 2026-06-19 07:48 UTC). Two independent defects, both fixed here. Note: the same commit `3e1236ab` passed this workflow the day before, so this is a newly-published advisory, not a code regression.

## 1. Unblock `dotnet restore` on an unpatchable transitive advisory
`Microsoft.Data.Sqlite` pulls in the native `SQLitePCLRaw.lib.e_sqlite3` package, which carries HIGH-severity advisory **GHSA-2m69-gcr7-jv3q**. .NET 10 `NuGetAudit` promotes it to `NU1903` and, with `TreatWarningsAsErrors=true`, fails `dotnet restore` on ~30 SQLite-referencing projects.

**Why not just bump the package:** the advisory's affected range is `<= 2.1.11` with **no `firstPatchedVersion` published** (2.1.11 is the latest release and is still flagged) -- there is nowhere to bump to. I verified this against the advisory itself (GitHub Security Advisory API). I tried pinning the SQLitePCLRaw stack to 2.1.11 with transitive pinning; restore still flagged 2.1.11, and global transitive pinning introduced unrelated `NU1109` downgrade errors. So a version bump cannot fix this.

**Fix:** an advisory-scoped `<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />` in `Directory.Packages.props`. This is NOT a blanket `NoWarn NU1903` -- any other/future vulnerable package still breaks the build. The finding stays visible to `dotnet list package --vulnerable` (the workflow's report step still surfaces it); only the build break is suppressed. A tracking comment says to remove it once a patched native lib (> 2.1.11) ships.

Verified: `dotnet restore BotNexus.slnx --force` -> 0 NU1903, 0 NU1109, exit 0. Full `dotnet build BotNexus.slnx --no-incremental -warnaserror` -> 0/0.

## 2. Repair the broken security auto-issue github-script
The workflow's own failure reporter built its body with `const body = `${{ steps.summary.outputs.body }}`;` -- interpolating the summary into a JS template literal. The summary contains Markdown with an inline-code backtick (`` `dotnet add package ...` ``), which prematurely terminates the template literal and breaks the script with `SyntaxError: Unexpected identifier 'dotnet'`. Result: every security-scan failure was silently un-reported. It is also a script-injection vector.

**Fix:** pass the body and existing-issue number via the step's `env:` block and read them with `process.env` (the GitHub-recommended pattern). The value is now inert data -- no template-literal break, no injection. Verified the script is syntactically valid and runs cleanly against a backtick-containing body via `node --check` + a standalone harness run.

## Tests
New `SecurityWorkflowAndAuditSuppressionArchitectureTests` (7 tests, all passing) -- text fitness functions over the committed repo files, matching the existing `SqliteBusyTimeoutArchitectureTests`/`DockerHealthcheckArchitectureTests` pattern:
- the advisory suppression is present and advisory-scoped (and NOT a blanket NU1903 suppression)
- the github-script step does not interpolate the body into a JS template literal, and reads from `process.env.SCAN_BODY`
- non-vacuity guards for both detectors (they flag the broken shape, accept the fixed shape)

`test-impacted.ps1` GREEN: Architecture.Tests 205 (198 + 7 new), Scenarios.Tests 29.

## Merge Notes
Touches only `Directory.Packages.props`, `.github/workflows/security-secrets-deps.yml`, and a new test file -- disjoint from all open PRs (#1529, #1530, #1531, #1533, #1534, #1537; none touch `Directory.Packages.props` or this workflow). Safe to merge in any order. This is a CI-unblocking fix for `main` and should merge promptly.
