### PR TITLE
fix(channels): treat Telegram 'message is not modified' as benign no-op

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotApiClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotApiClient.cs
@@ -79,16 +79,32 @@ public sealed class TelegramBotApiClient(
     /// <summary>
     /// Edits an existing message's text. Uses MarkdownV2 parse_mode.
     /// </summary>
-    public Task<TelegramMessage> EditMessageTextAsync(
+    /// <remarks>
+    /// Telegram returns <c>400 Bad Request: message is not modified</c> when the new text is
+    /// identical to what is already displayed. This is a benign condition that routinely occurs
+    /// during streaming when a throttled or final flush re-sends unchanged content. It is treated
+    /// as a no-op success — the message already holds the correct text — and the existing message
+    /// is returned so the streaming pipeline continues without aborting the turn.
+    /// </remarks>
+    public async Task<TelegramMessage> EditMessageTextAsync(
         long chatId,
         int messageId,
         string text,
         CancellationToken cancellationToken = default)
-        => PostForResultAsync<TelegramMessage>(
-            "editMessageText",
-            new { chat_id = chatId, message_id = messageId, text, parse_mode = "MarkdownV2" },
-            cancellationToken,
-            allowMarkdownFallback: false);
+    {
+        try
+        {
+            return await PostForResultAsync<TelegramMessage>(
+                "editMessageText",
+                new { chat_id = chatId, message_id = messageId, text, parse_mode = "MarkdownV2" },
+                cancellationToken,
+                allowMarkdownFallback: false);
+        }
+        catch (TelegramMessageNotModifiedException)
+        {
+            return new TelegramMessage { MessageId = messageId };
+        }
+    }
 
     /// <summary>
     /// Long-polls for new updates from the Telegram Bot API.
@@ -194,6 +210,13 @@ public sealed class TelegramBotApiClient(
                 continue;
             }
 
+            // 400 "message is not modified" is benign: the message already holds the requested
+            // content (common during streaming when a flush re-sends unchanged text). Surface it
+            // as a typed signal so callers can treat it as a no-op rather than a hard failure.
+            if (response.StatusCode == HttpStatusCode.BadRequest &&
+                body.Contains("message is not modified", StringComparison.OrdinalIgnoreCase))
+                throw new TelegramMessageNotModifiedException($"Telegram reported no change for {methodName}: {body}");
+
             // 400 on sendMessage with MarkdownV2 parse_mode means malformed markdown — signal fallback.
             if (response.StatusCode == HttpStatusCode.BadRequest && allowMarkdownFallback)
                 throw new TelegramMarkdownParseException($"Telegram rejected MarkdownV2 for {methodName}: {body}");
@@ -246,3 +269,10 @@ public sealed class TelegramBotApiClient(
 /// signalling that <see cref="TelegramBotApiClient"/> should retry as plain text.
 /// </summary>
 internal sealed class TelegramMarkdownParseException(string message) : Exception(message);
+
+/// <summary>
+/// Thrown internally when Telegram returns a 400 "message is not modified" for an edit,
+/// signalling that the existing message already holds the requested content. Callers treat
+/// this as a benign no-op so streaming edits with unchanged text do not abort the turn.
+/// </summary>
+internal sealed class TelegramMessageNotModifiedException(string message) : Exception(message);

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -331,6 +331,52 @@ public sealed class TelegramChannelAdapterTests
     }
 
     [Fact]
+    public async Task SendStreamEventAsync_EditReturnsMessageNotModified_DoesNotThrow_AndContinuesTurn()
+    {
+        // Regression for #1587: during streaming the adapter edits the reply message
+        // progressively. When a flush re-sends text identical to what is already displayed,
+        // Telegram returns 400 "message is not modified". This must be treated as a benign
+        // no-op — previously it threw HttpRequestException, aborting the turn and leaving the
+        // bot unresponsive to the next message.
+        var calls = new List<ApiCall>();
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            calls.Add(call);
+            return call.MethodName switch
+            {
+                "sendMessage" => JsonOk(new TelegramMessage { MessageId = 99, Chat = new TelegramChat { Id = 42 } }),
+                "editMessageText" => new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent(
+                        "{\"ok\":false,\"error_code\":400,\"description\":\"Bad Request: message is not modified: specified new message content and reply markup are exactly the same\"}",
+                        Encoding.UTF8,
+                        "application/json")
+                },
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            AllowedChatIds = { 42 },
+            StreamingBufferMs = 60000
+        }, handler);
+
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = new string('a', 101) });
+
+        // The forced end-of-message flush edits the already-sent text, triggering Telegram's
+        // "message is not modified". This must not throw.
+        await Should.NotThrowAsync(async () =>
+            await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }));
+
+        calls.Count(c => c.MethodName == "sendMessage").ShouldBe(1);
+        calls.Count(c => c.MethodName == "editMessageText").ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
     public async Task SendStreamEventAsync_WithCompositeAddress_RoutesFirstSend_ToForumTopic()
     {
         // Regression for PR #512: pre-refactor, streaming replies to Telegram forum topics


### PR DESCRIPTION
## Summary
Telegram bots reply to the first message but go silent on the follow-up. The gateway log shows `editMessageText` failing with `400 Bad Request: message is not modified` during streaming, which threw and aborted the turn.

## Cause
Streaming edits the reply message progressively. When a flush (typically the final `force:true` flush) re-sends text identical to what is already displayed, Telegram returns `400 message is not modified`. `PostForResultAsync` threw `HttpRequestException` for any non-success status, propagating up and aborting `ProcessAsync` — disrupting subsequent replies.

## Fix
- Detect the `message is not modified` 400 in `PostForResultAsync` and surface it as a typed `TelegramMessageNotModifiedException`.
- `EditMessageTextAsync` catches it and returns the unchanged message (same `message_id`), so the streaming pipeline continues without aborting.
- Regression test: an unchanged-content streaming edit no longer throws and the turn completes.

## Validation
- `test-impacted.ps1` green (Architecture + Scenarios + Gateway + Conversations, 3178 passed).
- New `SendStreamEventAsync_EditReturnsMessageNotModified_DoesNotThrow_AndContinuesTurn` passes; full Telegram adapter suite (50) green.
- Clean under TreatWarningsAsErrors.

Closes #1587