### PR TITLE
docs: backfill v0.9.0 release page + document cron DeleteAfterRun config

### DIFF
--- a/docs/cron-and-scheduling.md
+++ b/docs/cron-and-scheduling.md
@@ -205,6 +205,7 @@ Execute maintenance tasks: memory consolidation, session cleanup, log rotation.
 | `Agent` | string | (agent jobs only) | Name of agent to run |
 | `Prompt` | string | (agent jobs only) | Prompt to execute |
 | `Session` | string | (agent jobs only) | Session mode: `new`, `persistent`, or `named:<key>` |
+| `DeleteAfterRun` | bool | `false` | Opt-in cleanup for ephemeral jobs: when `true`, the scheduler deletes the run's agent session and its transcript after the run completes (across success / timeout / error / abort), provided the run produced a cron-scoped (`cron:`) session. Prevents run-scoped sessions from accumulating transcript entries indefinitely. Leave off for long-lived reporting jobs that intentionally persist context across runs — use compaction for those. Only ever deletes `cron:`-prefixed sessions, so a misconfigured flag cannot remove an unrelated long-lived session. |
 | `Action` | string | (system/maintenance jobs) | Action name to execute |
 | `Agents` | list | `[]` | Agent names for `consolidate-memory` |
 | `OutputChannels` | list | `[]` | Channels to route output to |

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -10,6 +10,7 @@ Browse the full version history of BotNexus. Each release page includes the full
 | Version | Date | |
 |---------|------|---|
 | **[v0.10.0](v0.10.0/)** | 2026-06-24 | ← Latest |
+| [v0.9.0](v0.9.0/) | 2026-06-23 | |
 | [v0.8.1](v0.8.1/) | 2026-06-20 | |
 | [v0.8.0](v0.8.0/) | 2026-06-17 | |
 | [v0.7.0](v0.7.0/) | 2026-06-16 | |

--- a/docs/releases/v0.9.0/index.md
+++ b/docs/releases/v0.9.0/index.md
@@ -1,0 +1,51 @@
+---
+title: "Release v0.9.0"
+description: "Release notes for BotNexus v0.9.0"
+date: "2026-06-23"
+---
+
+# Release v0.9.0
+
+> **Released:** 2026-06-23
+>
+> **Full diff:** [v0.8.1...v0.9.0](https://github.com/sytone/botnexus/compare/v0.8.1...v0.9.0)
+
+## [0.9.0] - 2026-06-23
+
+### ✨ Features
+
+- **security:** Add SecurityEvent model and trusted ring-buffer sink (#1533)
+- **cron:** Add opt-in DeleteAfterRun cleanup for ephemeral run sessions (#1571)
+
+### 🐛 Bug Fixes
+
+- **cli:** Align port-availability probe with the gateway wildcard bind (#1537)
+- **tools:** Coerce losslessly-safe tool argument shapes before rejecting (#1562)
+- **tools:** Return nearest-line diagnostic on edit 0-match instead of bare error (#1563)
+- **memory:** Sanitize control/role-injection markup before indexing transcript to memory (#1569)
+
+### 📖 Documentation
+
+- Backfill v0.7.0-v0.8.1 release pages + CLI reference accuracy fixes (#1534)
+
+### ⚡ Performance
+
+- **persistence:** Bound SQLite session/conversation caches and lock pools (#1530)
+
+### 🔨 Refactor
+
+- **gateway:** Extract PrepareTurnAsync from ProcessAsync (#1531)
+- **providers:** Unify duplicated completions converter into Core (#1543)
+- **gateway:** Split cross-world federation routing out of AgentExchangeService (#1544)
+- **providers:** Unify OpenAI/Copilot Responses stream parsers into Core (#1546)
+- **config:** Split ConfigPathResolver.TryConvertValue into a dispatcher (#1567)
+- **sessions:** Decompose LlmSessionCompactor.CompactAsync (#1568)
+- **gateway:** Split DefaultSubAgentManager spawn/completion into testable helpers (#1570)
+
+### 🔧 CI/Build
+
+- **security:** Add a guard for security-sensitive boundary files (#1529)
+- **workflows:** Add per-ref concurrency groups to stop stacked CodeQL/CI runs (#1549)
+
+[0.9.0]: https://github.com/sytone/botnexus/compare/v0.8.1...v0.9.0
+


### PR DESCRIPTION
## Changes

Daily documentation grooming for 2026-06-24. Docs-only, no code changes.

The `v0.9.0` and `v0.10.0` tags were both cut after the last grooming PR (#1534) merged. The `release-cli.yml` workflow **did** generate the `v0.10.0` page, but the `v0.9.0` tag skipped it — so its release page was missing and the release index chain was broken (`v0.10.0` linked straight to `v0.8.1`). This run backfills the gap and documents one new config field.

## New pages

- **`docs/releases/v0.9.0/index.md`** — backfilled the missing v0.9.0 release page. Generated by replicating `git-cliff`'s output (parsed `v0.8.1..v0.9.0`, grouped by `cliff.toml` parser order). The generator was byte-for-byte validated against the genuine git-cliff `v0.10.0` page (SHA256 match) before use. 17 commits across Features (2), Bug Fixes (4), Documentation (1), Performance (1), Refactor (7), CI/Build (2).

## Content fixes

- **`docs/releases/index.md`** — added the `v0.9.0` row, restoring the descending chain `v0.10.0 → v0.9.0 → v0.8.1`. `v0.10.0` keeps the `← Latest` marker.
- **`docs/cron-and-scheduling.md`** — documented the new `DeleteAfterRun` per-job config field (§3.2 Per-Job Configuration), shipped in `v0.9.0` via #1571. It is config-only (not a CLI option or tool param), so the only doc surface is the per-job config table.

## Structural improvements

None needed — structure audit was clean: 0 orphan pages, 0 dead sidebar links, all 11 required sections present.

## VitePress sidebar changes

None — release pages are reached via `docs/releases/index.md`, which is already the sidebar entry.

## Validation

- MOJIBAKE GATE: clean on all 3 changed files (sig=0, box-in-prose=0). The new v0.9.0 page is UTF-8 no-BOM, LF-only, with the git-cliff trailing-blank convention.
- `npm run docs:build` (VitePress 2.0.0-alpha.17, Node 22): **green** in 13.3s — no dead links, no config errors.
- SignalR hub contract verified in sync (24 server events / 11 client methods; `IGatewayHubClient.cs` untouched since v0.8.1). Providers unchanged (5 documented). No CLI reference drift.

## Flagged for Jon

- The genuine git-cliff `v0.10.0` page ends with a trailing blank line (`\n\n`); the hand-backfilled pages (v0.6.0–v0.8.1) end with a single `\n`. Cosmetic only — the new v0.9.0 page matches the authoritative git-cliff style. Not worth a churn PR to normalize the older pages.
- The root `CHANGELOG.md` (out of the groomer's `docs/` scope) likely also lacks the v0.9.0 section since the tag skipped the workflow — flagging in case it matters.

---
Automated by the daily documentation groomer.
