### PR TITLE
perf(blazor-client): coalesce streamed-delta renders and use StringBuilder buffers

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IClientStateStore.cs
@@ -14,6 +14,15 @@ public interface IClientStateStore
     /// <summary>Fire <see cref="OnChanged"/> to trigger UI re-render.</summary>
     void NotifyChanged();
 
+    /// <summary>
+    /// Request a UI re-render via <see cref="OnChanged"/>, time-coalesced for the high-frequency
+    /// streaming-delta path: a burst of calls collapses to at most one render per throttle window
+    /// so a long streamed response does not trigger one re-render per token (#1620). Use this only
+    /// for content/thinking deltas; discrete lifecycle events must use <see cref="NotifyChanged"/>
+    /// so they are never delayed.
+    /// </summary>
+    void NotifyChangedThrottled();
+
     // ── Agent-level ──────────────────────────────────────────────────────────
 
     /// <summary>All known agents keyed by agent ID.</summary>
@@ -334,11 +343,51 @@ public sealed class ConversationStreamState
     /// </remarks>
     public bool IsRunActive { get; set; }
 
-    /// <summary>Accumulated content delta buffer during streaming.</summary>
-    public string Buffer { get; set; } = "";
+    /// <summary>Accumulated content delta buffer during streaming. Backed by a
+    /// <see cref="System.Text.StringBuilder"/> so accumulating thousands of streamed deltas via
+    /// <see cref="AppendBuffer"/> is amortised O(1) per delta rather than an O(n) copy of the
+    /// growing reply on every token (#1620). The setter replaces the whole buffer (used for test
+    /// seeding and bulk resets) and is NOT on the streaming hot path.</summary>
+    public string Buffer
+    {
+        get => _buffer.ToString();
+        set { _buffer.Clear(); if (!string.IsNullOrEmpty(value)) _buffer.Append(value); }
+    }
 
-    /// <summary>Accumulated thinking-content buffer during streaming.</summary>
-    public string ThinkingBuffer { get; set; } = "";
+    /// <summary>Accumulated thinking-content buffer during streaming. Backed by a
+    /// <see cref="System.Text.StringBuilder"/> for the same reason as <see cref="Buffer"/>.</summary>
+    public string ThinkingBuffer
+    {
+        get => _thinkingBuffer.ToString();
+        set { _thinkingBuffer.Clear(); if (!string.IsNullOrEmpty(value)) _thinkingBuffer.Append(value); }
+    }
+
+    private readonly System.Text.StringBuilder _buffer = new();
+    private readonly System.Text.StringBuilder _thinkingBuffer = new();
+
+    /// <summary>Append a content delta to <see cref="Buffer"/>. A <see langword="null"/>
+    /// delta is treated as empty. O(1) amortised -- does not copy the accumulated reply.</summary>
+    public void AppendBuffer(string? delta)
+    {
+        if (!string.IsNullOrEmpty(delta))
+            _buffer.Append(delta);
+    }
+
+    /// <summary>Append a thinking-content delta to <see cref="ThinkingBuffer"/>. A
+    /// <see langword="null"/> delta is treated as empty. O(1) amortised.</summary>
+    public void AppendThinking(string? delta)
+    {
+        if (!string.IsNullOrEmpty(delta))
+            _thinkingBuffer.Append(delta);
+    }
+
+    /// <summary>Clear the content and thinking buffers without touching the streaming flags.
+    /// Used at the start of a fresh streamed message (<see cref="IsStreaming"/> stays asserted).</summary>
+    public void ClearBuffers()
+    {
+        _buffer.Clear();
+        _thinkingBuffer.Clear();
+    }
 
     /// <summary>In-progress tool calls for this conversation keyed by tool-call ID.</summary>
     public Dictionary<string, ActiveToolCall> ActiveToolCalls { get; } = new();
