### PR TITLE
fix(channels): make Telegram streaming-buffer flush surrogate-safe

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -591,11 +591,10 @@ public sealed class TelegramChannelAdapter(
         var maxLength = Math.Max(1, runtime.Config.MaxMessageLength);
         while (state.Buffer.Length > maxLength)
         {
-            var rawChunk = state.Buffer.ToString(0, maxLength);
+            var rawChunk = DrainStreamingBuffer(state.Buffer, maxLength);
             var formattedChunk = TelegramMarkdownFormatter.Convert(rawChunk);
             await SendOrEditStreamingMessageAsync(runtime, state, formattedChunk, cancellationToken);
             state.MessageId = null;
-            state.Buffer.Remove(0, maxLength);
         }
 
         if (!force && !ShouldFlush(state, runtime.Config))
@@ -939,6 +938,39 @@ public sealed class TelegramChannelAdapter(
         }
 
         return content.Substring(offset, length);
+    }
+
+    /// <summary>
+    /// Removes and returns a leading chunk of at most <paramref name="maxLength"/> UTF-16 code units
+    /// from the front of the streaming <paramref name="buffer"/>, never severing a surrogate pair at
+    /// the chunk boundary. Used by the mid-stream MarkdownV2 flush (<see cref="FlushLegacyMarkdownV2Async"/>)
+    /// to drain an over-length buffer one message at a time.
+    /// </summary>
+    /// <remarks>
+    /// The previous implementation sliced and removed a fixed <paramref name="maxLength"/> code units
+    /// (<c>Buffer.ToString(0, maxLength)</c> + <c>Buffer.Remove(0, maxLength)</c>), which severed an
+    /// emoji / astral glyph straddling the boundary into a lone high surrogate (this chunk) and an
+    /// orphaned low surrogate (left at the head of the buffer) — both invalid UTF-16 that Telegram
+    /// rejects. This shares the same boundary-safe back-off as <see cref="SliceSurrogateSafe"/>: if the
+    /// cut would land between a surrogate pair, the cut is shortened by one so the whole pair moves
+    /// into the next chunk. The buffer is advanced by the actual chunk length, so the deferred code
+    /// unit is never skipped, and at least one code unit is always drained (forward progress).
+    /// </remarks>
+    internal static string DrainStreamingBuffer(StringBuilder buffer, int maxLength)
+    {
+        var available = Math.Min(maxLength, buffer.Length);
+        var length = available;
+
+        // Back off by one if the cut would split a surrogate pair (last code unit is a high surrogate
+        // whose low half is still in the buffer). Keep at least one unit so the drain always advances.
+        if (length > 1 && length < buffer.Length && char.IsHighSurrogate(buffer[length - 1]))
+        {
+            length--;
+        }
+
+        var chunk = buffer.ToString(0, length);
+        buffer.Remove(0, length);
+        return chunk;
     }
 
     /// <summary>

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -2119,6 +2119,100 @@ public sealed class TelegramChannelAdapterTests
         result.Count(c => c.Contains("\U0001F600")).ShouldBe(1);
     }
 
