### PR TITLE
fix(gateway): build session summaries without loading transcripts

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionStore.cs
@@ -58,6 +58,36 @@ public interface ISessionStore
     Task<IReadOnlyList<GatewaySession>> ListAsync(AgentId? agentId = null, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns lightweight <see cref="SessionSummary"/> records for sessions whose
+    /// <c>UpdatedAt</c> is at or after <paramref name="updatedAfter"/>, <b>without loading
+    /// conversation transcripts</b>.
+    /// </summary>
+    /// <remarks>
+    /// This is the read path the WebUI session list and <c>SessionWarmupService</c> use.
+    /// Loading full session history just to render a metadata list does not scale — on a
+    /// large database it dominates the request and can exceed the SignalR hub cancellation
+    /// window. Transcript content is only needed when a user actually opens a conversation.
+    /// <para>
+    /// The default implementation maps from <see cref="ListAsync"/>, which still materialises
+    /// history; it exists so non-SQLite stores (File, InMemory, test doubles) keep working.
+    /// The SQLite store overrides this with a metadata-only query that derives
+    /// <c>MessageCount</c> from a <c>COUNT(*)</c> aggregate rather than reading entries.
+    /// </para>
+    /// </remarks>
+    /// <param name="updatedAfter">Lower bound (inclusive) on session <c>UpdatedAt</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    async Task<IReadOnlyList<SessionSummary>> ListSummariesAsync(
+        DateTimeOffset updatedAfter,
+        CancellationToken cancellationToken = default)
+    {
+        var sessions = await ListAsync(null, cancellationToken).ConfigureAwait(false);
+        return sessions
+            .Where(session => session.UpdatedAt >= updatedAfter)
+            .Select(SessionSummary.FromSession)
+            .ToList();
+    }
+
+    /// <summary>
     /// Lists sessions for a specific agent filtered by channel type,
     /// ordered by created time descending (newest first).
     /// </summary>

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/SessionSummary.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/SessionSummary.cs
@@ -17,4 +17,24 @@ public sealed record SessionSummary(
     int MessageCount,
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt,
-    string? ConversationId = null);
+    string? ConversationId = null)
+{
+    /// <summary>
+    /// Projects a fully materialised <see cref="GatewaySession"/> down to a lightweight
+    /// summary. Used by session stores that have no transcript-free read path (File,
+    /// InMemory, test doubles) so they can satisfy
+    /// <see cref="ISessionStore.ListSummariesAsync"/> from the same data they already load.
+    /// The SQLite store builds summaries directly from a metadata-only query instead.
+    /// </summary>
+    public static SessionSummary FromSession(GatewaySession session) => new(
+        session.SessionId.Value,
+        session.AgentId.Value,
+        session.ChannelType,
+        session.Status,
+        session.SessionType,
+        session.IsInteractive,
+        session.MessageCount,
+        session.CreatedAt,
+        session.UpdatedAt,
+        session.ConversationId.IsInitialized() ? session.ConversationId.Value : null);
+}

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
@@ -39,6 +39,23 @@ public abstract class SessionStoreBase : ISessionStore
         return ApplyAgentFilter(sessions, agentId).ToList();
     }
 
+    /// <summary>
+    /// Default summary path for stores without a transcript-free read: enumerate sessions
+    /// (still materialising history) and project to <see cref="SessionSummary"/>. Suitable
+    /// for File/InMemory stores used in development and tests. <see cref="SqliteSessionStore"/>
+    /// overrides this with a metadata-only query so production never loads the whole DB.
+    /// </summary>
+    public virtual async Task<IReadOnlyList<SessionSummary>> ListSummariesAsync(
+        DateTimeOffset updatedAfter,
+        CancellationToken cancellationToken = default)
+    {
+        var sessions = await EnumerateSessionsAsync(cancellationToken).ConfigureAwait(false);
+        return sessions
+            .Where(session => session.UpdatedAt >= updatedAfter)
+            .Select(SessionSummary.FromSession)
+            .ToList();
+    }
+
     public async Task<IReadOnlyList<GatewaySession>> ListAsync(
         AgentId? agentId,
         BotNexus.Gateway.Abstractions.Models.SessionStatus? status,

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -248,6 +248,97 @@ public sealed class SqliteSessionStore : SessionStoreBase
         }, cancellationToken: cancellationToken);
 
     /// <summary>
