### PR TITLE
feat(domain): add optional SpeakAs role override to InboundMessage

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/Messages.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Messages.cs
@@ -95,6 +95,29 @@ public sealed record InboundMessage
     /// <see cref="SessionEntry.Trigger"/>. See P9-E (#645) / directive G-3.
     /// </summary>
     public TriggerType? Trigger { get; init; }
+
+    /// <summary>
+    /// Optional override for the role this message should be recorded under when an
+    /// agent posts it into a channel. <c>null</c> (the default) means "no override" --
+    /// the role is derived from the sender kind downstream (see #1547 Step 2/3).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Foundation for post-as-assistant (<c>#1649</c>, Step 1/3 of <c>#1547</c>). Today
+    /// agent-initiated posts (e.g. the conversation tool, cross-channel relays) are
+    /// hard-stamped as <see cref="MessageRole.User"/>. Per the Hybrid approach agreed on
+    /// <c>#1547</c>, an agent should default to <see cref="MessageRole.Assistant"/> when
+    /// speaking as itself, with an explicit <see cref="MessageRole.User"/> override for
+    /// the on-behalf-of-user kickoff case. This field carries that intended role onto the
+    /// inbound path so the role-stamp step has a value to read.
+    /// </para>
+    /// <para>
+    /// This is purely additive plumbing: no consumer reads <see cref="SpeakAs"/> yet, so
+    /// the field has no behavioural effect on its own. Step 2/3 (<c>#1650</c>) wires the
+    /// role derivation; Step 3/3 (<c>#1651</c>) makes the render honour the assistant role.
+    /// </para>
+    /// </remarks>
+    public MessageRole? SpeakAs { get; init; }
 }
 
 /// <summary>

--- a/tests/domain/BotNexus.Domain.Tests/InboundMessageSpeakAsTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/InboundMessageSpeakAsTests.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using System.Reflection;
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Domain.Tests;
+
+/// <summary>
+/// Covers the optional <see cref="InboundMessage.SpeakAs"/> field added as the
+/// domain foundation for post-as-assistant (#1649, Step 1/3 of #1547). The field
+/// carries the intended message role for agent-initiated posts; <c>null</c> means
+/// "no override -- derive the role from the sender kind in Step 2". No consumer
+/// reads it yet, so these tests pin only the additive shape: it defaults to null,
+/// preserves an explicit value through construction, and round-trips through
+/// record value-equality / <c>with</c>.
+/// </summary>
+public sealed class InboundMessageSpeakAsTests
+{
+    [Fact]
+    public void InboundMessage_Constructor_WithoutSpeakAs_ShouldDefaultToNull()
+    {
+        var message = CreateMessage();
+
+        message.SpeakAs.ShouldBeNull();
+    }
+
+    [Fact]
+    public void InboundMessage_WithExplicitSpeakAs_ShouldPreserveValue()
+    {
+        var message = CreateMessage() with { SpeakAs = MessageRole.Assistant };
+
+        message.SpeakAs.ShouldNotBeNull();
+        message.SpeakAs!.ShouldBe(MessageRole.Assistant);
+    }
+
+    [Fact]
+    public void InboundMessage_WithUserSpeakAs_ShouldPreserveValue()
+    {
+        var message = CreateMessage() with { SpeakAs = MessageRole.User };
+
+        message.SpeakAs.ShouldBe(MessageRole.User);
+    }
+
+    [Fact]
+    public void InboundMessage_SpeakAs_ShouldSurviveRecordWithCopy()
+    {
+        var original = CreateMessage() with { SpeakAs = MessageRole.Assistant };
+
+        // A copy that changes an unrelated field must preserve SpeakAs.
+        var copy = original with { Content = "changed" };
+
+        copy.SpeakAs.ShouldBe(MessageRole.Assistant);
+        copy.Content.ShouldBe("changed");
+    }
+
+    [Fact]
+    public void InboundMessage_SpeakAs_DifferentiatesOtherwiseIdenticalCopies()
+    {
+        // Start from one shared base so every other field (incl. the by-reference
+        // Metadata dictionary and the UtcNow Timestamp) is identical between the
+        // two copies -- this isolates SpeakAs as the only differing field, so the
+        // record's generated equality reflects exactly the SpeakAs change.
+        var baseline = CreateMessage();
+
+        var asAssistant = baseline with { SpeakAs = MessageRole.Assistant };
+        var alsoAssistant = baseline with { SpeakAs = MessageRole.Assistant };
+        var asUser = baseline with { SpeakAs = MessageRole.User };
+
+        asAssistant.ShouldBe(alsoAssistant);
+        asAssistant.ShouldNotBe(asUser);
+        asAssistant.ShouldNotBe(baseline); // null vs assistant
+    }
+
+    [Fact]
+    public void InboundMessage_SpeakAs_IsNullableMessageRole()
+    {
+        var property = typeof(InboundMessage)
+            .GetProperty(nameof(InboundMessage.SpeakAs), BindingFlags.Public | BindingFlags.Instance);
+
+        property.ShouldNotBeNull();
+        property!.PropertyType.ShouldBe(typeof(MessageRole));
+
+        // Nullable reference annotation: the property must be marked nullable so
+        // "no override" is the documented default rather than a required value.
+        var nullabilityInfo = new NullabilityInfoContext().Create(property);
+        nullabilityInfo.ReadState.ShouldBe(NullabilityState.Nullable);
+    }
+
+    private static InboundMessage CreateMessage() => new()
+    {
+        ChannelType = ChannelKey.From("signalr"),
+        SenderId = "sender-1",
+        Sender = CitizenId.Of(UserId.From("sender-1")),
+        ChannelAddress = ChannelAddress.From("conversation-1"),
+        Content = "hello",
+    };
+}


