### PR TITLE
docs: backfill v0.10.1 release page

### DIFF
--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -9,7 +9,8 @@ Browse the full version history of BotNexus. Each release page includes the full
 
 | Version | Date | |
 |---------|------|---|
-| **[v0.10.0](v0.10.0/)** | 2026-06-24 | ← Latest |
+| **[v0.10.1](v0.10.1/)** | 2026-06-24 | ← Latest |
+| [v0.10.0](v0.10.0/) | 2026-06-24 | |
 | [v0.9.0](v0.9.0/) | 2026-06-23 | |
 | [v0.8.1](v0.8.1/) | 2026-06-20 | |
 | [v0.8.0](v0.8.0/) | 2026-06-17 | |

--- a/docs/releases/v0.10.1/index.md
+++ b/docs/releases/v0.10.1/index.md
@@ -1,0 +1,23 @@
+---
+title: "Release v0.10.1"
+description: "Release notes for BotNexus v0.10.1"
+date: "2026-06-24"
+---
+
+# Release v0.10.1
+
+> **Released:** 2026-06-24
+>
+> **Full diff:** [v0.10.0...v0.10.1](https://github.com/sytone/botnexus/compare/v0.10.0...v0.10.1)
+
+## [0.10.1] - 2026-06-24
+
+### 🐛 Bug Fixes
+
+- **gateway:** Build session summaries without loading transcripts (#1581) (#1582)
+- **channels:** Route Telegram streaming replies by agent in multi-bot mode (#1583) (#1584)
+- **portal:** Serve Blazor assets compressed and stop shipping stale generations (#1586)
+- **channels:** Treat Telegram 'message is not modified' as benign no-op (#1588)
+
+[0.10.1]: https://github.com/sytone/botnexus/compare/v0.10.0...v0.10.1
+


### PR DESCRIPTION
## Changes

Backfills the missing **v0.10.1** release page. The `v0.10.1` tag was cut at `08c792df` outside the `release-cli.yml` workflow (by the daily build-validation cron), so the workflow's git-cliff release-page generation was skipped — `docs/releases/v0.10.1/` did not exist on `main`.

## New pages

- `docs/releases/v0.10.1/index.md` — generated to match git-cliff output exactly. Contains the 4 `fix` commits between `v0.10.0` and `v0.10.1`:
  - **gateway:** Build session summaries without loading transcripts (#1581) (#1582)
  - **channels:** Route Telegram streaming replies by agent in multi-bot mode (#1583) (#1584)
  - **portal:** Serve Blazor assets compressed and stop shipping stale generations (#1586)
  - **channels:** Treat Telegram 'message is not modified' as benign no-op (#1588)

## Content fixes

- `docs/releases/index.md` — added the `v0.10.1` row at the top of the version table and moved the `← Latest` marker from v0.10.0 to v0.10.1 (v0.10.0 dropped to a plain row). Chain stays version-descending: `v0.10.1 → v0.10.0 → v0.9.0 → …`.

## Validation

- Generator byte-matched (SHA256) against the genuine workflow-generated `v0.10.0` page before being trusted for v0.10.1.
- New page is UTF-8 no-BOM, LF-only, ends with a trailing blank line (matches genuine git-cliff); the `🐛 Bug Fixes` heading and `← Latest` arrow are genuine UTF-8 (mojibake gate clean — `sig=0`, `box-in-prose=0` on both changed files).
- `npm run docs:build` (VitePress) passes — 0 dead links, 0 config errors.

## Audit (no other changes needed this run)

- Providers / extensions / channels: all current surface documented — no new pages owed.
- SignalR hub contract: in sync (24 server events / 11 client methods all present).
- CLI reference: no drift — no merge since the last run touched any `Commands/*.cs`.
- Config docs: `richMessages` / `maxRichMessageLength` (#1594) and Tool Result Persistence (#1605) already landed with their PRs in `main`; no gap.

---
Automated by the daily documentation groomer.
