### PR TITLE
docs: daily documentation grooming 2026-06-26 (v0.11.0 release page)

### DIFF
--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -9,7 +9,8 @@ Browse the full version history of BotNexus. Each release page includes the full
 
 | Version | Date | |
 |---------|------|---|
-| **[v0.10.1](v0.10.1/)** | 2026-06-24 | ← Latest |
+| **[v0.11.0](v0.11.0/)** | 2026-06-24 | ← Latest |
+| [v0.10.1](v0.10.1/) | 2026-06-24 | |
 | [v0.10.0](v0.10.0/) | 2026-06-24 | |
 | [v0.9.0](v0.9.0/) | 2026-06-23 | |
 | [v0.8.1](v0.8.1/) | 2026-06-20 | |

--- a/docs/releases/v0.11.0/index.md
+++ b/docs/releases/v0.11.0/index.md
@@ -1,0 +1,32 @@
+---
+title: "Release v0.11.0"
+description: "Release notes for BotNexus v0.11.0"
+date: "2026-06-24"
+---
+
+# Release v0.11.0
+
+> **Released:** 2026-06-24
+>
+> **Full diff:** [v0.10.1...v0.11.0](https://github.com/sytone/botnexus/compare/v0.10.1...v0.11.0)
+
+## [0.11.0] - 2026-06-24
+
+### ✨ Features
+
+- **channels:** Add Telegram Rich Message API client methods (#1591) (#1592)
+- **channels:** Send Telegram outbound via Rich Markdown with MarkdownV2 fallback (#1591) (#1594)
+- **channels:** Stream Telegram replies via Rich Message drafts (#1591) (#1604)
+- **sessions:** Cap oversized tool results at write time (#1605)
+
+### 🐛 Bug Fixes
+
+- **qmd:** Kill orphaned qmd subprocess on caller cancellation (#1601)
+- **security:** Bound untrusted external JSON HTTP response reads (#1603)
+
+### 📖 Documentation
+
+- Backfill v0.9.0 release page + document cron DeleteAfterRun config (#1593)
+
+[0.11.0]: https://github.com/sytone/botnexus/compare/v0.10.1...v0.11.0
+


### PR DESCRIPTION
## Changes

Backfilled the **v0.11.0** release page, which was skipped because the `v0.11.0` tag was cut manually (outside the `release-cli.yml` workflow) by the daily build-validation cron at `ad132cf1`.

## New pages

- `docs/releases/v0.11.0/index.md` — full changelog for v0.11.0 (the first MINOR since v0.10.0), covering the 7 commits in `v0.10.1..v0.11.0`:
  - **✨ Features (4):** Telegram Rich Message API client (#1592), outbound Rich Markdown + MarkdownV2 fallback (#1594), Rich Message draft streaming (#1604) — all part of the Telegram Rich Markdown epic (#1591) — plus write-time tool-result cap (#1605).
  - **🐛 Bug Fixes (2):** kill orphaned qmd subprocess on cancellation (#1601); bound untrusted external JSON HTTP response reads (#1603).
  - **📖 Documentation (1):** backfill v0.9.0 release page + document cron `DeleteAfterRun` (#1593).

## Content fixes

- `docs/releases/index.md` — added the `v0.11.0` row and moved the `← Latest` marker from `v0.10.1` to `v0.11.0`; the previously-latest `v0.10.1` row drops back to a plain entry.

## Validation

- Generator byte-validated (SHA256) against both `v0.10.1` (the genuine double-PR-number page) **and** `v0.10.0` (genuine git-cliff workflow output) before generating v0.11.0 — exact match on both.
- Double PR numbers (`(#1591) (#1592)` etc.) preserved verbatim, matching git-cliff (`commit_preprocessors = []`, no `[remote]` section).
- Page is UTF-8 no-BOM, LF-only, trailing `\n\n` (git-cliff style); emoji headings sourced from existing pages (no retyping).
- Mojibake gate clean (0 signature glyphs, 0 box-drawing in prose) on both changed files.
- VitePress `docs:build` GREEN (0 dead links) — the new page is reachable from `releases/index.md`.

---
Automated by the daily documentation groomer.
