### PR TITLE
fix(portal): serve Blazor assets compressed and stop shipping stale generations

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj
@@ -10,6 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="BotNexus.Gateway.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
     <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
     <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Dispatching\BotNexus.Gateway.Dispatching.csproj" />
@@ -26,29 +30,37 @@
        Files are output to $(OutputPath)blazor/ and propagated to consuming projects
        via _CopyFilesMarkedCopyLocal. -->
   <Target Name="PublishBlazorClient" AfterTargets="Build">
+    <!-- Clean the intermediate publish dir so stale fingerprinted assets from a prior
+         build are not carried forward (each content change produces a new hashed name;
+         publish overwrites but never removes the old generation). -->
+    <RemoveDir Directories="$(IntermediateOutputPath)blazor-publish" />
     <Exec Command="dotnet publish &quot;$(MSBuildProjectDirectory)\..\BotNexus.Extensions.Channels.SignalR.BlazorClient\BotNexus.Extensions.Channels.SignalR.BlazorClient.csproj&quot; -c $(Configuration) -o &quot;$(IntermediateOutputPath)blazor-publish&quot; --nologo -v:q" />
   </Target>
 
   <Target Name="CopyBlazorClient" AfterTargets="PublishBlazorClient">
+    <!-- Wipe the bundled output first so only the current generation ships. -->
+    <RemoveDir Directories="$(OutputPath)blazor" />
     <ItemGroup>
       <BlazorPublishFiles Include="$(IntermediateOutputPath)blazor-publish\wwwroot\**" />
     </ItemGroup>
-    <Copy SourceFiles="@(BlazorPublishFiles)" DestinationFolder="$(OutputPath)blazor\%(RecursiveDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(BlazorPublishFiles)" DestinationFolder="$(OutputPath)blazor\%(RecursiveDir)" />
   </Target>
 
   <!-- Publish the mobile Blazor WASM client and bundle at blazor-mobile/
        ContinueOnError means a mobile build failure does NOT break the desktop portal. -->
   <Target Name="PublishMobileBlazorClient" AfterTargets="Build">
+    <RemoveDir Directories="$(IntermediateOutputPath)blazor-mobile-publish" />
     <Exec Command="dotnet publish &quot;$(MSBuildProjectDirectory)/../BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.csproj&quot; -c $(Configuration) -o &quot;$(IntermediateOutputPath)blazor-mobile-publish&quot; --nologo -v:q"
           ContinueOnError="true"
           IgnoreExitCode="true" />
   </Target>
 
   <Target Name="CopyMobileBlazorClient" AfterTargets="PublishMobileBlazorClient">
+    <RemoveDir Directories="$(OutputPath)blazor-mobile" />
     <ItemGroup>
       <MobileBlazorPublishFiles Include="$(IntermediateOutputPath)blazor-mobile-publish\wwwroot\**" />
     </ItemGroup>
-    <Copy SourceFiles="@(MobileBlazorPublishFiles)" DestinationFolder="$(OutputPath)blazor-mobile\%(RecursiveDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(MobileBlazorPublishFiles)" DestinationFolder="$(OutputPath)blazor-mobile\%(RecursiveDir)" />
   </Target>
 
   </Project>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalREndpointContributor.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalREndpointContributor.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 
 namespace BotNexus.Extensions.Channels.SignalR;
 
@@ -77,9 +78,22 @@ public class SignalREndpointContributor : IEndpointContributor
             if (fileInfo.Exists && !fileInfo.IsDirectory)
             {
                 var contentType = GetContentType(subPath);
+
+                // Prefer a precompressed sibling (.br/.gz) when the client accepts it.
+                // Blazor publish emits these next to each asset; serving them keeps the
+                // large runtime wasm/js small over the wire and avoids mid-flight load
+                // failures on mobile over slow/proxied links. The Content-Type stays the
+                // original payload type; Content-Encoding tells the browser how to decode.
+                var (encodedFile, encoding) = SelectEncodedFile(
+                    fileProvider, subPath, context.Request.Headers.AcceptEncoding);
+                var fileToServe = encodedFile ?? fileInfo;
+
                 context.Response.ContentType = contentType;
-                context.Response.ContentLength = fileInfo.Length;
-                await using var stream = fileInfo.CreateReadStream();
+                if (encoding is not null)
+                    context.Response.Headers.ContentEncoding = encoding;
+                context.Response.Headers.Vary = "Accept-Encoding";
+                context.Response.ContentLength = fileToServe.Length;
+                await using var stream = fileToServe.CreateReadStream();
                 await stream.CopyToAsync(context.Response.Body);
                 return;
             }
@@ -94,6 +108,35 @@ public class SignalREndpointContributor : IEndpointContributor
 
             await next();
         });