+    // ── FlushLegacyMarkdownV2Async streaming-buffer drain: surrogate-safe (#1616) ────────
+    // The mid-stream draft/streaming flush drains the StringBuilder buffer in maxLength-sized
+    // chunks. A fixed code-unit slice (Buffer.ToString(0, maxLength) + Buffer.Remove(0, maxLength))
+    // severs an emoji straddling the boundary — the same hazard #1596/#1606 fixed for the final-send
+    // chunkers, but on a different code path. DrainStreamingBuffer is the surrogate-safe drainer.
+
+    /// <summary>
+    /// An ASCII-only buffer drains in fixed maxLength chunks (the common path is unaffected by the
+    /// surrogate-safety back-off). Regression guard that the rewrite did not change normal chunking.
+    /// </summary>
+    [Fact]
+    public void DrainStreamingBuffer_AsciiOnly_DrainsAtExactLength()
+    {
+        var buffer = new StringBuilder("abcdefghijabcdefghijX"); // 20 ASCII + 1 trailing unit = 21
+        var chunks = DrainLoopChunks(buffer, 10);
+        // The while-loop drains while Length > maxLength: two full 10-unit chunks; the 1-unit
+        // remainder "X" is left for the final flush (loop stops at Length == 1 <= 10).
+        chunks.ShouldBe(new[] { "abcdefghij", "abcdefghij" });
+        buffer.ToString().ShouldBe("X");
+    }
+
+    /// <summary>
+    /// When an astral (surrogate-pair) emoji straddles the <c>maxLength</c> boundary, the streaming
+    /// drain must move the whole pair into the next chunk rather than emitting a lone high surrogate
+    /// and orphaning the low surrogate at the head of the buffer. This is the core #1616 defect.
+    /// </summary>
+    [Fact]
+    public void DrainStreamingBuffer_EmojiStraddlesBoundary_MovesPairWhole_NoLoneSurrogate()
+    {
+        // "aaa" + 😀 (2 code units) + "bbb"; maxLength 4 would cut after "aaa" + high surrogate.
+        var buffer = new StringBuilder("aaa\U0001F600bbb");
+        var chunks = DrainLoopChunks(buffer, 4);
+        AssertNoLoneSurrogateAcrossChunks(chunks);
+        // The emoji survives intact across the drain; reassembling drained chunks + the buffered
+        // remainder is lossless and the pair is never severed.
+        AssertNoLoneSurrogateAcrossChunks([buffer.ToString()]);
+        (string.Concat(chunks) + buffer.ToString()).ShouldBe("aaa\U0001F600bbb");
+        (string.Concat(chunks) + buffer.ToString()).Count(c => c == '\uD83D').ShouldBe(1);
+    }
+
+    /// <summary>
+    /// A dense run of emoji drained against a misaligned <c>maxLength</c> must never sever any pair
+    /// across the many chunk boundaries, and the drained chunks plus remainder must reassemble
+    /// byte-for-byte.
+    /// </summary>
+    [Fact]
+    public void DrainStreamingBuffer_ManyEmoji_NeverSplitsAnyPair()
+    {
+        var content = string.Concat(Enumerable.Repeat("\U0001F600", 50)); // 50 emoji = 100 code units
+        var buffer = new StringBuilder(content);
+        var chunks = DrainLoopChunks(buffer, 3); // 3 is misaligned with the 2-unit pairs
+        AssertNoLoneSurrogateAcrossChunks(chunks);
+        AssertNoLoneSurrogateAcrossChunks([buffer.ToString()]);
+        (string.Concat(chunks) + buffer.ToString()).ShouldBe(content);
+        (string.Concat(chunks) + buffer.ToString()).Count(c => c == '\uD83D').ShouldBe(50);
+    }
+
+    /// <summary>
+    /// The drain only emits full chunks while the buffer still exceeds <c>maxLength</c>; the trailing
+    /// remainder (≤ maxLength) is left in the buffer for the final flush, exactly as the legacy loop
+    /// does. A pair must not be severed when the boundary lands inside the trailing remainder.
+    /// </summary>
+    [Fact]
+    public void DrainStreamingBuffer_LeavesTrailingRemainderInBuffer()
+    {
+        var buffer = new StringBuilder("aaaaa\U0001F600"); // 5 ASCII + emoji (2 units) = 7 units
+        var chunks = DrainLoopChunks(buffer, 6);
+        AssertNoLoneSurrogateAcrossChunks(chunks);
+        // First drain backs off the boundary so it does not split the pair; the emoji is deferred
+        // wholly into the remainder, which stays buffered (Length <= maxLength means loop stops).
+        char.IsHighSurrogate(buffer.ToString()[^1]).ShouldBeFalse(
+            "buffer must not be left ending on a lone high surrogate");
+        (string.Concat(chunks) + buffer.ToString()).ShouldBe("aaaaa\U0001F600");
+    }
+
+    /// <summary>
+    /// Runs the surrogate-safe drain one chunk at a time via the production helper while the buffer
+    /// still exceeds <paramref name="maxLength"/>, mirroring the <c>FlushLegacyMarkdownV2Async</c>
+    /// while-loop. The trailing remainder (≤ maxLength) is intentionally left in
+    /// <paramref name="buffer"/> — the production code flushes it separately as the final message —
+    /// so reassembly assertions must add <c>buffer.ToString()</c> to the returned chunks.
+    /// </summary>
+    private static List<string> DrainLoopChunks(StringBuilder buffer, int maxLength)
+    {
+        var chunks = new List<string>();
+        while (buffer.Length > maxLength)
+        {
+            var before = buffer.Length;
+            chunks.Add(TelegramChannelAdapter.DrainStreamingBuffer(buffer, maxLength));
+            buffer.Length.ShouldBeLessThan(before, "each drain must make forward progress");
+        }
+        return chunks;
+    }
+
     /// <summary>
     /// Asserts the OpenClaw invariant: no chunk ends on an unpaired high surrogate, and no chunk
     /// begins on an unpaired low surrogate — i.e. no surrogate pair was severed across a boundary.


