### PR TITLE
fix(security): bound untrusted external JSON HTTP response reads

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Core/Utilities/BoundedHttpContent.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Utilities/BoundedHttpContent.cs
@@ -1,0 +1,184 @@
+using System.Text;
+using System.Text.Json;
+
+namespace BotNexus.Agent.Providers.Core.Utilities;
+
+/// <summary>
+/// Reads untrusted external HTTP response bodies with a hard byte cap so a hostile or
+/// malfunctioning endpoint streaming an unbounded body cannot force the runtime to buffer the
+/// whole payload before parsing (an availability / OOM-DoS vector).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The framework default <see cref="HttpClient.MaxResponseContentBufferSize"/> is ~2 GB, which is
+/// effectively unbounded for the JSON endpoints BotNexus talks to (web-search upstreams, model
+/// discovery). <c>ReadAsStringAsync</c> / <c>ReadFromJsonAsync</c> buffer the <em>entire</em> body
+/// with no limit. These helpers read the content <em>stream</em> incrementally and abort the moment
+/// the cap is exceeded — without first materializing the full advertised body.
+/// </para>
+/// <para>
+/// Two cheap rejections happen up front: a declared <c>Content-Length</c> larger than the cap is
+/// rejected before a single body byte is pulled, and the streaming read itself stops as soon as the
+/// running total crosses the cap (defending against a lying or chunked/no-length body).
+/// </para>
+/// <para>
+/// Port of OpenClaw's <c>readProviderJsonResponse</c> / <c>readResponseWithLimit</c> campaign (16 MiB
+/// shared cap), adapted to .NET <see cref="HttpContent"/>.
+/// </para>
+/// </remarks>
+public static class BoundedHttpContent
+{
+    /// <summary>
+    /// Default maximum response body size in bytes (16 MiB). Mirrors the OpenClaw shared cap. Far
+    /// larger than any legitimate search / model-discovery JSON payload, yet small enough that a
+    /// hostile endpoint cannot exhaust memory before the read is aborted.
+    /// </summary>
+    public const long DefaultMaxResponseBytes = 16L * 1024 * 1024;
+
+    /// <summary>
+    /// Mirrors the implicit options used by <c>System.Net.Http.Json.HttpContent.ReadFromJsonAsync</c>
+    /// (case-insensitive property matching) so swapping callers onto the bounded reader does not
+    /// change deserialization semantics.
+    /// </summary>
+    private static readonly JsonSerializerOptions WebDefaults = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Reads the response content as a string, aborting if the body exceeds <paramref name="maxBytes"/>.
+    /// </summary>
+    /// <param name="content">The HTTP response content (untrusted external body).</param>
+    /// <param name="maxBytes">Maximum number of bytes to read before aborting. Defaults to <see cref="DefaultMaxResponseBytes"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The decoded body as a string.</returns>
+    /// <exception cref="ResponseContentTooLargeException">The body exceeds <paramref name="maxBytes"/>.</exception>
+    public static async Task<string> ReadStringWithLimitAsync(
+        HttpContent content,
+        long maxBytes = DefaultMaxResponseBytes,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        if (maxBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxBytes), maxBytes, "maxBytes must be positive.");
+
+        // Cheap rejection: a declared Content-Length over the cap never needs a body byte pulled.
+        var declaredLength = content.Headers.ContentLength;
+        if (declaredLength is { } length && length > maxBytes)
+            throw new ResponseContentTooLargeException(maxBytes, length);
+
+        await using var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var buffer = await ReadBoundedAsync(stream, maxBytes, cancellationToken).ConfigureAwait(false);
+
+        // Honour a declared charset if present; default to UTF-8 (the JSON default).
+        var charSet = content.Headers.ContentType?.CharSet;
+        var encoding = ResolveEncoding(charSet);
+        return encoding.GetString(buffer);
+    }
+
+    /// <summary>
+    /// Reads the response content as JSON of type <typeparamref name="T"/>, aborting if the body
+    /// exceeds <paramref name="maxBytes"/> before deserializing.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize the JSON body into.</typeparam>
+    /// <param name="content">The HTTP response content (untrusted external body).</param>
+    /// <param name="options">Optional JSON serializer options.</param>
+    /// <param name="maxBytes">Maximum number of bytes to read before aborting. Defaults to <see cref="DefaultMaxResponseBytes"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The deserialized value, or <c>null</c> when the body is empty / JSON null.</returns>
+    /// <exception cref="ResponseContentTooLargeException">The body exceeds <paramref name="maxBytes"/>.</exception>
+    public static async Task<T?> ReadFromJsonWithLimitAsync<T>(
+        HttpContent content,
+        JsonSerializerOptions? options = null,
+        long maxBytes = DefaultMaxResponseBytes,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        if (maxBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxBytes), maxBytes, "maxBytes must be positive.");
+
+        var declaredLength = content.Headers.ContentLength;
+        if (declaredLength is { } length && length > maxBytes)
+            throw new ResponseContentTooLargeException(maxBytes, length);
+
+        await using var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var buffer = await ReadBoundedAsync(stream, maxBytes, cancellationToken).ConfigureAwait(false);
+
+        if (buffer.Length == 0)
+            return default;
+
+        // Default to web defaults (case-insensitive property matching) to match the behaviour of
+        // System.Net.Http.Json's ReadFromJsonAsync, which the callers previously used. Without this,
+        // a lowercase JSON field (e.g. Ollama's "capabilities") would silently fail to bind.
+        return JsonSerializer.Deserialize<T>(buffer, options ?? WebDefaults);
+    }
+
+    /// <summary>
+    /// Reads <paramref name="stream"/> into a byte array, throwing once the running total would
+    /// exceed <paramref name="maxBytes"/>. The read stops at the first chunk that crosses the cap,
+    /// so an unbounded / lying body is never fully buffered.
+    /// </summary>
+    private static async Task<byte[]> ReadBoundedAsync(
+        Stream stream,
+        long maxBytes,
+        CancellationToken cancellationToken)
+    {
+        // 81920 == the default Stream.CopyToAsync buffer size.
+        const int chunkSize = 81920;
+        var rented = new byte[chunkSize];
+        using var accumulator = new MemoryStream();
+        long total = 0;
+
+        while (true)
+        {
+            var read = await stream.ReadAsync(rented.AsMemory(0, chunkSize), cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+                break;
+
+            total += read;
+            if (total > maxBytes)
+                throw new ResponseContentTooLargeException(maxBytes, total);
+
+            accumulator.Write(rented, 0, read);
+        }
+
+        return accumulator.ToArray();
+    }
+
+    private static Encoding ResolveEncoding(string? charSet)
+    {
+        if (string.IsNullOrWhiteSpace(charSet))
+            return Encoding.UTF8;
+
+        try
+        {
+            // Strip surrounding quotes some servers emit, e.g. charset="utf-8".
+            return Encoding.GetEncoding(charSet.Trim().Trim('"'));
+        }
+        catch (ArgumentException)
+        {
+            return Encoding.UTF8;
+        }
+    }
+}
+
+/// <summary>
+/// Thrown when an untrusted HTTP response body exceeds the configured byte cap. Treated as a
+/// transport-level failure (the body is discarded; the read is aborted mid-flight).
+/// </summary>
+public sealed class ResponseContentTooLargeException : Exception
+{
+    /// <summary>The byte cap that was exceeded.</summary>
+    public long MaxBytes { get; }
+
+    /// <summary>
+    /// The size that triggered the rejection: the declared <c>Content-Length</c> when rejected up
+    /// front, otherwise the running byte count at the point the cap was crossed.
+    /// </summary>
+    public long ObservedBytes { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ResponseContentTooLargeException"/> class.</summary>
+    public ResponseContentTooLargeException(long maxBytes, long observedBytes)
+        : base($"HTTP response body exceeded the {maxBytes}-byte limit (observed at least {observedBytes} bytes). The response was discarded to prevent excessive memory use.")
+    {
+        MaxBytes = maxBytes;
+        ObservedBytes = observedBytes;
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.OpenAICompat/OllamaCapabilityChecker.cs
+++ b/src/agent/BotNexus.Agent.Providers.OpenAICompat/OllamaCapabilityChecker.cs
@@ -1,4 +1,5 @@
 using BotNexus.Agent.Providers.Core.Compatibility;
+using BotNexus.Agent.Providers.Core.Utilities;
 using System.Net.Http.Json;
 
 namespace BotNexus.Agent.Providers.OpenAICompat;
@@ -46,9 +47,16 @@ public static class OllamaCapabilityChecker
 
             try
             {
-                var response = await httpClient.PostAsJsonAsync(
-                    $"{apiBase}/api/show",
-                    new { name = modelId },
+                // ResponseHeadersRead so the body is NOT pre-buffered — the bounded reader must see the
+                // raw stream to abort an unbounded/hostile body before it is materialized. Build the
+                // request explicitly since PostAsJsonAsync pre-buffers the response.
+                using var request = new HttpRequestMessage(HttpMethod.Post, $"{apiBase}/api/show")
+                {
+                    Content = JsonContent.Create(new { name = modelId })
+                };
+                var response = await httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken).ConfigureAwait(false);
 
                 if (!response.IsSuccessStatusCode)
@@ -57,7 +65,8 @@ public static class OllamaCapabilityChecker
                     return false;
                 }
 
-                var body = await response.Content.ReadFromJsonAsync<OllamaShowResponse>(
+                var body = await BoundedHttpContent.ReadFromJsonWithLimitAsync<OllamaShowResponse>(
+                    response.Content,
                     cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 var supportsTools = body?.Capabilities?.Contains("tools", StringComparer.OrdinalIgnoreCase) == true;

--- a/src/extensions/BotNexus.Extensions.WebTools/Search/BingSearchProvider.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/Search/BingSearchProvider.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using BotNexus.Agent.Providers.Core.Utilities;
 
 namespace BotNexus.Extensions.WebTools.Search;
 
@@ -25,10 +26,14 @@ internal sealed class BingSearchProvider : ISearchProvider
         using var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
         request.Headers.Add("Ocp-Apim-Subscription-Key", _apiKey);
 
-        var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+        // ResponseHeadersRead so the body is NOT pre-buffered by HttpClient — the bounded reader
+        // below must see the raw stream to abort an unbounded/hostile body before it is materialized.
+        var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
-        var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        // The body is an untrusted external search upstream — cap the read so a hostile or
+        // malfunctioning endpoint cannot stream an unbounded body and OOM the gateway.
+        var json = await BoundedHttpContent.ReadStringWithLimitAsync(response.Content, cancellationToken: ct).ConfigureAwait(false);
         using var doc = JsonDocument.Parse(json);
 
         var results = new List<SearchResult>();

--- a/src/extensions/BotNexus.Extensions.WebTools/Search/BraveSearchProvider.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/Search/BraveSearchProvider.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using BotNexus.Agent.Providers.Core.Utilities;
 
 namespace BotNexus.Extensions.WebTools.Search;
 
@@ -27,10 +28,14 @@ internal sealed class BraveSearchProvider : ISearchProvider
         request.Headers.Add("Accept-Encoding", "gzip");
         request.Headers.Add("X-Subscription-Token", _apiKey);
 
-        var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+        // ResponseHeadersRead so the body is NOT pre-buffered by HttpClient — the bounded reader
+        // below must see the raw stream to abort an unbounded/hostile body before it is materialized.
+        var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
-        var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        // The body is an untrusted external search upstream — cap the read so a hostile or
+        // malfunctioning endpoint cannot stream an unbounded body and OOM the gateway.
+        var json = await BoundedHttpContent.ReadStringWithLimitAsync(response.Content, cancellationToken: ct).ConfigureAwait(false);
         using var doc = JsonDocument.Parse(json);
 
         var results = new List<SearchResult>();

--- a/src/extensions/BotNexus.Extensions.WebTools/Search/MicrosoftAiSearchProvider.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/Search/MicrosoftAiSearchProvider.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using BotNexus.Agent.Providers.Core.Utilities;
 
 namespace BotNexus.Extensions.WebTools.Search;
 
@@ -79,10 +80,14 @@ internal sealed class MicrosoftAiSearchProvider : ISearchProvider
         request.Headers.Add("x-apikey", _apiKey);
         request.Content = new StringContent(json, Encoding.UTF8, "application/json");
 
-        var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+        // ResponseHeadersRead so the body is NOT pre-buffered by HttpClient — the bounded reader
+        // below must see the raw stream to abort an unbounded/hostile body before it is materialized.
+        var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
-        var responseJson = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        // The body is an untrusted external search upstream — cap the read so a hostile or
+        // malfunctioning endpoint cannot stream an unbounded body and OOM the gateway.
+        var responseJson = await BoundedHttpContent.ReadStringWithLimitAsync(response.Content, cancellationToken: ct).ConfigureAwait(false);
         using var doc = JsonDocument.Parse(responseJson);
         var root = doc.RootElement;
 

--- a/src/extensions/BotNexus.Extensions.WebTools/Search/TavilySearchProvider.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/Search/TavilySearchProvider.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using BotNexus.Agent.Providers.Core.Utilities;
 
 namespace BotNexus.Extensions.WebTools.Search;
 
@@ -32,10 +33,16 @@ internal sealed class TavilySearchProvider : ISearchProvider
         var json = JsonSerializer.Serialize(requestBody);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-        var response = await _httpClient.PostAsync(ApiEndpoint, content, ct).ConfigureAwait(false);
+        // Use SendAsync with ResponseHeadersRead (PostAsync pre-buffers the body) so the bounded
+        // reader below sees the raw stream and can abort an unbounded/hostile body before it is
+        // materialized.
+        using var request = new HttpRequestMessage(HttpMethod.Post, ApiEndpoint) { Content = content };
+        var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
-        var responseJson = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        // The body is an untrusted external search upstream — cap the read so a hostile or
+        // malfunctioning endpoint cannot stream an unbounded body and OOM the gateway.
+        var responseJson = await BoundedHttpContent.ReadStringWithLimitAsync(response.Content, cancellationToken: ct).ConfigureAwait(false);
         using var doc = JsonDocument.Parse(responseJson);
 
         var results = new List<SearchResult>();

--- a/tests/agent/BotNexus.Agent.Providers.Core.Tests/Utilities/BoundedHttpContentTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Core.Tests/Utilities/BoundedHttpContentTests.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using BotNexus.Agent.Providers.Core.Utilities;
+
+namespace BotNexus.Agent.Providers.Core.Tests.Utilities;
+
+public class BoundedHttpContentTests
+{
+    [Fact]
+    public async Task ReadStringWithLimitAsync_UnderCap_ReturnsBody()
+    {
+        var content = new StringContent("""{"ok":true}""", Encoding.UTF8, "application/json");
+
+        var body = await BoundedHttpContent.ReadStringWithLimitAsync(content, maxBytes: 1024);
+
+        body.ShouldBe("""{"ok":true}""");
+    }
+
+    [Fact]
+    public async Task ReadStringWithLimitAsync_OverCap_ThrowsBeforeBufferingWholeBody()
+    {
+        // A body far larger than the cap. The reader must abort once the running total crosses the
+        // cap, NOT pull the whole advertised body first.
+        var content = new StringContent(new string('a', 4096), Encoding.UTF8, "text/plain");
+
+        var act = async () => await BoundedHttpContent.ReadStringWithLimitAsync(content, maxBytes: 1024);
+
+        var ex = await act.ShouldThrowAsync<ResponseContentTooLargeException>();
+        ex.MaxBytes.ShouldBe(1024);
+    }
+
+    [Fact]
+    public async Task ReadStringWithLimitAsync_DeclaredContentLengthOverCap_RejectsWithoutReadingBody()
+    {
+        // The stream would never end if read; the declared Content-Length must reject up front so
+        // not a single body byte is pulled.
+        using var stream = new NeverEndingStream();
+        var content = new StreamContent(stream);
+        content.Headers.ContentLength = long.MaxValue;
+
+        var act = async () => await BoundedHttpContent.ReadStringWithLimitAsync(content, maxBytes: 1024);
+
+        var ex = await act.ShouldThrowAsync<ResponseContentTooLargeException>();
+        ex.ObservedBytes.ShouldBe(long.MaxValue);
+        // If a body byte had been pulled the test would hang; reaching here proves early rejection.
+        stream.BytesRead.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ReadStringWithLimitAsync_UnboundedNoLengthStream_AbortsMidFlight()
+    {
+        // No Content-Length (chunked / lying endpoint). The streaming read itself must abort once
+        // it has read past the cap — proving we never buffer the whole infinite body.
+        using var stream = new NeverEndingStream();
+        var content = new StreamContent(stream);
+
+        var act = async () => await BoundedHttpContent.ReadStringWithLimitAsync(content, maxBytes: 1024);
+
+        await act.ShouldThrowAsync<ResponseContentTooLargeException>();
+        // Bounded by one chunk past the cap, never the full (infinite) body.
+        stream.BytesRead.ShouldBeLessThan(10L * 1024 * 1024);
+        stream.BytesRead.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task ReadStringWithLimitAsync_HonoursDeclaredCharset()
+    {
+        // Latin-1 'é' (0xE9) — proves we decode with the declared charset, not blindly UTF-8.
+        var bytes = new byte[] { 0xE9 };
+        var content = new ByteArrayContent(bytes);
+        content.Headers.ContentType = new MediaTypeHeaderValue("text/plain") { CharSet = "iso-8859-1" };
+
+        var body = await BoundedHttpContent.ReadStringWithLimitAsync(content, maxBytes: 1024);
+
+        body.ShouldBe("é");
+    }
+
+    [Fact]
+    public async Task ReadFromJsonWithLimitAsync_UnderCap_Deserializes()
+    {
+        var content = new StringContent("""{"value":42}""", Encoding.UTF8, "application/json");
+
+        var result = await BoundedHttpContent.ReadFromJsonWithLimitAsync<Sample>(content, maxBytes: 1024);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task ReadFromJsonWithLimitAsync_OverCap_ThrowsResponseContentTooLarge()
+    {
+        var bigJson = "{\"value\":42,\"pad\":\"" + new string('x', 4096) + "\"}";
+        var content = new StringContent(bigJson, Encoding.UTF8, "application/json");
+
+        var act = async () => await BoundedHttpContent.ReadFromJsonWithLimitAsync<Sample>(content, maxBytes: 1024);
+
+        await act.ShouldThrowAsync<ResponseContentTooLargeException>();
+    }
+
+    [Fact]
+    public async Task ReadFromJsonWithLimitAsync_EmptyBody_ReturnsDefault()
+    {
+        var content = new StringContent(string.Empty, Encoding.UTF8, "application/json");
+
+        var result = await BoundedHttpContent.ReadFromJsonWithLimitAsync<Sample>(content, maxBytes: 1024);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ReadStringWithLimitAsync_NonPositiveCap_Throws()
+    {
+        var content = new StringContent("x");
+
+        var act = async () => await BoundedHttpContent.ReadStringWithLimitAsync(content, maxBytes: 0);
+
+        await act.ShouldThrowAsync<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void DefaultMaxResponseBytes_Is16MiB()
+    {
+        BoundedHttpContent.DefaultMaxResponseBytes.ShouldBe(16L * 1024 * 1024);
+    }
+
+    private sealed class Sample
+    {
+        public int Value { get; set; }
+    }
+
+    /// <summary>
+    /// A read stream that returns bytes forever — stands in for a hostile endpoint streaming an
+    /// unbounded body. Records how many bytes were actually pulled so a test can prove the bounded
+    /// reader aborted instead of draining it.
+    /// </summary>
+    private sealed class NeverEndingStream : Stream
+    {
+        public long BytesRead { get; private set; }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            Array.Fill(buffer, (byte)'a', offset, count);
+            BytesRead += count;
+            return count;
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            buffer.Span.Fill((byte)'a');
+            BytesRead += buffer.Length;
+            return ValueTask.FromResult(buffer.Length);
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/tests/agent/BotNexus.Agent.Providers.OpenAICompat.Tests/OllamaCapabilityCheckerTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.OpenAICompat.Tests/OllamaCapabilityCheckerTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using BotNexus.Agent.Providers.OpenAICompat;
+
+namespace BotNexus.Agent.Providers.OpenAICompat.Tests;
+
+/// <summary>
+/// Covers the bounded read + case-insensitive deserialization of the Ollama <c>/api/show</c>
+/// capability probe (see <c>BoundedHttpContent</c>). Each test uses a unique base URL because the
+/// checker caches results in a process-wide static dictionary keyed on base URL + model.
+/// </summary>
+public class OllamaCapabilityCheckerTests
+{
+    [Fact]
+    public async Task SupportsToolsAsync_WithLowercaseCapabilitiesField_ReturnsTrue()
+    {
+        // Ollama returns lowercase JSON ("capabilities"); the bounded reader must keep the
+        // case-insensitive (web-default) matching that ReadFromJsonAsync provided.
+        var handler = new StubHandler(HttpStatusCode.OK, """{"capabilities":["completion","tools"]}""");
+        var client = new HttpClient(handler);
+
+        var result = await OllamaCapabilityChecker.SupportsToolsAsync(
+            client, "http://ollama-lowercase-1:11434/v1", "llama3.1", CancellationToken.None);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task SupportsToolsAsync_WithoutToolsCapability_ReturnsFalse()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK, """{"capabilities":["completion"]}""");
+        var client = new HttpClient(handler);
+
+        var result = await OllamaCapabilityChecker.SupportsToolsAsync(
+            client, "http://ollama-notools-1:11434/v1", "llama3.1", CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task SupportsToolsAsync_WithUnboundedResponseBody_DegradesToFalseWithoutOom()
+    {
+        // A hostile/misbehaving endpoint streaming an unbounded body must be aborted by the bounded
+        // reader; the checker's catch then yields the safe default (no tools) rather than OOMing.
+        using var stream = new NeverEndingStream();
+        var handler = new StreamingStubHandler(stream);
+        var client = new HttpClient(handler);
+
+        var result = await OllamaCapabilityChecker.SupportsToolsAsync(
+            client, "http://ollama-unbounded-1:11434/v1", "llama3.1", CancellationToken.None);
+
+        result.ShouldBeFalse();
+        // Never drained the infinite body — bounded to roughly the cap plus one chunk.
+        stream.BytesRead.ShouldBeLessThan(
+            BotNexus.Agent.Providers.Core.Utilities.BoundedHttpContent.DefaultMaxResponseBytes + (1024L * 1024));
+    }
+
+    [Fact]
+    public async Task SupportsToolsAsync_WithNonSuccessStatus_ReturnsFalse()
+    {
+        var handler = new StubHandler(HttpStatusCode.NotFound, """{"error":"model not found"}""");
+        var client = new HttpClient(handler);
+
+        var result = await OllamaCapabilityChecker.SupportsToolsAsync(
+            client, "http://ollama-404-1:11434/v1", "missing", CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json")
+            });
+    }
+
+    private sealed class StreamingStubHandler(Stream stream) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                // No Content-Length — forces the streaming read path to enforce the cap.
+                Content = new StreamContent(stream)
+            });
+    }
+
+    private sealed class NeverEndingStream : Stream
+    {
+        public long BytesRead { get; private set; }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            Array.Fill(buffer, (byte)'a', offset, count);
+            BytesRead += count;
+            return count;
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            buffer.Span.Fill((byte)'a');
+            BytesRead += buffer.Length;
+            return ValueTask.FromResult(buffer.Length);
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.WebTools.Tests/Search/BraveSearchProviderTests.cs
+++ b/tests/extensions/BotNexus.Extensions.WebTools.Tests/Search/BraveSearchProviderTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using BotNexus.Agent.Providers.Core.Utilities;
 using BotNexus.Extensions.WebTools.Search;
 using BotNexus.Extensions.WebTools.Tests.Helpers;
 
@@ -81,5 +82,64 @@ public class BraveSearchProviderTests
         var results = await provider.SearchAsync("query", 5, CancellationToken.None);
         results.ShouldBeEmpty();
         handler.Requests.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithUnboundedResponseBody_AbortsBeforeOom()
+    {
+        // A hostile/misbehaving search upstream streaming an unbounded body must be aborted by the
+        // bounded reader rather than buffered whole. Proves the provider routes through the cap.
+        using var stream = new NeverEndingStream();
+        var handler = new StreamingResponseHandler(stream);
+        var provider = new BraveSearchProvider(new HttpClient(handler), "api-key");
+
+        var act = () => provider.SearchAsync("query", 5, CancellationToken.None);
+
+        await act.ShouldThrowAsync<ResponseContentTooLargeException>();
+        // Far less than the 16 MiB default cap's worth past one chunk — never the infinite body.
+        stream.BytesRead.ShouldBeLessThan(BoundedHttpContent.DefaultMaxResponseBytes + (1024L * 1024));
+    }
+
+    private sealed class StreamingResponseHandler(Stream stream) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // No Content-Length — forces the streaming read path to enforce the cap.
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(stream)
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class NeverEndingStream : Stream
+    {
+        public long BytesRead { get; private set; }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            Array.Fill(buffer, (byte)'a', offset, count);
+            BytesRead += count;
+            return count;
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            buffer.Span.Fill((byte)'a');
+            BytesRead += buffer.Length;
+            return ValueTask.FromResult(buffer.Length);
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
Closes #1595

## Summary
Untrusted external HTTP JSON responses (web-search upstreams + Ollama model discovery) were read with `ReadAsStringAsync` / `ReadFromJsonAsync` and **no byte cap**, so a hostile or malfunctioning endpoint could stream an unbounded body and OOM the gateway before the payload was parsed (availability/DoS). Verified against `a82a89dd`: there is no `MaxResponseContentBufferSize` cap anywhere in the codebase.

This is the BotNexus counterpart of OpenClaw's `readProviderJsonResponse` / `readResponseWithLimit` campaign (16 MiB shared cap), adapted to .NET `HttpContent`.

## Changes
- **New shared helper** `BotNexus.Agent.Providers.Core.Utilities.BoundedHttpContent` (referenced by both WebTools and OpenAICompat):
  - `ReadStringWithLimitAsync` / `ReadFromJsonWithLimitAsync<T>` read the response **stream** incrementally and abort with a typed `ResponseContentTooLargeException` the moment a declared `Content-Length` **or** the running byte count crosses the cap (default **16 MiB**) — without ever buffering the whole body.
  - The JSON read defaults to **web (case-insensitive)** serializer options, matching `ReadFromJsonAsync`'s prior binding behaviour (so e.g. Ollama's lowercase `capabilities` field still binds).
- **Routed the four search providers** (`Brave` / `Tavily` / `Bing` / `MicrosoftAi`) and the **Ollama capability checker** through the bounded reader.
- **Switched those requests to `HttpCompletionOption.ResponseHeadersRead`** so `HttpClient` no longer pre-buffers the body before our code sees it — without this the cap is cosmetic (HttpClient would already have buffered the whole payload).

## Tests
- `BoundedHttpContentTests` (10): under/over cap, **streaming over-cap aborts mid-flight** (never drains an infinite body), declared `Content-Length` over cap **rejected without pulling a single body byte**, charset decoding honoured, empty body, JSON happy/over-cap.
- `BraveSearchProviderTests` (+1): an unbounded streaming search response surfaces `ResponseContentTooLargeException` and never drains the infinite body — proves the provider routes through the cap.
- `OllamaCapabilityCheckerTests` (4, new): lowercase `capabilities` → true (locks the case-insensitivity), over-cap body **degrades to the safe ""no tools"" default** without OOM, non-success → false.
- `test-impacted.ps1` green (Architecture + Scenarios always-run + Providers.Core 320 / OpenAICompat 54 / WebTools 138). Full pre-commit suite (solution build + all unit/integration projects) also passed.

## Merge Notes
Fully independent of the four open PRs — touches only `BotNexus.Extensions.WebTools/Search/*`, `OllamaCapabilityChecker.cs`, and the new `Providers.Core.Utilities` helper. Zero file overlap with #1601 (Qmd), #1594 / #1590 (Telegram), or #1593 (docs). Safe to merge in any order. No config or public-API surface change; the 16 MiB cap is an internal constant.