### PR TITLE
feat(sessions): trigger compaction on oversized single entries

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -715,7 +715,39 @@ Large tool results (for example a recursive directory listing or a session-histo
 | `toolResultPersistence.enabled` | bool | `true` | Enables the write-time tool-result size cap. |
 | `toolResultPersistence.maxBytes` | int | 16384 (16 KiB) | Maximum UTF-8 byte size of a single persisted tool result. Larger results are truncated with a `[truncated N bytes]` marker. A value of 0 or less disables truncation even when `enabled` is true. |
 
-The section is optional — when absent, the default 16 KiB cap is applied. This is independent of (and complementary to) session compaction: the cap prevents oversized results from ever being persisted, while compaction summarises accumulated context over time.
+The section is optional - when absent, the default 16 KiB cap is applied. This is independent of (and complementary to) session compaction: the cap prevents oversized results from ever being persisted, while compaction summarises accumulated context over time.
+
+
+#### Session Compaction
+
+The `compaction` section tunes when and how a session's history is summarised to stay within the model's context window. Compaction is triggered when **either** of two signals trips (whichever fires first):
+
+- **Token-count threshold** — the estimated LLM-visible token total exceeds `contextWindowTokens × tokenThresholdRatio`.
+- **Bloat-aware (largest-entry) threshold** — a *single* visible history entry is at or above `largestEntryBytesThreshold` UTF-8 bytes. A session can accumulate a small number of enormous low-value entries (for example a raw transcript dump or a directory listing) whose total still sits under the token threshold while the visible tail is dominated by dead weight; this signal makes such a session eligible for compaction so the oversized entry gets summarised away instead of being re-sent on every turn.
+
+```json
+{
+  "gateway": {
+    "compaction": {
+      "preservedTurns": 3,
+      "tokenThresholdRatio": 0.6,
+      "contextWindowTokens": 128000,
+      "largestEntryBytesThreshold": 65536
+    }
+  }
+}
+```
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `preservedTurns` | int | 3 | Number of most recent user turns preserved verbatim (never summarised). |
+| `maxSummaryChars` | int | 16000 | Maximum characters for the compaction summary. |
+| `tokenThresholdRatio` | double | 0.6 | Fraction of the context window (0.0–1.0) at which the token-count trigger fires. |
+| `contextWindowTokens` | int | 128000 | Approximate context window size (tokens) used for the token-count trigger. |
+| `largestEntryBytesThreshold` | int | 65536 (64 KiB) | A single visible entry at or above this UTF-8 byte size triggers compaction on its own, independently of the token-count threshold. Measured in bytes (not characters) so multibyte payloads are accounted for accurately. A value of 0 or less disables the bloat-aware trigger, leaving only the token-count threshold. |
+| `circuitBreakerCooldownSeconds` | int | 600 | How long the per-session compaction circuit breaker stays open after repeated failures before retrying. |
+
+The section is optional — when absent, the defaults above apply. The bloat-aware trigger complements [Tool Result Persistence](#tool-result-persistence): write-time truncation prevents most oversized entries from ever being persisted, while the bloat-aware trigger ensures any already-accumulated (or un-capped) large entry still becomes eligible for summarisation.
 
 
 #### Shell Execution Settings

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionOptions.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionOptions.cs
@@ -19,6 +19,19 @@ public sealed record CompactionOptions
     /// <summary>Approximate context window size in tokens for the model (default: 128000).</summary>
     public int ContextWindowTokens { get; init; } = 128_000;
 
+    /// <summary>
+    /// Per-entry size (in UTF-8 bytes) at or above which a single visible history entry makes the
+    /// session eligible for compaction, independently of the token-count threshold (#1599 — bloat-aware
+    /// trigger). A session can accumulate a small number of enormous low-value entries (e.g. a raw
+    /// transcript dump or a directory listing) whose total still sits under <see cref="TokenThresholdRatio"/>
+    /// while the visible tail is dominated by dead weight. This signal is <b>additive</b>: whichever of the
+    /// token-count threshold or this per-entry byte threshold trips first triggers compaction. Only
+    /// LLM-visible entries are considered (historical / already-summarised entries are excluded, exactly
+    /// like the token trigger). Default: 65536 (64 KiB). Values &lt;= 0 disable the byte-based trigger,
+    /// restoring the pre-#1599 token-count-only behaviour.
+    /// </summary>
+    public int LargestEntryBytesThreshold { get; init; } = 65_536;
+
     /// <summary>Model to use for summarization. If null, uses the session's model.</summary>
     public string? SummarizationModel { get; init; }
 

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -94,6 +94,7 @@ public static class GatewayServiceCollectionExtensions
                     MaxSummaryChars = ParseInt(compactionSection["maxSummaryChars"], new CompactionOptions().MaxSummaryChars),
                     TokenThresholdRatio = ParseDouble(compactionSection["tokenThresholdRatio"], new CompactionOptions().TokenThresholdRatio),
                     ContextWindowTokens = ParseInt(compactionSection["contextWindowTokens"], new CompactionOptions().ContextWindowTokens),
+                    LargestEntryBytesThreshold = ParseInt(compactionSection["largestEntryBytesThreshold"], new CompactionOptions().LargestEntryBytesThreshold),
                     SummarizationModel = ParseString(compactionSection["summarizationModel"], new CompactionOptions().SummarizationModel),
                     SummarizationProvider = ParseString(compactionSection["summarizationProvider"], new CompactionOptions().SummarizationProvider),
                     CircuitBreakerCooldownSeconds = ParseInt(compactionSection["circuitBreakerCooldownSeconds"], new CompactionOptions().CircuitBreakerCooldownSeconds)

--- a/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
@@ -76,16 +76,28 @@ public sealed class LlmSessionCompactor : ISessionCompactor
     {
         var estimatedTokens = EstimateVisibleTokenCount(session);
         var threshold = (int)(options.ContextWindowTokens * options.TokenThresholdRatio);
-        var shouldCompact = estimatedTokens > threshold;
+        var tokenTrigger = estimatedTokens > threshold;
+
+        // #1599: bloat-aware trigger. A session can be dominated by a small number of enormous
+        // low-value entries (e.g. a raw transcript dump) whose total still sits under the token
+        // threshold. Make a single oversized *visible* entry eligible for compaction on its own.
+        // Additive: whichever of the token-count or per-entry-byte signal trips first wins.
+        var (bloatTrigger, largestEntryBytes) = EvaluateLargestVisibleEntryBytes(session, options.LargestEntryBytesThreshold);
+
+        var shouldCompact = tokenTrigger || bloatTrigger;
 
         _logger.LogDebug(
             "ShouldCompact check for session {SessionId}: estimated {EstimatedTokens} tokens, " +
-            "threshold {Threshold} (window {Window} * ratio {Ratio}), result: {ShouldCompact}",
+            "threshold {Threshold} (window {Window} * ratio {Ratio}), largestVisibleEntry {LargestBytes} bytes " +
+            "(byteThreshold {ByteThreshold}, bloatTrigger {BloatTrigger}), result: {ShouldCompact}",
             session.SessionId,
             estimatedTokens,
             threshold,
             options.ContextWindowTokens,
             options.TokenThresholdRatio,
+            largestEntryBytes,
+            options.LargestEntryBytesThreshold,
+            bloatTrigger,
             shouldCompact);
 
         return shouldCompact;
@@ -745,6 +757,46 @@ public sealed class LlmSessionCompactor : ISessionCompactor
             .Where(SessionContextProjector.IsVisibleInLiveContext)
             .Sum(entry => (long)(entry.Content?.Length ?? 0));
         return (int)Math.Min(totalChars / 4, int.MaxValue);
+    }
+
+    /// <summary>
+    /// #1599 bloat-aware trigger: finds the largest single LLM-visible entry by UTF-8 byte size and
+    /// reports whether it meets or exceeds <paramref name="thresholdBytes"/>. Only visible entries are
+    /// considered (historical / already-summarised entries are hidden from the LLM and excluded, matching
+    /// the token-count trigger). UTF-8 bytes are measured rather than UTF-16 char count so multibyte
+    /// payloads (which cost more real context) are accounted for accurately. A threshold &lt;= 0 disables
+    /// the signal entirely (returns <c>(false, 0)</c>) without scanning, preserving pre-#1599 behaviour.
+    /// </summary>
+    /// <returns>A tuple of (whether the bloat trigger fires, the largest visible entry's byte size).</returns>
+    private static (bool exceeds, long largestBytes) EvaluateLargestVisibleEntryBytes(Session session, int thresholdBytes)
+    {
+        if (thresholdBytes <= 0)
+        {
+            return (false, 0);
+        }
+
+        long largest = 0;
+        foreach (var entry in session.History)
+        {
+            if (!SessionContextProjector.IsVisibleInLiveContext(entry))
+            {
+                continue;
+            }
+
+            var content = entry.Content;
+            if (string.IsNullOrEmpty(content))
+            {
+                continue;
+            }
+
+            var bytes = Encoding.UTF8.GetByteCount(content);
+            if (bytes > largest)
+            {
+                largest = bytes;
+            }
+        }
+
+        return (largest >= thresholdBytes, largest);
     }
 
     /// <summary>

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
@@ -441,8 +441,17 @@ public sealed class LlmSessionCompactorTests
             ("user", new string('a', 100_000)),
             ("assistant", new string('b', 100_000)));
         var compactor = CreateCompactor("summary");
-        // Set threshold high enough that the session should NOT trigger compaction
-        var options = new CompactionOptions { ContextWindowTokens = 1_000_000, TokenThresholdRatio = 0.5 };
+        // Set threshold high enough that the session should NOT trigger compaction.
+        // #1599: disable the bloat-aware per-entry byte trigger here so this test isolates the
+        // TOKEN-count path only — each 100K-char ASCII entry is ~97.6 KiB, which would otherwise
+        // (correctly) trip the default 64 KiB largest-entry trigger. The bloat-aware trigger is
+        // covered by its own dedicated tests above.
+        var options = new CompactionOptions
+        {
+            ContextWindowTokens = 1_000_000,
+            TokenThresholdRatio = 0.5,
+            LargestEntryBytesThreshold = 0
+        };
         // 200K chars / 4 = 50K estimated tokens < 500K threshold
         compactor.ShouldCompact(session.Session, options).ShouldBeFalse();
     }