+    /// Transcript-free summary read: a single metadata query over <c>sessions</c> with a
+    /// <c>COUNT(*)</c> aggregate from <c>session_history</c> for <c>MessageCount</c>. Session
+    /// <c>content</c> is never read, so this stays cheap regardless of how large the history
+    /// table grows. Replaces the previous warmup path that loaded every session's full
+    /// transcript just to build a metadata list (issue #1581).
+    /// </summary>
+    /// <remarks>
+    /// The <paramref name="updatedAfter"/> bound is applied on parsed values rather than in
+    /// SQL: timestamps are persisted via <c>DateTimeOffset.ToString("O")</c>, which preserves
+    /// the original UTC offset, so a lexicographic <c>updated_at &gt;= ?</c> comparison would be
+    /// wrong across rows written at different offsets. AgentId is resolved from
+    /// <c>Conversation.AgentId</c> (P9-I) and cached per conversation; rows whose conversation
+    /// no longer resolves to an agent are skipped — they cannot belong to an agent's visible
+    /// list.
+    /// </remarks>
+    public override async Task<IReadOnlyList<SessionSummary>> ListSummariesAsync(
+        DateTimeOffset updatedAfter,
+        CancellationToken cancellationToken = default)
+        => await RetryOnTransientAsync(async () =>
+        {
+            await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                SELECT s.id, s.channel_type, s.session_type, s.status,
+                       s.created_at, s.updated_at, s.conversation_id,
+                       COALESCE(h.cnt, 0) AS message_count
+                FROM sessions s
+                LEFT JOIN (
+                    SELECT session_id, COUNT(*) AS cnt
+                    FROM session_history
+                    GROUP BY session_id
+                ) h ON h.session_id = s.id
+                """;
+
+            // Read raw rows first; resolving the agent per row touches the conversation
+            // store and must not happen while the data reader holds the connection.
+            var rows = new List<(string Id, ChannelKey? Channel, SessionType Type, SessionStatus Status,
+                DateTimeOffset Created, DateTimeOffset Updated, string? ConversationId, int Count)>();
+
+            await using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    var updated = ParseTimestamp(reader.GetString(5));
+                    if (updated < updatedAfter)
+                        continue;
+
+                    var id = reader.GetString(0);
+                    ChannelKey? channel = reader.IsDBNull(1) ? (ChannelKey?)null : ChannelKey.From(reader.GetString(1));
+                    var type = ParseSessionType(reader.IsDBNull(2) ? null : reader.GetString(2), SessionId.From(id), channel);
+                    var status = ParseStatus(reader.IsDBNull(3) ? null : reader.GetString(3));
+                    var created = ParseTimestamp(reader.GetString(4));
+                    var conversationId = reader.IsDBNull(6) ? null : reader.GetString(6);
+                    var count = reader.IsDBNull(7) ? 0 : (int)reader.GetInt64(7);
+                    rows.Add((id, channel, type, status, created, updated, conversationId, count));
+                }
+            }
+
+            var summaries = new List<SessionSummary>(rows.Count);
+            foreach (var row in rows)
+            {
+                var agentId = await ResolveAgentForConversationAsync(row.ConversationId, cancellationToken).ConfigureAwait(false);
+                if (string.IsNullOrEmpty(agentId))
+                    continue;
+
+                // Mirror Session.IsInteractive: a user-facing session is UserAgent-typed and
+                // not delivered over the internal "cron" channel.
+                var isInteractive = row.Type.Equals(SessionType.UserAgent)
+                    && (!row.Channel.HasValue
+                        || !string.Equals(row.Channel.Value.Value, "cron", StringComparison.OrdinalIgnoreCase));
+
+                summaries.Add(new SessionSummary(
+                    row.Id,
+                    agentId,
+                    row.Channel,
+                    row.Status,
+                    row.Type,
+                    isInteractive,
+                    row.Count,
+                    row.Created,
+                    row.Updated,
+                    row.ConversationId));
+            }
+
+            return (IReadOnlyList<SessionSummary>)summaries;
+        }, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
     /// Returns sessions for a single conversation, using the
     /// <c>idx_sessions_conversation_created</c> index to avoid loading the
     /// full session table. Honours the same chronological-ascending /

--- a/src/gateway/BotNexus.Gateway/Sessions/SessionWarmupService.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/SessionWarmupService.cs
@@ -123,10 +123,22 @@ public sealed class SessionWarmupService : ISessionWarmupService, IHostedService
                     _cache.TryRemove(existingAgentId, out _);
             }
 
+            // One transcript-free query for every agent, then bucket in memory. The store
+            // never materialises session history here (issue #1581).
+            var summaries = await _sessionStore.ListSummariesAsync(ComputeUpdatedAfter(options), ct);
+            var byAgent = summaries
+                .GroupBy(static summary => summary.AgentId, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    static group => group.Key,
+                    static group => (IReadOnlyList<SessionSummary>)group.ToArray(),
+                    StringComparer.OrdinalIgnoreCase);
+
             foreach (var agentId in agentIds)
             {
-                var summaries = await BuildSummariesForAgentAsync(agentId, options, ct);
-                _cache[agentId] = summaries;
+                var agentSummaries = byAgent.TryGetValue(agentId, out var list)
+                    ? list
+                    : Array.Empty<SessionSummary>();
+                _cache[agentId] = BuildVisibleSummaries(agentSummaries, options);
             }
         }
         finally
@@ -140,8 +152,12 @@ public sealed class SessionWarmupService : ISessionWarmupService, IHostedService
         await _refreshGate.WaitAsync(ct);
         try
         {
-            var summaries = await BuildSummariesForAgentAsync(agentId, _options.Value, ct);
-            _cache[agentId] = summaries;
+            var options = _options.Value;
+            var summaries = await _sessionStore.ListSummariesAsync(ComputeUpdatedAfter(options), ct);
+            var agentSummaries = summaries
+                .Where(summary => string.Equals(summary.AgentId, agentId, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            _cache[agentId] = BuildVisibleSummaries(agentSummaries, options);
         }
         finally
         {
@@ -149,62 +165,48 @@ public sealed class SessionWarmupService : ISessionWarmupService, IHostedService
         }
     }
 
-    private async Task<List<SessionSummary>> BuildSummariesForAgentAsync(string agentId, SessionWarmupOptions options, CancellationToken ct)
+    private static DateTimeOffset ComputeUpdatedAfter(SessionWarmupOptions options)
+        => DateTimeOffset.UtcNow.AddHours(-Math.Max(0, options.RetentionWindowHours));
+
+    private static List<SessionSummary> BuildVisibleSummaries(
+        IEnumerable<SessionSummary> summaries,
+        SessionWarmupOptions options)
     {
-        var retentionHours = Math.Max(0, options.RetentionWindowHours);
-        var updatedAfter = DateTimeOffset.UtcNow.AddHours(-retentionHours);
         var maxSessions = Math.Max(0, options.MaxSessionsPerAgent);
-
-        var sessions = await _sessionStore.ListAsync(AgentId.From(agentId), ct);
-        var summaries = GetVisibleSessionsAsync(sessions, updatedAfter, options.CollapseChannelContinuations)
-            .OrderByDescending(static session => session.UpdatedAt)
+        return GetVisibleSummaries(summaries, options.CollapseChannelContinuations)
+            .OrderByDescending(static summary => summary.UpdatedAt)
             .Take(maxSessions)
-            .Select(static session => new SessionSummary(
-                session.SessionId.Value,
-                session.AgentId.Value,
-                session.ChannelType,
-                session.Status,
-                session.SessionType,
-                session.IsInteractive,
-                session.MessageCount,
-                session.CreatedAt,
-                session.UpdatedAt,
-                session.ConversationId.IsInitialized() ? session.ConversationId.Value : null))
             .ToList();
-
-        _logger.LogDebug("Session warmup cache refreshed for agent {AgentId}: {Count} sessions", agentId, summaries.Count);
-        return summaries;
     }
 
-    private static IEnumerable<GatewaySession> GetVisibleSessionsAsync(
-        IEnumerable<GatewaySession> sessions,
-        DateTimeOffset updatedAfter,
+    private static IEnumerable<SessionSummary> GetVisibleSummaries(
+        IEnumerable<SessionSummary> summaries,
         bool collapseChannelContinuations)
     {
         // Only surface user-agent sessions; hide internal types (Soul, Cron, AgentSubAgent, etc.)
-        // and sessions delivered via the "cron" channel even if typed as UserAgent.
-        var visibleCandidates = sessions
-            .Where(session =>
-                session.UpdatedAt >= updatedAfter
-                && session.SessionType.Equals(SessionType.UserAgent)
-                && (!session.ChannelType.HasValue
-                    || !string.Equals(session.ChannelType.Value.Value, "cron", StringComparison.OrdinalIgnoreCase)))
+        // and sessions delivered via the "cron" channel even if typed as UserAgent. The retention
+        // window has already been applied by the store's ListSummariesAsync.
+        var visibleCandidates = summaries
+            .Where(summary =>
+                summary.SessionType.Equals(SessionType.UserAgent)
+                && (!summary.ChannelType.HasValue
+                    || !string.Equals(summary.ChannelType.Value.Value, "cron", StringComparison.OrdinalIgnoreCase)))
             .ToArray();
 
         if (!collapseChannelContinuations)
             return visibleCandidates;
 
         var visible = visibleCandidates
-            .Where(static session => !session.ChannelType.HasValue)
+            .Where(static summary => !summary.ChannelType.HasValue)
             .ToList();
 
         foreach (var channelSessions in visibleCandidates
-                     .Where(static session => session.ChannelType.HasValue)
-                     .GroupBy(static session => session.ChannelType!.Value))
+                     .Where(static summary => summary.ChannelType.HasValue)
+                     .GroupBy(static summary => summary.ChannelType!.Value))
         {
             var mostRecentActiveOrSuspended = channelSessions
-                .Where(session => session.Status == GatewaySessionStatus.Active || session.Status == GatewaySessionStatus.Suspended)
-                .OrderByDescending(static session => session.UpdatedAt)
+                .Where(summary => summary.Status == GatewaySessionStatus.Active || summary.Status == GatewaySessionStatus.Suspended)
+                .OrderByDescending(static summary => summary.UpdatedAt)
                 .FirstOrDefault();
 
             if (mostRecentActiveOrSuspended is not null)
@@ -214,8 +216,8 @@ public sealed class SessionWarmupService : ISessionWarmupService, IHostedService
             }
 
             var mostRecentSealed = channelSessions
-                .Where(session => session.Status == GatewaySessionStatus.Sealed)
-                .OrderByDescending(static session => session.UpdatedAt)
+                .Where(summary => summary.Status == GatewaySessionStatus.Sealed)
+                .OrderByDescending(static summary => summary.UpdatedAt)
                 .FirstOrDefault();
 
             if (mostRecentSealed is not null)

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionWarmupServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionWarmupServiceTests.cs
@@ -23,7 +23,8 @@ public sealed class SessionWarmupServiceTests
         await service.StartAsync(CancellationToken.None);
         var sessions = await service.GetAvailableSessionsAsync(CancellationToken.None);
 
-        store.Verify(value => value.ListAsync(BotNexus.Domain.Primitives.AgentId.From("agent-a"), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        store.Verify(value => value.ListSummariesAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        store.Verify(value => value.ListAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId?>(), It.IsAny<CancellationToken>()), Times.Never);
         sessions.Where(summary => summary.SessionId == "startup-1").ShouldHaveSingleItem();
     }
 
@@ -238,6 +239,7 @@ public sealed class SessionWarmupServiceTests
         var available = await service.GetAvailableSessionsAsync(CancellationToken.None);
 
         available.ShouldBeEmpty();
+        store.Verify(value => value.ListSummariesAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.Never);
         store.Verify(value => value.ListAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -257,6 +259,14 @@ public sealed class SessionWarmupServiceTests
         store.Setup(value => value.ListAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((BotNexus.Domain.Primitives.AgentId? agentId, CancellationToken _) =>
                 sessions.Where(session => !agentId.HasValue || session.AgentId == agentId.Value).ToList());
+        // Warmup now reads through the transcript-free summary path. Mirror the real default
+        // implementation (map + retention-window filter) so the mock stays faithful.
+        store.Setup(value => value.ListSummariesAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTimeOffset updatedAfter, CancellationToken _) =>
+                (IReadOnlyList<SessionSummary>)sessions
+                    .Where(session => session.UpdatedAt >= updatedAfter)
+                    .Select(SessionSummary.FromSession)
+                    .ToList());
         return store;
     }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SqliteSessionStoreListSummariesTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SqliteSessionStoreListSummariesTests.cs
@@ -1,0 +1,135 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Tests.Sessions;
+
+/// <summary>
+/// Regression tests for <see cref="SqliteSessionStore.ListSummariesAsync"/> (#1581).
+/// The summary path must derive <c>MessageCount</c> from a COUNT aggregate without
+/// loading transcript content, honour the <c>updatedAfter</c> window on parsed values,
+/// and resolve the agent from the conversation.
+/// </summary>
+public sealed class SqliteSessionStoreListSummariesTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly string _connectionString;
+    private readonly InMemoryConversationStore _conversations = new();
+
+    public SqliteSessionStoreListSummariesTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"botnexus-tests-{Guid.NewGuid():N}.db");
+        _connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = _dbPath,
+            Pooling = false
+        }.ToString();
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        try
+        {
+            if (File.Exists(_dbPath))
+                File.Delete(_dbPath);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; SQLite file locks can linger briefly on Windows.
+        }
+    }
+
+    private SqliteSessionStore CreateStore()
+        => new(_connectionString, NullLogger<SqliteSessionStore>.Instance, _conversations);
+
+    private async Task SeedSessionAsync(
+        string sessionId,
+        string agentId,
+        SessionStatus status,
+        DateTimeOffset updatedAt,
+        int historyEntries,
+        ChannelKey? channelType = null)
+    {
+        var conversationId = ConversationId.Create();
+        await _conversations.CreateAsync(new Conversation
+        {
+            ConversationId = conversationId,
+            AgentId = AgentId.From(agentId)
+        });
+
+        var store = CreateStore();
+        var session = await store.GetOrCreateAsync(SessionId.From(sessionId), AgentId.From(agentId));
+        session.Session.ConversationId = conversationId;
+        session.ChannelType = channelType;
+        session.Status = status;
+        session.AddEntries(Enumerable.Range(0, historyEntries)
+            .Select(i => new SessionEntry
+            {
+                Role = MessageRole.FromString(i % 2 == 0 ? "user" : "assistant"),
+                Content = $"entry-{i}",
+                Timestamp = updatedAt
+            }));
+        // Set UpdatedAt last: AddEntries bumps it to "now".
+        session.UpdatedAt = updatedAt;
+        await store.SaveAsync(session);
+    }
+
+    [Fact]
+    public async Task ListSummariesAsync_DerivesMessageCount_WithoutLoadingTranscript()
+    {
+        var now = DateTimeOffset.UtcNow;
+        await SeedSessionAsync("sum-recent", "agent-a", SessionStatus.Active, now.AddHours(-1), historyEntries: 4);
+
+        var store = CreateStore();
+        var summaries = await store.ListSummariesAsync(now.AddHours(-24));
+
+        var summary = summaries.ShouldHaveSingleItem();
+        summary.SessionId.ShouldBe("sum-recent");
+        summary.AgentId.ShouldBe("agent-a");
+        summary.MessageCount.ShouldBe(4);
+        summary.Status.ShouldBe(SessionStatus.Active);
+        summary.SessionType.ShouldBe(SessionType.UserAgent);
+        summary.IsInteractive.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ListSummariesAsync_ExcludesSessionsOutsideRetentionWindow()
+    {
+        var now = DateTimeOffset.UtcNow;
+        await SeedSessionAsync("sum-recent", "agent-a", SessionStatus.Active, now.AddHours(-2), historyEntries: 1);
+        await SeedSessionAsync("sum-old", "agent-a", SessionStatus.Active, now.AddHours(-48), historyEntries: 1);
+
+        var store = CreateStore();
+        var ids = (await store.ListSummariesAsync(now.AddHours(-24)))
+            .Select(summary => summary.SessionId)
+            .ToList();
+
+        ids.ShouldContain("sum-recent");
+        ids.ShouldNotContain("sum-old");
+    }
+
+    [Fact]
+    public async Task ListSummariesAsync_ResolvesAgentAndChannelFromMetadata()
+    {
+        var now = DateTimeOffset.UtcNow;
+        await SeedSessionAsync("sum-a", "agent-a", SessionStatus.Active, now.AddHours(-1), historyEntries: 2);
+        await SeedSessionAsync("sum-b", "agent-b", SessionStatus.Sealed, now.AddHours(-1), historyEntries: 3,
+            channelType: ChannelKey.From("telegram"));
+
+        var store = CreateStore();
+        var summaries = await store.ListSummariesAsync(now.AddHours(-24));
+
+        summaries.ShouldContain(s => s.SessionId == "sum-a");
+        var b = summaries.Single(s => s.SessionId == "sum-b");
+        b.AgentId.ShouldBe("agent-b");
+        b.ChannelType!.Value.Value.ShouldBe("telegram");
+        b.Status.ShouldBe(SessionStatus.Sealed);
+        b.MessageCount.ShouldBe(3);
+    }
+}


### PR DESCRIPTION
## Problem
`GatewayHub.SubscribeAll` triggers `SessionWarmupService` to warm its summary cache. The old path called `ISessionStore.ListAsync`, which loads **every session with its full `session_history` transcript** and only then filters to a 24h / 10-per-agent window. On a large (~164 MB) session DB this exceeds the hub's cancellation window, throwing `TaskCanceledException` and leaving the WebUI stuck on *connecting / timing out*.

## Fix
- Add `ISessionStore.ListSummariesAsync(updatedAfter, ct)` returning lightweight `SessionSummary` records (default impl maps via `ListAsync` for File/InMemory stores).
- `SqliteSessionStore` overrides it with a single metadata query (`sessions` + `COUNT(*)` over `session_history` via the existing index) — **no transcript content is read**.
- `SessionWarmupService` now builds its cache from summaries with one query, grouping by agent in memory. Transcript content is only loaded when a conversation is actually selected in the SignalR UI.
- `updatedAfter` is filtered in C# because timestamps are stored with `ToString(""O"")` (original offset, not normalized to UTC), so a SQL string compare would be unsafe.

Telegram is unaffected — it stores its own history independently.

## Tests
- New `SqliteSessionStoreListSummariesTests` (message-count aggregation, retention-window exclusion, agent/channel resolution).
- `SessionWarmupServiceTests` updated to assert the summary path is used and full `ListAsync` is never called.
- `scripts/repo/test-impacted.ps1` green (Architecture + Scenarios + all affected projects).

Closes #1581