### PR DESCRIPTION
Closes #1649

## Summary

Step 1/3 of #1547 (post-as-assistant, Hybrid approach). Adds an optional
`MessageRole? SpeakAs` field to `InboundMessage` carrying the intended message
role for agent-initiated posts. `null` (the default) means "no override" -- the
role is derived from the sender kind downstream in Step 2.

This is **purely additive domain plumbing**: no consumer reads the field yet, so
there is no behavioural change. It exists so the role-stamp step (#1650) has a
field to read, and the render step (#1651) can honour the assistant role.

## Changes

- `src/domain/BotNexus.Domain/Gateway/Models/Messages.cs` -- add
  `public MessageRole? SpeakAs { get; init; }` to `InboundMessage` (uses the
  existing `MessageRole` domain primitive; nullable so "no override" is the
  documented default). Full XML doc explaining the Hybrid rationale and the
  no-consumer-yet status.
- `tests/domain/BotNexus.Domain.Tests/InboundMessageSpeakAsTests.cs` -- new
  unit tests pinning the additive shape: defaults to `null`, preserves an
  explicit `Assistant`/`User` value through construction, survives a `with`-copy
  of an unrelated field, differentiates otherwise-identical copies, and is a
  nullable `MessageRole`.

## Acceptance criteria (#1649)

- [x] `InboundMessage` exposes an optional `SpeakAs`/`SenderRole` (default `null`).
- [x] Field round-trips through record construction / `with` (the only boundary
  it crosses today; `InboundMessage` is an in-process record, not JSON-serialized
  on this path -- `InboundMessageContext.FromInboundMessage` does not need to
  read it in Step 1).
- [x] No behavioural change -- nothing reads the field yet (existing tests stay
  green; full `test-impacted` passed).
- [x] Unit test: defaults to `null` and preserves an explicit value through
  construction.

## Test evidence

- RED proven: the test file failed to compile (12x CS "InboundMessage does not
  contain a definition for SpeakAs") before the field was added.
- GREEN: 6/6 new tests pass. Full `scripts/repo/test-impacted.ps1` =
  "All impacted tests passed" (Domain.Tests 373/0 incl. the 6 new tests,
  Architecture.Tests 212/0, Scenarios.Tests 29/0, 24 impacted projects).

## Merge Notes

Independent and file-disjoint from every open PR (#1679/#1680/#1682/#1683/#1684)
-- only touches `Messages.cs` + a new Domain test. Safe to merge in any order.
This is the foundation for #1650 (Step 2/3) and #1651 (Step 3/3), which must
merge after this so they have the `SpeakAs` field to read.