@@ -630,6 +639,137 @@ public sealed class LlmSessionCompactorTests
 
         compactor.ShouldCompact(session.Session, options).ShouldBeFalse(
             "historical entries must not contribute to the token budget");
+    }
+
+    // ─── Issue #1599: bloat-aware compaction trigger (byte / largest-entry) ──────────
+
+    /// <summary>
+    /// #1599 core: a single oversized low-value entry must make the session eligible for
+    /// compaction even when the global token-count threshold is nowhere near crossed. The
+    /// canonical failure (live session 5ae3d91c) had ~51K tokens (below the token trigger)
+    /// but two rows carrying 117 KB of dead weight — compaction never fired.
+    /// </summary>
+    [Fact]
+    public void ShouldCompact_OversizedSingleEntry_BelowTokenThreshold_TriggersOnBytes()
+    {
+        var session = CreateSession(
+            ("user", "tiny"),
+            ("assistant", "also tiny"),
+            ("tool", new string('x', 70 * 1024)),   // 70 KiB single dead-weight tool result
+            ("user", "latest"));
+        var compactor = CreateCompactor("summary");
+        // Huge context window so the token-count trigger is NOT crossed: ~70 KiB / 4 ≈ 17.9K tokens,
+        // threshold = 1,000,000 * 0.5 = 500,000 tokens. Token path alone would return false.
+        var options = new CompactionOptions
+        {
+            ContextWindowTokens = 1_000_000,
+            TokenThresholdRatio = 0.5,
+            LargestEntryBytesThreshold = 64 * 1024
+        };
+
+        compactor.ShouldCompact(session.Session, options).ShouldBeTrue(
+            "a single >64 KiB visible entry must trigger the bloat-aware path even below the token threshold");
+    }
+
+    /// <summary>
+    /// #1599: the byte-aware trigger must be visibility-aware, exactly like the token trigger —
+    /// an oversized entry that is already historical (folded into a prior summary) is hidden
+    /// from the LLM and must NOT re-trigger compaction.
+    /// </summary>
+    [Fact]
+    public void ShouldCompact_OversizedHistoricalEntry_DoesNotTriggerOnBytes()
+    {
+        var session = CreateSession(("user", "tiny"));
+        var entries = new List<SessionEntry>
+        {
+            new() { Role = MessageRole.Tool, Content = new string('x', 70 * 1024), IsHistory = true },
+            new() { Role = MessageRole.System, Content = "summary", IsCompactionSummary = true },
+            new() { Role = MessageRole.User, Content = "tiny" }
+        };
+        session.ReplaceHistory(entries);
+        var compactor = CreateCompactor("summary");
+        var options = new CompactionOptions
+        {
+            ContextWindowTokens = 1_000_000,
+            TokenThresholdRatio = 0.5,
+            LargestEntryBytesThreshold = 64 * 1024
+        };
+
+        compactor.ShouldCompact(session.Session, options).ShouldBeFalse(
+            "a historical oversized entry is hidden from the LLM and must not trigger the bloat path");
+    }
+
+    /// <summary>
+    /// #1599: the bloat-aware trigger is opt-out via threshold &lt;= 0. With it disabled, an
+    /// oversized entry below the token threshold must NOT trigger (preserves pre-#1599 behavior).
+    /// </summary>
+    [Fact]
+    public void ShouldCompact_BloatThresholdDisabled_DoesNotTriggerOnBytes()
+    {
+        var session = CreateSession(
+            ("user", "tiny"),
+            ("tool", new string('x', 70 * 1024)),
+            ("user", "latest"));
+        var compactor = CreateCompactor("summary");
+        var options = new CompactionOptions
+        {
+            ContextWindowTokens = 1_000_000,
+            TokenThresholdRatio = 0.5,
+            LargestEntryBytesThreshold = 0   // disabled
+        };
+
+        compactor.ShouldCompact(session.Session, options).ShouldBeFalse(
+            "with the bloat threshold disabled, only the token-count trigger applies");
+    }
+
+    /// <summary>
+    /// #1599: no false positives — many small entries that are individually well under the byte
+    /// threshold and collectively under the token threshold must NOT trigger. The bloat path only
+    /// fires on a genuinely oversized single entry, never on an accumulation of normal-sized ones.
+    /// </summary>
+    [Fact]
+    public void ShouldCompact_AllEntriesUnderByteThreshold_BelowTokenThreshold_ReturnsFalse()
+    {
+        var entries = Enumerable.Range(0, 20)
+            .Select(i => (i % 2 == 0 ? "user" : "assistant", new string('a', 1024)))
+            .ToArray();
+        var session = CreateSession(entries);
+        var compactor = CreateCompactor("summary");
+        var options = new CompactionOptions
+        {
+            ContextWindowTokens = 1_000_000,
+            TokenThresholdRatio = 0.5,
+            LargestEntryBytesThreshold = 64 * 1024
+        };
+
+        compactor.ShouldCompact(session.Session, options).ShouldBeFalse(
+            "normal-sized entries under the per-entry byte threshold must not trip the bloat path");
+    }
+
+    /// <summary>
+    /// #1599: the bloat trigger measures UTF-8 BYTES, not UTF-16 char count. A multibyte payload
+    /// whose char count is below the threshold but whose byte count exceeds it must trigger.
+    /// (e.g. the Japanese character あ is 3 UTF-8 bytes; 24K of them = 24K chars but ~72 KiB.)
+    /// </summary>
+    [Fact]
+    public void ShouldCompact_OversizedEntry_MeasuresUtf8Bytes_NotCharCount()
+    {
+        // 24,000 chars of a 3-byte character = 24K chars (< 64K char) but ~72 KiB (> 64 KiB byte).
+        var multibyte = new string('あ', 24_000);
+        var session = CreateSession(
+            ("user", "tiny"),
+            ("tool", multibyte),
+            ("user", "latest"));
+        var compactor = CreateCompactor("summary");
+        var options = new CompactionOptions
+        {
+            ContextWindowTokens = 1_000_000,
+            TokenThresholdRatio = 0.5,
+            LargestEntryBytesThreshold = 64 * 1024
+        };
+
+        compactor.ShouldCompact(session.Session, options).ShouldBeTrue(
+            "a multibyte entry under the char threshold but over the byte threshold must trigger");
     }
 
     // ─── Issue #665: Session compactor continuity audit ──────────────────────


