### PR TITLE
fix(qmd): kill orphaned qmd subprocess on caller cancellation

### DIFF
--- a/src/extensions/BotNexus.Extensions.Qmd/QmdCliBackend.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/QmdCliBackend.cs
@@ -120,9 +120,19 @@ public sealed class QmdCliBackend : IQmdBackend
         {
             await process.WaitForExitAsync(timeoutCts.Token);
         }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
+            // The wait was aborted for one of two reasons; in BOTH cases the qmd child (which may be a
+            // long-running embedding/query that never exits on its own) must be killed, or it is orphaned.
+            // Previously this catch was guarded with `when (!ct.IsCancellationRequested)`, so a caller
+            // cancellation skipped the kill and `using var process` disposed the handle without reaping the
+            // child. Always kill the process tree, then surface the appropriate exception.
             try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+
+            if (ct.IsCancellationRequested)
+                throw; // caller cancellation -> propagate the OperationCanceledException
+
+            // Internal timeout (timeoutCts fired while the caller token is still live).
             throw new TimeoutException($"qmd CLI call timed out after {_timeout.TotalSeconds}s. Args: {string.Join(' ', arguments)}");
         }
 

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdCliBackendCancellationTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdCliBackendCancellationTests.cs
@@ -1,0 +1,136 @@
+using System.Diagnostics;
+
+namespace BotNexus.Extensions.Qmd.Tests;
+
+/// <summary>
+/// Verifies that <see cref="QmdCliBackend.RunAsync"/> never leaves an orphaned <c>qmd</c>
+/// child process behind when the call is aborted. The internal-timeout path already killed
+/// the process tree; the caller-cancellation path used to skip the kill (the catch was guarded
+/// with <c>when (!ct.IsCancellationRequested)</c>), orphaning a still-running child. These tests
+/// spawn a real long-lived child via the backend, abort it, and assert the child actually exits.
+/// Mirrors the OpenClaw "abort orphaned qmd subprocess on caller signal" fix whose fixture child
+/// "never closes on its own", so the only way the call can settle cleanly is the abort killing it.
+/// </summary>
+public sealed class QmdCliBackendCancellationTests
+{
+    // A long-lived child that first writes its own PID to <paramref name="pidFile"/> then sleeps,
+    // so the test can poll that exact PID for exit after aborting. The sleep child belongs to the
+    // process the backend starts, so killing the process tree reaps it. Cross-platform.
+    private static (string exe, List<string> args) PidWritingSleeper(string pidFile)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // powershell writes $PID (the process QmdCliBackend starts) then sleeps.
+            return ("powershell.exe", new List<string>
+            {
+                "-NoProfile", "-NonInteractive", "-Command",
+                $"$PID | Out-File -FilePath '{pidFile}' -Encoding ascii; Start-Sleep -Seconds 120"
+            });
+        }
+
+        // bash writes $$ (its own PID) then sleeps.
+        return ("/bin/bash", new List<string>
+        {
+            "-c", $"echo $$ > '{pidFile}'; sleep 120"
+        });
+    }
+
+    private static async Task<int> WaitForPidFileAsync(string pidFile, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (File.Exists(pidFile))
+            {
+                var text = (await File.ReadAllTextAsync(pidFile)).Trim();
+                if (int.TryParse(text, out var pid) && pid > 0)
+                    return pid;
+            }
+            await Task.Delay(25);
+        }
+
+        throw new TimeoutException($"Child never wrote its PID to {pidFile} within {timeout.TotalSeconds}s.");
+    }
+
+    private static bool IsProcessAlive(int pid)
+    {
+        try
+        {
+            using var p = Process.GetProcessById(pid);
+            return !p.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            // No process with that id is running -> it exited (was killed).
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task<bool> WaitForExitAsync(int pid, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (!IsProcessAlive(pid))
+                return true;
+            await Task.Delay(25);
+        }
+
+        return !IsProcessAlive(pid);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCallerTokenCancelled_KillsChildProcessTree_NoOrphan()
+    {
+        var pidFile = Path.Combine(Path.GetTempPath(), $"qmd-cancel-test-{Guid.NewGuid():N}.pid");
+        var (exe, args) = PidWritingSleeper(pidFile);
+
+        // Generous internal timeout so it is the CALLER cancellation -- not the internal timeout --
+        // that aborts the wait. This is the path that previously leaked the child.
+        var backend = new QmdCliBackend(exe, timeout: TimeSpan.FromMinutes(5));
+        using var cts = new CancellationTokenSource();
+
+        var run = backend.RunAsync(args, cts.Token);
+
+        // Wait until the child is actually running (it has written its PID), then cancel the caller.
+        var childPid = await WaitForPidFileAsync(pidFile, TimeSpan.FromSeconds(20));
+        Assert.True(IsProcessAlive(childPid), "child should be running before cancellation");
+
+        cts.Cancel();
+
+        // Caller cancellation must surface as an OperationCanceledException (not a TimeoutException).
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run);
+
+        // And, crucially, the child must have been killed -- no orphaned qmd subprocess.
+        var exited = await WaitForExitAsync(childPid, TimeSpan.FromSeconds(20));
+        Assert.True(exited, $"child process {childPid} should have been killed on caller cancellation, but it is still running (orphaned)");
+
+        try { File.Delete(pidFile); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenInternalTimeoutFires_StillKillsChildProcessTree()
+    {
+        var pidFile = Path.Combine(Path.GetTempPath(), $"qmd-timeout-test-{Guid.NewGuid():N}.pid");
+        var (exe, args) = PidWritingSleeper(pidFile);
+
+        // Very short internal timeout, caller token never cancelled -> internal-timeout kill path.
+        var backend = new QmdCliBackend(exe, timeout: TimeSpan.FromMilliseconds(500));
+
+        var run = backend.RunAsync(args, CancellationToken.None);
+
+        var childPid = await WaitForPidFileAsync(pidFile, TimeSpan.FromSeconds(20));
+
+        // The internal-timeout path surfaces a TimeoutException.
+        await Assert.ThrowsAsync<TimeoutException>(() => run);
+
+        var exited = await WaitForExitAsync(childPid, TimeSpan.FromSeconds(20));
+        Assert.True(exited, $"child process {childPid} should have been killed on internal timeout, but it is still running (orphaned)");
+
+        try { File.Delete(pidFile); } catch { /* best effort */ }
+    }
+}


### PR DESCRIPTION
Closes #1597

## What & why
`QmdCliBackend.RunAsync` killed the `qmd` child process only when its **internal timeout** fired. The catch was guarded:

```csharp
catch (OperationCanceledException) when (!ct.IsCancellationRequested)
{
    process.Kill(entireProcessTree: true);
    throw new TimeoutException(...);
}
```

When the **caller's** `CancellationToken` was cancelled (the `memory_search` / `knowledge_search` turn aborts, or a higher layer times the call out), `WaitForExitAsync(timeoutCts.Token)` throws `OperationCanceledException`, but `when (!ct.IsCancellationRequested)` is **false**, so the catch was skipped, the OCE propagated, and `using var process` disposed the handle **without killing the child**. A still-running `qmd` subprocess (which may be a long-lived embedding/query that never exits on its own) was orphaned.

`SearchAsync` / `GetDocumentAsync` / `GetStoresAsync` / `UpdateIndexAsync` / `EmbedAsync` all route through `RunAsync`, so every qmd CLI path shared the leak.

## Fix
Always kill the process tree when the wait is cancelled — for **any** reason — then surface the appropriate exception:

```csharp
catch (OperationCanceledException)
{
    try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
    if (ct.IsCancellationRequested)
        throw;                    // caller cancellation -> propagate OCE
    throw new TimeoutException(...);  // internal timeout
}
```

The interface already threads `CancellationToken` end-to-end, so no signature or caller changes were needed — the only gap was the kill-on-caller-cancel in `RunAsync`.

## Tests (TDD)
Added `QmdCliBackendCancellationTests` (cross-platform: `powershell.exe`/`/bin/bash`):
- `RunAsync_WhenCallerTokenCancelled_KillsChildProcessTree_NoOrphan` — spawns a real long-lived child that records its PID, cancels the caller token mid-run, asserts the call throws `OperationCanceledException` **and** the child PID is dead (no orphan). This test **failed before the fix** (child 41956 survived) and passes after.
- `RunAsync_WhenInternalTimeoutFires_StillKillsChildProcessTree` — regression-locks the existing internal-timeout kill path (throws `TimeoutException`, child killed).

`scripts/repo/test-impacted.ps1` green: Architecture.Tests + Scenarios.Tests (always-run) + Qmd.Tests (99 tests).

## OpenClaw provenance
Mirrors `78184ea7e42f` / `eadd69b44c57` / `73dd758310e8` (`fix(memory): abort orphaned qmd search subprocess ...`), whose fixture child "never closes on its own" so the only way the search settles is the caller-owned abort killing the subprocess.

## Merge Notes
Single-file behavioral fix to `src/extensions/BotNexus.Extensions.Qmd/QmdCliBackend.cs` + one new test file. **No file overlap** with the three open PRs (#1594 / #1593 / #1590 are all Telegram/docs). Safe to merge in any order relative to them. No interface, config, or docs change (the documented 30s CLI timeout is unchanged).
