### PR TITLE
fix(channels): route Telegram streaming replies by agent in multi-bot mode

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -179,7 +179,7 @@ public sealed class TelegramChannelAdapter(
         if (string.IsNullOrEmpty(delta) || !TelegramChannelAddress.TryDecode(target.ChannelAddress, out var chatId, out var messageThreadId))
             return;
 
-        var runtime = ResolveSingleConfiguredBot();
+        var runtime = ResolveStreamingBot(null);
         EnsureChatAllowed(runtime.Config, chatId);
         var stateKey = target.ChannelAddress.Value;
         var state = runtime.StreamingStates.GetOrAdd(stateKey, _ => new StreamingState(chatId, messageThreadId));
@@ -208,7 +208,7 @@ public sealed class TelegramChannelAdapter(
         if (!TelegramChannelAddress.TryDecode(target.ChannelAddress, out var chatId, out var messageThreadId))
             return;
 
-        var runtime = ResolveSingleConfiguredBot();
+        var runtime = ResolveStreamingBot(streamEvent.AgentId);
         EnsureChatAllowed(runtime.Config, chatId);
         var stateKey = target.ChannelAddress.Value;
         var state = runtime.StreamingStates.GetOrAdd(stateKey, _ => new StreamingState(chatId, messageThreadId));
@@ -564,12 +564,32 @@ public sealed class TelegramChannelAdapter(
         }
     }
 
-    private BotRuntime ResolveSingleConfiguredBot()
+    // Resolves which bot a streamed reply should be sent through. Single-bot
+    // deployments are unambiguous; multi-bot deployments route by the originating
+    // agent because each bot binds a distinct agentId and the enriched
+    // AgentStreamEvent carries that agent — this sends the reply back through the
+    // same bot that received the message.
+    private BotRuntime ResolveStreamingBot(AgentId? agentId)
     {
         if (_bots.Count == 1)
             return _bots.Values.Single();
 
-        throw new InvalidOperationException("Streaming over Telegram requires a single configured bot or explicit bot routing metadata.");
+        if (agentId is { } id)
+        {
+            var matches = _bots.Values
+                .Where(b => string.Equals(b.Config.AgentId, id.Value, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (matches.Count == 1)
+                return matches[0];
+
+            if (matches.Count > 1)
+                throw new InvalidOperationException(
+                    $"Multiple Telegram bots are configured for agent '{id.Value}'. Each bot must bind a distinct agentId.");
+        }
+
+        throw new InvalidOperationException(
+            "Streaming over Telegram requires a single configured bot or a stream event carrying the originating agent id.");
     }
 
     private BotRuntime ResolveOutboundBot(OutboundMessage message)

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramMultiBotTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramMultiBotTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using BotNexus.Domain.Primitives;
 using BotNexus.Extensions.Channels.Telegram;
 using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Models;
@@ -152,6 +153,74 @@ public sealed class TelegramMultiBotTests
         message.RoutingHints.ShouldNotBeNull();
         message.RoutingHints!.RequestedAgentId!.Value.Value.ShouldBe("legacy-agent");
         message.Content.ShouldBe("legacy message");
+    }
+
+    /// <summary>
+    /// Regression for the multi-bot streaming reply bug: when two bots are configured,
+    /// a streamed reply must be routed to the bot whose configured agent matches the
+    /// stream event's AgentId — not rejected by the old single-bot-only resolver.
+    /// </summary>
+    [Fact]
+    public async Task SendStreamEvent_MultiBot_RoutesReplyToBotMatchingAgent()
+    {
+        var larrySends = new List<string>();
+        var assistantSends = new List<string>();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, List<string> sendSink)
+        {
+            var method = req.RequestUri?.Segments.LastOrDefault()?.Trim('/');
+            if (method == "sendMessage")
+            {
+                sendSink.Add(req.RequestUri!.AbsoluteUri);
+                return JsonOk(new TelegramMessage { MessageId = 999, Chat = new TelegramChat { Id = 202 } });
+            }
+            if (method == "getUpdates") return JsonOk(Array.Empty<TelegramUpdate>());
+            return JsonOk(true);
+        }
+
+        var options = new TelegramGatewayOptions
+        {
+            Bots =
+            {
+                ["larry-bot"] = new TelegramBotConfig
+                {
+                    BotToken = "token-larry",
+                    AgentId = "agent-b",
+                    AllowedChatIds = { 101 },
+                    PollingTimeoutSeconds = 1
+                },
+                ["assistant-bot"] = new TelegramBotConfig
+                {
+                    BotToken = "token-assistant",
+                    AgentId = "assistant",
+                    AllowedChatIds = { 202 },
+                    PollingTimeoutSeconds = 1
+                }
+            }
+        };
+
+        var httpFactory = new StubHttpClientFactory(name => name == "larry-bot"
+            ? new HttpClient(new StubHandler(req => Task.FromResult(Handler(req, larrySends))))
+            : new HttpClient(new StubHandler(req => Task.FromResult(Handler(req, assistantSends)))));
+
+        var adapter = new TelegramChannelAdapter(
+            NullLogger<TelegramChannelAdapter>.Instance,
+            Options.Create(options),
+            httpFactory);
+
+        var target = new ChannelStreamTarget(
+            ConversationId.From("conv-1"),
+            SessionId.From("sess-1"),
+            TelegramChannelAddress.Encode(202, null));
+
+        var assistant = AgentId.From("assistant");
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageStart, AgentId = assistant });
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "hi there", AgentId = assistant });
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd, AgentId = assistant });
+
+        assistantSends.ShouldNotBeEmpty();
+        assistantSends.ShouldContain(u => u.Contains("token-assistant"));
+        larrySends.ShouldBeEmpty();
     }
 
     private static TelegramUpdate MakeUpdate(int updateId, long chatId, string text) =>


### PR DESCRIPTION
## Problem
With multiple Telegram bots configured (multi-bot `channels.telegram.bots` map, e.g. keel + farnsworth), inbound polling works for every bot but **no bot ever replies**. The gateway logs:

```
System.InvalidOperationException: Streaming over Telegram requires a single configured bot or explicit bot routing metadata.
   at TelegramChannelAdapter.ResolveSingleConfiguredBot()
   at TelegramChannelAdapter.SendStreamEventAsync()
```

## Root cause
The non-streaming outbound path (`ResolveOutboundBot`) already routes by `metadata['telegramBotName']`, but the **streaming** path (`SendStreamEventAsync` / `SendStreamDeltaAsync`) called `ResolveSingleConfiguredBot()`, which throws whenever 2+ bots are configured. Streaming replies were never made multi-bot aware.

## Fix
Replace `ResolveSingleConfiguredBot()` with `ResolveStreamingBot(AgentId?)`:
- one bot configured → return it (unchanged behaviour);
- multiple bots → route to the bot whose configured `agentId` matches the enriched `AgentStreamEvent.AgentId`.

Each bot binds a distinct agent, and `GatewayHost` stamps the originating agent on every stream event, so the reply goes back through the same bot that received the message.

## Tests
- New `SendStreamEvent_MultiBot_RoutesReplyToBotMatchingAgent` verifies a streamed reply for agent `assistant` is sent through the `assistant` bot's API client and never the other bot.
- `scripts/repo/test-impacted.ps1` green (Architecture + Scenarios + Gateway, 3177 passed).

Closes #1583