### PR DESCRIPTION
Closes #1599

Part of #1551 — **Part B2: make compaction bloat-aware (byte / largest-entry-aware trigger).**

## Problem
On the live session in #1551 (`5ae3d91c`), `is_compaction_summary = 0` across all 90 history rows — compaction **never fired** — because the ~51K raw-token total had not crossed the token-count trigger, **even though two individual rows carried 117 KB of dead weight** (an 83 KB transcript dump + a 33 KB directory listing). A session can accumulate a small number of enormous useless single entries without ever tripping compaction, then re-send that dead weight to the model on every subsequent turn.

The compaction trigger (`LlmSessionCompactor.ShouldCompact`) keyed **only** on `estimatedTokens > contextWindowTokens × tokenThresholdRatio`. There was no per-entry / total-bytes signal.

## Changes
- **`CompactionOptions.LargestEntryBytesThreshold`** (new, default `65536` = 64 KiB; `<= 0` disables). A single LLM-visible entry at or above this UTF-8 byte size makes the session eligible for compaction on its own.
- **`ShouldCompact`** now ORs in the bloat-aware signal: `tokenTrigger || bloatTrigger`. The two are **additive** — whichever condition trips first triggers compaction. The existing token-count trigger is unchanged.
- New private helper **`EvaluateLargestVisibleEntryBytes`**: scans only LLM-visible entries (historical / already-summarised entries are excluded, exactly like the token trigger) and measures **UTF-8 bytes** (not UTF-16 char count) so multibyte payloads are accounted for accurately. Threshold `<= 0` short-circuits without scanning, preserving pre-#1599 behaviour. The `ShouldCompact` debug log now reports the largest visible entry size and which signal fired.
- Config binding: `gateway:compaction:largestEntryBytesThreshold` wired in `GatewayServiceCollectionExtensions`.
- Docs: new **Session Compaction** section in `docs/configuration.md` documenting both triggers and the full `compaction` config table.