@@ -361,8 +410,8 @@ public sealed class ConversationStreamState
     public void Reset()
     {
         IsStreaming = false;
-        Buffer = "";
-        ThinkingBuffer = "";
+        _buffer.Clear();
+        _thinkingBuffer.Clear();
     }
 
     /// <summary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
@@ -10,6 +10,21 @@ public sealed class ClientStateStore : IClientStateStore
     private readonly Dictionary<string, string> _sessionToAgent = new(); // sessionId → agentId
     private readonly Dictionary<string, AskUserPromptState> _pendingAskUserByConversation = new();
 
+    // High-frequency streaming deltas (content/thinking) route through NotifyChangedThrottled,
+    // which coalesces a burst into at most one render per window so a long streamed response
+    // does not trigger one StateHasChanged per token (#1620). Discrete lifecycle events keep
+    // using the immediate NotifyChanged. The window is computed from an injectable clock so the
+    // coalescing is deterministically testable (mirrors the repo's TimeProvider test pattern).
+    private static readonly TimeSpan ThrottleWindow = TimeSpan.FromMilliseconds(50);
+    private readonly TimeProvider _clock;
+    private DateTimeOffset _lastNotifyUtc = DateTimeOffset.MinValue;
+
+    /// <summary>
+    /// Creates the store. <paramref name="clock"/> drives the streaming-render coalescing
+    /// window; it defaults to <see cref="TimeProvider.System"/> and is only overridden in tests.
+    /// </summary>
+    public ClientStateStore(TimeProvider? clock = null) => _clock = clock ?? TimeProvider.System;
+
     // ── IClientStateStore ────────────────────────────────────────────────────
 
     /// <inheritdoc />
@@ -273,7 +288,7 @@ public sealed class ClientStateStore : IClientStateStore
         if (conv is null)
             return;
 
-        conv.StreamState.Buffer += delta;
+        conv.StreamState.AppendBuffer(delta);
         NotifyChanged();
     }
 
@@ -297,9 +312,7 @@ public sealed class ClientStateStore : IClientStateStore
             });
         }
 
-        conv.StreamState.Buffer = "";
-        conv.StreamState.ThinkingBuffer = "";
-        conv.StreamState.IsStreaming = false;
+        conv.StreamState.Reset();
 
         // Keep agent-level state in sync
         foreach (var agent in _agents.Values)
@@ -473,6 +486,30 @@ public sealed class ClientStateStore : IClientStateStore
     // ── Internal helpers ─────────────────────────────────────────────────────
 
     /// <inheritdoc />
-    public void NotifyChanged() => OnChanged?.Invoke();
+    public void NotifyChanged()
+    {
+        // Immediate render for discrete lifecycle events (tool start/end, message complete,
+        // run end, etc.). Resets the coalescing window so any change accumulated by a throttled
+        // delta is now on screen and the next streamed delta fires on its leading edge.
+        _lastNotifyUtc = _clock.GetUtcNow();
+        OnChanged?.Invoke();
+    }
+
+    /// <inheritdoc />
+    public void NotifyChangedThrottled()
+    {
+        // Leading-edge + coalesce: the first notify in a window renders immediately; further
+        // notifies inside the same window are dropped (coalesced) so a burst of streamed tokens
+        // collapses to at most one render per window. The trailing accumulated state is always
+        // flushed by the next window's leading edge or by a discrete NotifyChanged (which every
+        // stream terminates with: message-end / turn-end / commit). This avoids a background
+        // timer entirely, keeping the path allocation-free and deterministically testable.
+        var now = _clock.GetUtcNow();
+        if (now - _lastNotifyUtc < ThrottleWindow)
+            return;
+
+        _lastNotifyUtc = now;
+        OnChanged?.Invoke();
+    }
 }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -143,8 +143,7 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
 
         agent.IsStreaming = true;
         conv.StreamState.IsStreaming = true;
-        conv.StreamState.Buffer = "";
-        conv.StreamState.ThinkingBuffer = "";
+        conv.StreamState.ClearBuffers();
         agent.ProcessingStage = "🤖 Agent is responding…";
         _store.NotifyChanged();
     }