### PR DESCRIPTION
Closes #1616

## Problem

`FlushLegacyMarkdownV2Async` (the mid-stream draft/streaming flush for legacy/MarkdownV2 replies) drained the in-flight `StringBuilder` buffer with a **fixed code-unit slice**:

```csharp
while (state.Buffer.Length > maxLength)
{
    var rawChunk = state.Buffer.ToString(0, maxLength);   // code-unit slice
    ...
    state.Buffer.Remove(0, maxLength);                    // code-unit removal
}
```

If an emoji / astral glyph straddles the `maxLength` boundary, this severs the surrogate pair: the chunk ends in a **lone high surrogate** and the **orphaned low surrogate** is left at the head of the buffer for the next chunk. Both are invalid UTF-16, which the Telegram Bot API rejects with `400 can't parse entities`.

This is the **same defect class** as #1596 (fixed by #1606 via `SliceSurrogateSafe`), but on a **different code path**: #1606 fixed the final-send chunkers (`SplitMessage` / `SplitMarkdown`); this is the live mid-stream draft/streaming flush, which #1606 does not touch (verified — `FlushLegacyMarkdownV2Async` was untouched by that PR).

## Fix

- New `internal static string DrainStreamingBuffer(StringBuilder buffer, int maxLength)` that removes and returns a leading chunk of at most `maxLength` code units, **never severing a surrogate pair** — it shares the exact boundary back-off as the canonical `SliceSurrogateSafe` (#1606): if the cut would land between a pair, the cut shortens by one so the whole pair moves into the next chunk. The buffer advances by the **actual** chunk length (so the deferred code unit is not skipped), and at least one unit is always drained (forward progress).
- `FlushLegacyMarkdownV2Async`'s drain loop now calls `DrainStreamingBuffer` instead of the fixed slice + remove. The trailing remainder (= maxLength) is still left for the final flush, unchanged.

Both the streaming drain and the final-send chunkers now route boundary-cutting through the same surrogate-safe primitive shape (the issue's "ensure all chunkers share one surrogate-safe slice helper").

## Tests (TDD, written first)

4 new tests in `TelegramChannelAdapterTests.cs` driving `DrainStreamingBuffer` directly:
- `DrainStreamingBuffer_AsciiOnly_DrainsAtExactLength` — common path regression guard (fixed-length chunks, remainder left buffered).
- `DrainStreamingBuffer_EmojiStraddlesBoundary_MovesPairWhole_NoLoneSurrogate` — the core #1616 defect: `"aaa" + emoji + "bbb"` with `maxLength 4`; asserts no chunk ends on a lone high surrogate, the pair is intact, and drain + remainder reassemble losslessly.
- `DrainStreamingBuffer_ManyEmoji_NeverSplitsAnyPair` — 50 emoji vs misaligned `maxLength 3`; no pair severed across any boundary, lossless reassembly.
- `DrainStreamingBuffer_LeavesTrailingRemainderInBuffer` — boundary lands inside the remainder; the pair is deferred whole and the buffer is never left ending on a lone high surrogate.

All reuse the existing `AssertNoLoneSurrogateAcrossChunks` invariant helper. `test-impacted.ps1` green: Gateway.Tests 3227/0 (+4 new, 0 regression) + Architecture 212 + Scenarios 29 + Gateway.Conversations.

## Merge Notes

File-disjoint from all open PRs (#1642 conversations store, #1640 cron, #1637 ratelimit, #1634 blazor-client, #1619 claim-auditor, #1608 docs) — touches only `TelegramChannelAdapter.cs` + its test. Depends on `SliceSurrogateSafe` which is already in `main` via #1606 (merged). Safe to merge in any order, in parallel with all open PRs.