+    }
+
+    // Returns the precompressed sibling file and its Content-Encoding token when the
+    // client accepts an encoding for which a sibling exists; otherwise (null, null).
+    // Brotli is preferred over gzip. Already-compressed requests are left untouched.
+    internal static (IFileInfo? File, string? Encoding) SelectEncodedFile(
+        IFileProvider fileProvider, string subPath, StringValues acceptEncoding)
+    {
+        if (subPath.EndsWith(".br", StringComparison.OrdinalIgnoreCase) ||
+            subPath.EndsWith(".gz", StringComparison.OrdinalIgnoreCase))
+            return (null, null);
+
+        var accepts = acceptEncoding.ToString();
+
+        if (accepts.Contains("br", StringComparison.OrdinalIgnoreCase))
+        {
+            var br = fileProvider.GetFileInfo(subPath + ".br");
+            if (br.Exists && !br.IsDirectory)
+                return (br, "br");
+        }
+
+        if (accepts.Contains("gzip", StringComparison.OrdinalIgnoreCase))
+        {
+            var gz = fileProvider.GetFileInfo(subPath + ".gz");
+            if (gz.Exists && !gz.IsDirectory)
+                return (gz, "gzip");
+        }
+
+        return (null, null);
     }
 
     private static string GetContentType(string path) => Path.GetExtension(path).ToLowerInvariant() switch

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/SignalRBlazorAssetEncodingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/SignalRBlazorAssetEncodingTests.cs
@@ -1,0 +1,99 @@
+using BotNexus.Extensions.Channels.SignalR;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+
+namespace BotNexus.Gateway.Tests.Channels;
+
+/// <summary>
+/// Verifies the Blazor static-asset middleware prefers precompressed siblings
+/// (.br/.gz) emitted by Blazor publish when the client advertises the matching
+/// Accept-Encoding. This keeps the large runtime wasm/js small over the wire and
+/// avoids mid-flight load failures on mobile over slow/proxied links.
+/// </summary>
+public sealed class SignalRBlazorAssetEncodingTests
+{
+    [Fact]
+    public void SelectEncodedFile_PrefersBrotli_WhenClientAcceptsBr()
+    {
+        var provider = new StubFileProvider("/_framework/app.wasm.br", "/_framework/app.wasm.gz");
+
+        var (file, encoding) = SignalREndpointContributor.SelectEncodedFile(
+            provider, "/_framework/app.wasm", "gzip, deflate, br");
+
+        encoding.ShouldBe("br");
+        file.ShouldNotBeNull();
+        file!.Name.ShouldEndWith(".br");
+    }
+
+    [Fact]
+    public void SelectEncodedFile_FallsBackToGzip_WhenBrNotAccepted()
+    {
+        var provider = new StubFileProvider("/_framework/app.wasm.br", "/_framework/app.wasm.gz");
+
+        var (file, encoding) = SignalREndpointContributor.SelectEncodedFile(
+            provider, "/_framework/app.wasm", "gzip, deflate");
+
+        encoding.ShouldBe("gzip");
+        file!.Name.ShouldEndWith(".gz");
+    }
+
+    [Fact]
+    public void SelectEncodedFile_ReturnsNull_WhenNoCompressedSiblingExists()
+    {
+        var provider = new StubFileProvider();
+
+        var (file, encoding) = SignalREndpointContributor.SelectEncodedFile(
+            provider, "/_framework/app.wasm", "gzip, br");
+
+        file.ShouldBeNull();
+        encoding.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SelectEncodedFile_ReturnsNull_WhenClientAcceptsNoEncoding()
+    {
+        var provider = new StubFileProvider("/_framework/app.wasm.br");
+
+        var (file, encoding) = SignalREndpointContributor.SelectEncodedFile(
+            provider, "/_framework/app.wasm", StringValues.Empty);
+
+        file.ShouldBeNull();
+        encoding.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SelectEncodedFile_DoesNotDoubleCompress_AlreadyCompressedRequest()
+    {
+        var provider = new StubFileProvider("/_framework/app.wasm.br.br");
+
+        var (file, encoding) = SignalREndpointContributor.SelectEncodedFile(
+            provider, "/_framework/app.wasm.br", "br");
+
+        file.ShouldBeNull();
+        encoding.ShouldBeNull();
+    }
+
+    private sealed class StubFileProvider(params string[] existingPaths) : IFileProvider
+    {
+        private readonly HashSet<string> _existing = new(existingPaths, StringComparer.Ordinal);
+
+        public IFileInfo GetFileInfo(string subpath) =>
+            _existing.Contains(subpath)
+                ? new StubFileInfo(subpath)
+                : new NotFoundFileInfo(subpath);
+
+        public IDirectoryContents GetDirectoryContents(string subpath) => NotFoundDirectoryContents.Singleton;
+        public IChangeToken Watch(string filter) => NullChangeToken.Singleton;
+    }
+
+    private sealed class StubFileInfo(string subpath) : IFileInfo
+    {
+        public bool Exists => true;
+        public long Length => 42;
+        public string? PhysicalPath => null;
+        public string Name => subpath[(subpath.LastIndexOf('/') + 1)..];
+        public DateTimeOffset LastModified => DateTimeOffset.UnixEpoch;
+        public bool IsDirectory => false;
+        public Stream CreateReadStream() => new MemoryStream(new byte[42]);
+    }
+}


### PR DESCRIPTION
## Summary
The hand-rolled Blazor static-asset middleware served uncompressed payloads (including the ~20MB `dotnet.native` wasm) despite Blazor publish emitting `.br`/`.gz` siblings. This caused slow loads and intermittent `Importing a module script failed` errors on mobile over slow/proxied links. The publish/copy pipeline also accumulated stale fingerprint generations (~5) because copies used `SkipUnchangedFiles` and never cleaned output.

## Changes
- `SignalREndpointContributor`: serve the precompressed sibling (brotli preferred, gzip fallback) when the client accepts it — sets `Content-Encoding` + `Vary: Accept-Encoding`, keeps the original `Content-Type` and the compressed file length.
- `BotNexus.Extensions.Channels.SignalR.csproj`: clean publish intermediate dirs and `blazor`/`blazor-mobile` output before copy; drop `SkipUnchangedFiles` so only the current generation ships.
- Unit tests for `SelectEncodedFile`: brotli preference, gzip fallback, no-sibling, no-accept, and already-compressed short-circuit.

## Validation
- `test-impacted.ps1` green (Architecture + Scenarios + Gateway + Conversations, 3181 passed).
- Build clean under TreatWarningsAsErrors.

Closes #1585