@@ -158,9 +157,9 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         var conv = agent!.Conversations.GetValueOrDefault(convId);
         if (conv is null) return;
 
-        conv.StreamState.Buffer += evt.ContentDelta ?? "";
+        conv.StreamState.AppendBuffer(evt.ContentDelta);
         agent.ProcessingStage = "🤖 Agent is responding…";
-        _store.NotifyChanged();
+        _store.NotifyChangedThrottled();
     }
 
     public void HandleThinkingDelta(AgentStreamEvent evt)
@@ -172,9 +171,9 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         var conv = agent!.Conversations.GetValueOrDefault(convId);
         if (conv is null) return;
 
-        conv.StreamState.ThinkingBuffer += evt.ThinkingContent ?? "";
+        conv.StreamState.AppendThinking(evt.ThinkingContent);
         agent.ProcessingStage = "💭 Thinking…";
-        _store.NotifyChanged();
+        _store.NotifyChangedThrottled();
     }
 
     public void HandleToolStart(AgentStreamEvent evt)

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/StreamRenderThrottleTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/StreamRenderThrottleTests.cs
@@ -1,0 +1,198 @@
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Shouldly;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Tests for the streaming hot-path performance fix (#1620): the content/thinking
+/// delta buffers must accumulate without an O(n^2) per-delta string copy, and the
+/// high-frequency delta render-notify must be time-coalesced so a long streamed
+/// response does not produce one re-render per token, while discrete lifecycle
+/// events still notify immediately.
+/// </summary>
+public sealed class StreamRenderThrottleTests
+{
+    // ── ConversationStreamState buffer accumulation (O(n^2) fix) ───────────────
+
+    [Fact]
+    public void AppendBuffer_accumulates_deltas_in_order()
+    {
+        var state = new ConversationStreamState();
+
+        state.AppendBuffer("Hello");
+        state.AppendBuffer(", ");
+        state.AppendBuffer("world");
+
+        state.Buffer.ShouldBe("Hello, world");
+    }
+
+    [Fact]
+    public void AppendBuffer_treats_null_delta_as_empty()
+    {
+        var state = new ConversationStreamState();
+
+        state.AppendBuffer("a");
+        state.AppendBuffer(null);
+        state.AppendBuffer("b");
+
+        state.Buffer.ShouldBe("ab");
+    }
+
+    [Fact]
+    public void AppendThinking_accumulates_separately_from_content()
+    {
+        var state = new ConversationStreamState();
+
+        state.AppendBuffer("answer");
+        state.AppendThinking("reasoning");
+
+        state.Buffer.ShouldBe("answer");
+        state.ThinkingBuffer.ShouldBe("reasoning");
+    }
+
+    [Fact]
+    public void Reset_clears_both_buffers()
+    {
+        var state = new ConversationStreamState { IsStreaming = true };
+        state.AppendBuffer("content");
+        state.AppendThinking("thinking");
+
+        state.Reset();
+
+        state.Buffer.ShouldBe("");
+        state.ThinkingBuffer.ShouldBe("");
+        state.IsStreaming.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Buffer_returns_full_accumulation_after_many_appends()
+    {
+        // Regression guard for the O(n^2) concat path: many small deltas must still
+        // reassemble losslessly into the full streamed response.
+        var state = new ConversationStreamState();
+        var expected = string.Empty;
+        for (var i = 0; i < 2000; i++)
+        {
+            var token = $"t{i} ";
+            state.AppendBuffer(token);
+            expected += token;
+        }
+
+        state.Buffer.ShouldBe(expected);
+    }
+
+    // ── ClientStateStore throttled notify (render-storm fix) ───────────────────
+
+    [Fact]
+    public void NotifyChangedThrottled_coalesces_a_burst_into_few_renders()
+    {
+        var clock = new FixedClock(new DateTimeOffset(2026, 6, 25, 19, 0, 0, TimeSpan.Zero));
+        var store = new ClientStateStore(clock);
+        var renders = 0;
+        store.OnChanged += () => renders++;
+
+        // A tight burst of 1000 deltas all within the same coalescing window
+        // (clock does not advance) must NOT produce 1000 renders.
+        for (var i = 0; i < 1000; i++)
+            store.NotifyChangedThrottled();
+
+        renders.ShouldBeLessThan(1000);
+        // Leading-edge fire: the first throttled notify renders immediately.
+        renders.ShouldBe(1);
+    }
+
+    [Fact]
+    public void NotifyChangedThrottled_fires_again_after_window_elapses()
+    {
+        var clock = new FixedClock(new DateTimeOffset(2026, 6, 25, 19, 0, 0, TimeSpan.Zero));
+        var store = new ClientStateStore(clock);
+        var renders = 0;
+        store.OnChanged += () => renders++;
+
+        store.NotifyChangedThrottled();   // leading edge -> render #1
+        renders.ShouldBe(1);
+
+        // Still inside the window: coalesced, no new render.
+        store.NotifyChangedThrottled();
+        renders.ShouldBe(1);
+
+        // Advance past the coalescing window: the next throttled notify flushes.
+        clock.Advance(TimeSpan.FromMilliseconds(100));
+        store.NotifyChangedThrottled();
+        renders.ShouldBe(2);
+    }
+
+    [Fact]
+    public void NotifyChanged_always_fires_immediately_even_within_window()
+    {
+        var clock = new FixedClock(new DateTimeOffset(2026, 6, 25, 19, 0, 0, TimeSpan.Zero));
+        var store = new ClientStateStore(clock);
+        var renders = 0;
+        store.OnChanged += () => renders++;
+
+        store.NotifyChangedThrottled();   // render #1 (leading edge)
+        store.NotifyChangedThrottled();   // coalesced
+        renders.ShouldBe(1);
+
+        // Discrete lifecycle event: must flush immediately, never coalesced,
+        // so tool-start/tool-end/message-complete are always visible at once.
+        store.NotifyChanged();
+        renders.ShouldBe(2);
+    }
+
+    [Fact]
+    public void NotifyChanged_flushes_a_pending_coalesced_throttled_change()
+    {
+        var clock = new FixedClock(new DateTimeOffset(2026, 6, 25, 19, 0, 0, TimeSpan.Zero));
+        var store = new ClientStateStore(clock);
+        var renders = 0;
+        store.OnChanged += () => renders++;
+
+        store.NotifyChangedThrottled();   // render #1, opens the window
+        store.NotifyChangedThrottled();   // coalesced (pending)
+        store.NotifyChangedThrottled();   // coalesced (pending)
+        renders.ShouldBe(1);
+
+        // A discrete notify after coalesced deltas flushes immediately and resets the window,
+        // guaranteeing the trailing accumulated state is on screen even if no further delta arrives.
+        store.NotifyChanged();            // render #2 (flush)
+        renders.ShouldBe(2);
+
+        // The window was just reset, so an immediate throttled delta coalesces (no new render)
+        // until the window elapses -- then the next throttled delta fires on its leading edge.
+        store.NotifyChangedThrottled();   // still inside reset window -> coalesced
+        renders.ShouldBe(2);
+        clock.Advance(TimeSpan.FromMilliseconds(100));
+        store.NotifyChangedThrottled();   // new window leading edge -> render #3
+        renders.ShouldBe(3);
+    }
+
+    [Fact]
+    public void Default_store_constructs_without_a_clock_argument()
+    {
+        // DI registers ClientStateStore with no clock; the system clock must be the default.
+        var store = new ClientStateStore();
+        var renders = 0;
+        store.OnChanged += () => renders++;
+
+        store.NotifyChangedThrottled();
+
+        renders.ShouldBe(1);
+    }
+
+    /// <summary>
+    /// Minimal fake <see cref="TimeProvider"/> that only models wall-clock advance,
+    /// mirroring the repo's existing TestTimeProvider pattern. The throttle computes
+    /// the coalescing window from <see cref="GetUtcNow"/>, so this is deterministic.
+    /// </summary>
+    private sealed class FixedClock : TimeProvider
+    {
+        private DateTimeOffset _now;
+
+        public FixedClock(DateTimeOffset start) => _now = start;
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+}


### PR DESCRIPTION
Closes #1620

## Problem
The Blazor SignalR client's streaming hot path had two compounding costs on every streamed token:

1. **O(n²) buffer growth.** `conv.StreamState.Buffer += delta` (GatewayEventHandler `HandleContentDelta` L161 / `HandleThinkingDelta` L175) reallocated and copied the *entire* accumulated reply on **every** delta. A multi-thousand-token answer copied the growing string thousands of times on the SignalR callback thread → quadratic allocation + GC churn.
2. **Render storm.** Each delta called `_store.NotifyChanged()` → `OnChanged?.Invoke()` synchronously, so every subscribed component ran `StateHasChanged` per token chunk. `ClientStateStore.NotifyChanged` had **zero** throttle/coalescing.

## Fix
**Buffer (O(n²) → amortised O(1)):**
- `ConversationStreamState.Buffer` / `ThinkingBuffer` are now backed by a `StringBuilder`. New `AppendBuffer(string?)` / `AppendThinking(string?)` append in amortised O(1) (no copy of the accumulated reply). The hot-path delta handlers use these.
- The `Buffer`/`ThinkingBuffer` get/set contract is preserved (setter replaces the whole buffer) so all existing call sites and tests are unchanged; the setter is only used for seeding/bulk reset, never on the streaming path. Added `ClearBuffers()` (buffers only, keeps `IsStreaming`) for the message-start reset.

**Render storm (coalesced notify):**
- New `IClientStateStore.NotifyChangedThrottled()` — a **leading-edge + coalesce** notify: the first call in a window renders immediately; further calls inside the same window are dropped, so a burst of streamed tokens collapses to at most one render per window (default 50ms ≈ 20fps). The trailing accumulated state is always flushed by the next window's leading edge or by a discrete `NotifyChanged` (every stream terminates with message-end / turn-end / commit).
- The two delta handlers route through `NotifyChangedThrottled()`. Discrete lifecycle events (message-start, tool-start/end, message-end, run-end, etc.) keep the immediate `NotifyChanged()` so correctness is never delayed.
- No background timer: the window is computed from an injectable `TimeProvider` (defaults to `TimeProvider.System`, the repo's established testable-time pattern), so the path stays allocation-free and the coalescing is **deterministically testable**.

## Tests (TDD, written first)
New `StreamRenderThrottleTests` (10):
- Buffer accumulation: in-order append, null-delta-as-empty, content/thinking kept separate, `Reset` clears both, 2000-append lossless reassembly (O(n²) regression guard).
- Throttle: a 1000-call burst within one window produces exactly 1 render (leading edge); fires again after the window elapses; discrete `NotifyChanged` always fires immediately even inside the window and flushes a pending coalesced change; default ctor (no clock) works.

`test-impacted.ps1` green: BlazorClient.Tests **616 passed / 0 failed** (incl all existing `ClientStateStoreTests` / `GatewayEventHandlerTests` / `CacheTokenFlowTests` / `AgentInteractionServiceTests` that exercise the buffers — zero regression), Architecture 212, Scenarios 29, Gateway.Conversations + Gateway.Tests all pass.

## Merge Notes
File-disjoint from all open PRs — touches only `BlazorClient.Core` services (`IClientStateStore.cs`, `ClientStateStore.cs`, `GatewayEventHandler.cs`). No shared files with #1606 (Telegram), #1607 (compaction), #1608 (docs/releases), or #1619 (Agent.Core claim auditor). Safe to merge in any order, in parallel. No config/API/docs surface change (internal client perf fix).