### On acceptance criterion 3 ("prune the largest first")
Once the trigger fires, the existing `SplitHistory` path already summarises the **older** portion of the visible history (everything before the last *N* user turns) — which is exactly where an accumulated oversized tool result sits — so the bloat gets collapsed into the summary by the established summarisation pass. The genuinely-missing piece was the **trigger** (a bloated-but-below-token-threshold session was never becoming eligible at all); that is what this PR adds. No `SplitHistory` rewrite was needed to shed the bloat.

## Tests (TDD — written first)
New tests in `LlmSessionCompactorTests` (region `#1599`):
- `ShouldCompact_OversizedSingleEntry_BelowTokenThreshold_TriggersOnBytes` — the core defect: a 70 KiB tool result below the token threshold now triggers.
- `ShouldCompact_OversizedHistoricalEntry_DoesNotTriggerOnBytes` — visibility-aware: an oversized `IsHistory` entry must NOT re-trigger.
- `ShouldCompact_BloatThresholdDisabled_DoesNotTriggerOnBytes` — `threshold = 0` opt-out preserves pre-#1599 behaviour.
- `ShouldCompact_AllEntriesUnderByteThreshold_BelowTokenThreshold_ReturnsFalse` — no false positives from an accumulation of normal-sized entries.
- `ShouldCompact_OversizedEntry_MeasuresUtf8Bytes_NotCharCount` — proves byte (not char) measurement via a 3-byte multibyte payload under the char threshold but over the byte threshold.

One pre-existing test (`ShouldCompact_LargeSessionBelowThreshold_ReturnsFalse`) was scoped to set `LargestEntryBytesThreshold = 0` with a comment: its two 100K-char (~97.6 KiB) entries now *correctly* trip the bloat trigger, so the test was narrowed to isolate the token-count dimension it was written to exercise (the bloat dimension is covered by the new dedicated tests). No assertion was weakened or suppressed.

`scripts/repo/test-impacted.ps1` green: Architecture 212, Scenarios 29, Gateway.Tests 3214 (0 fail), + 16 other impacted projects.

## Merge Notes
Single-component change (`BotNexus.Gateway.Sessions` compactor + `Gateway.Contracts` options + gateway config wiring + docs). No file overlap with the only other open PR (#1606, Telegram). Complements the already-merged Part B1 (#1598/PR #1605, write-time tool-result cap): B1 prevents most oversized entries from ever being persisted; B2 ensures any already-accumulated or un-capped large entry still becomes eligible for summarisation. Safe to merge in any order relative to #1606.
