### PR TITLE
fix(cron): wire StreamSetupTimeoutMs so cloud compaction stalls fail fast

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Core/ProviderEndpointClassifier.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/ProviderEndpointClassifier.cs
@@ -1,0 +1,41 @@
+namespace BotNexus.Agent.Providers.Core;
+
+/// <summary>
+/// Classifies a model's API BaseUrl as a local/self-hosted endpoint versus a remote cloud endpoint.
+/// Used to decide whether the cron/compaction stream-setup idle cap (StreamSetupTimeoutMs) should be
+/// applied (#1652): cloud calls get a fail-fast cap so a stalled first token never wedges a
+/// background turn, while local/self-hosted servers (ollama, vllm, lmstudio, sglang bound to
+/// localhost / 127.0.0.1) are left uncapped because they are legitimately slow to warm up.
+/// Mirrors the localhost/127.0.0.1 detection pattern in
+/// <c>BotNexus.Agent.Providers.OpenAICompat.CompatDetector</c> without taking a dependency on it.
+/// </summary>
+public static class ProviderEndpointClassifier
+{
+    /// <summary>
+    /// Returns true when <paramref name="baseUrl"/> points at a local/self-hosted provider
+    /// (host is <c>localhost</c> or <c>127.0.0.1</c>). A null/empty/whitespace BaseUrl is treated as
+    /// NOT local (returns false): an unknown host is conservatively treated as cloud so the safety
+    /// cap still applies and a mis-registered model cannot stall a background call forever. Matching
+    /// is case-insensitive and works on either a raw host:port string or a full URL.
+    /// </summary>
+    public static bool IsLocalProviderBaseUrl(string? baseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+            return false;
+
+        var normalized = baseUrl.ToLowerInvariant();
+
+        // Prefer a precise host check when the value parses as an absolute URL, so a cloud host that
+        // merely contained the substring "localhost" (e.g. a path or subdomain) is not misclassified.
+        if (Uri.TryCreate(normalized, UriKind.Absolute, out var uri))
+        {
+            var host = uri.Host;
+            return host is "localhost" or "127.0.0.1";
+        }
+
+        // Fallback for bare host:port forms that are not absolute URIs.
+        return normalized is "localhost" or "127.0.0.1"
+            || normalized.StartsWith("localhost:", StringComparison.Ordinal)
+            || normalized.StartsWith("127.0.0.1:", StringComparison.Ordinal);
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionOptions.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionOptions.cs
@@ -56,6 +56,24 @@ public sealed record CompactionOptions
     /// </summary>
     public int CircuitBreakerCooldownSeconds { get; init; } = 600;
 
+    /// <summary>
+    /// Stream-setup idle cap (milliseconds) applied to the compaction summarization model call when
+    /// the resolved candidate is a CLOUD provider (default: 60000 = 60s, mirroring OpenClaw's
+    /// CRON_LLM_IDLE_TIMEOUT_MS). This wires the otherwise-inert
+    /// <c>StreamOptions.StreamSetupTimeoutMs</c> first-token watchdog so a cloud model that stalls
+    /// mid-stream (or never emits a first token) is aborted early. Compaction is a background
+    /// (non-interactive) call that already has an outer per-attempt watchdog
+    /// (<see cref="TimeoutSeconds"/>); the stream stall must fail well INSIDE that window so the
+    /// model fallback chain still has time to try the next candidate rather than the whole attempt
+    /// timing out. The cap is intentionally NOT applied to LOCAL/self-hosted providers (localhost /
+    /// 127.0.0.1 - e.g. ollama, vllm, lmstudio, sglang) because those endpoints are legitimately slow
+    /// to warm up; the cloud-vs-local decision is made via
+    /// <c>ProviderEndpointClassifier.IsLocalProviderBaseUrl</c> from the resolved model BaseUrl.
+    /// Values &lt;= 0 disable the cap entirely (restores the pre-#1652 behaviour where no setup-phase
+    /// timeout is enforced).
+    /// </summary>
+    public int CronLlmIdleTimeoutMs { get; init; } = 60_000;
+
     /// <summary>Pre-compaction memory flush configuration.</summary>
     public MemoryFlushOptions MemoryFlush { get; init; } = new();
 }

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -97,7 +97,8 @@ public static class GatewayServiceCollectionExtensions
                     LargestEntryBytesThreshold = ParseInt(compactionSection["largestEntryBytesThreshold"], new CompactionOptions().LargestEntryBytesThreshold),
                     SummarizationModel = ParseString(compactionSection["summarizationModel"], new CompactionOptions().SummarizationModel),
                     SummarizationProvider = ParseString(compactionSection["summarizationProvider"], new CompactionOptions().SummarizationProvider),
-                    CircuitBreakerCooldownSeconds = ParseInt(compactionSection["circuitBreakerCooldownSeconds"], new CompactionOptions().CircuitBreakerCooldownSeconds)
+                    CircuitBreakerCooldownSeconds = ParseInt(compactionSection["circuitBreakerCooldownSeconds"], new CompactionOptions().CircuitBreakerCooldownSeconds),
+                    CronLlmIdleTimeoutMs = ParseInt(compactionSection["cronLlmIdleTimeoutMs"], new CompactionOptions().CronLlmIdleTimeoutMs)
                 };
                 services.AddSingleton<IOptions<CompactionOptions>>(_ => Options.Create(configuredCompaction));
                 services.Replace(ServiceDescriptor.Singleton<IOptionsMonitor<CompactionOptions>>(

--- a/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
@@ -598,6 +598,27 @@ public sealed class LlmSessionCompactor : ISessionCompactor
     }
 
     /// <summary>
+    /// Resolves the stream-setup idle cap (StreamSetupTimeoutMs, milliseconds) for a single
+    /// compaction summarization attempt (#1652). Returns the configured
+    /// <see cref="CompactionOptions.CronLlmIdleTimeoutMs"/> for CLOUD providers so a stalled
+    /// first token fails fast (well inside the outer <see cref="CompactionOptions.TimeoutSeconds"/>
+    /// watchdog, leaving time for the fallback chain to try the next candidate), and 0 (disabled)
+    /// for LOCAL/self-hosted providers (localhost / 127.0.0.1 - e.g. ollama, vllm, lmstudio,
+    /// sglang) which are legitimately slow to warm up. A non-positive configured value also
+    /// disables the cap. The cloud-vs-local decision uses the resolved model BaseUrl (which has
+    /// already had any per-provider endpoint override applied in BuildCandidateModels).
+    /// </summary>
+    internal static int ResolveStreamSetupTimeoutMs(LlmModel model, CompactionOptions options)
+    {
+        if (options.CronLlmIdleTimeoutMs <= 0)
+            return 0;
+
+        return ProviderEndpointClassifier.IsLocalProviderBaseUrl(model.BaseUrl)
+            ? 0
+            : options.CronLlmIdleTimeoutMs;
+    }
+
+    /// <summary>
     /// Attempts a single summarization call against one model. Returns the trimmed summary text (or
     /// empty if none) and whether the attempt failed transiently (timeout / provider error). A
     /// per-attempt timeout is treated as a transient failure of <em>this</em> model, not a caller
@@ -620,9 +641,16 @@ public sealed class LlmSessionCompactor : ISessionCompactor
                 .ConfigureAwait(false);
         }
 
-        var streamOptions = apiKey is not null
-            ? new SimpleStreamOptions { ApiKey = apiKey, CancellationToken = cancellationToken }
-            : null;
+        // #1652: wire the otherwise-inert StreamSetupTimeoutMs first-token watchdog for this
+        // background (non-interactive) compaction call. Always build the options so the cap is
+        // applied even when apiKey is null (a null ApiKey falls back to environment keys in the
+        // provider, exactly as passing null options did before - behaviour-preserving for auth).
+        var streamOptions = new SimpleStreamOptions
+        {
+            ApiKey = apiKey,
+            CancellationToken = cancellationToken,
+            StreamSetupTimeoutMs = ResolveStreamSetupTimeoutMs(model, options)
+        };
 
         // Create a timeout-linked token so hung provider calls are cancelled after
         // CompactionOptions.TimeoutSeconds. The linked token fires on whichever

--- a/tests/agent/BotNexus.Agent.Providers.Core.Tests/ProviderEndpointClassifierTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Core.Tests/ProviderEndpointClassifierTests.cs
@@ -1,0 +1,47 @@
+namespace BotNexus.Agent.Providers.Core.Tests;
+
+/// <summary>
+/// Tests for the cloud-vs-local provider classification used to decide whether the cron/compaction
+/// stream-setup idle cap (StreamSetupTimeoutMs) should be applied (#1652). Cloud endpoints get the
+/// cap so a stalled first-token never wedges a background call; local/self-hosted endpoints
+/// (ollama, vllm, lmstudio, sglang on localhost/127.0.0.1) are left uncapped because they are
+/// legitimately slow to warm up.
+/// </summary>
+public class ProviderEndpointClassifierTests
+{
+    [Theory]
+    [InlineData("https://api.anthropic.com")]
+    [InlineData("https://api.githubcopilot.com")]
+    [InlineData("https://api.individual.githubcopilot.com")]
+    [InlineData("https://api.enterprise.githubcopilot.com")]
+    [InlineData("https://api.openai.com/v1")]
+    public void IsLocalProviderBaseUrl_CloudHost_ReturnsFalse(string baseUrl)
+    {
+        ProviderEndpointClassifier.IsLocalProviderBaseUrl(baseUrl).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("http://localhost:11434")]
+    [InlineData("http://127.0.0.1:11434")]
+    [InlineData("http://localhost:8000")]
+    [InlineData("http://127.0.0.1:8000")]
+    [InlineData("http://localhost:1234")]
+    [InlineData("http://localhost:30000")]
+    [InlineData("http://LOCALHOST:11434")]
+    [InlineData("http://127.0.0.1")]
+    public void IsLocalProviderBaseUrl_LocalHost_ReturnsTrue(string baseUrl)
+    {
+        ProviderEndpointClassifier.IsLocalProviderBaseUrl(baseUrl).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsLocalProviderBaseUrl_NullOrEmpty_ReturnsFalse(string? baseUrl)
+    {
+        // Null/empty means "unknown host"; treat as cloud so the safety cap still applies and a
+        // mis-registered model cannot stall a background call forever.
+        ProviderEndpointClassifier.IsLocalProviderBaseUrl(baseUrl).ShouldBeFalse();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorStreamIdleCapTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorStreamIdleCapTests.cs
@@ -1,0 +1,165 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Sessions;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Sessions;
+
+/// <summary>
+/// Tests for #1652: the compaction summarization call must set a non-zero stream-setup idle cap
+/// (StreamSetupTimeoutMs) when the resolved candidate model is a CLOUD provider, so a stalled
+/// first-token fails fast (well inside the outer per-attempt TimeoutSeconds watchdog) and the
+/// fallback chain can try the next candidate. For LOCAL/self-hosted models (localhost / 127.0.0.1)
+/// the cap stays 0 because those endpoints are legitimately slow to warm up. The cap is the
+/// configurable CompactionOptions.CronLlmIdleTimeoutMs (default 60000).
+/// </summary>
+public sealed class LlmSessionCompactorStreamIdleCapTests
+{
+    private static readonly LlmModel CloudModel = new(
+        Id: "claude-haiku-4.5", Name: "Haiku", Api: "anthropic-api", Provider: "anthropic",
+        BaseUrl: "https://api.anthropic.com", Reasoning: false, Input: ["text"],
+        Cost: new ModelCost(0, 0, 0, 0), ContextWindow: 128000, MaxTokens: 4096);
+
+    private static readonly LlmModel LocalModel = new(
+        Id: "qwen2.5", Name: "Qwen Local", Api: "anthropic-api", Provider: "ollama",
+        BaseUrl: "http://localhost:11434", Reasoning: false, Input: ["text"],
+        Cost: new ModelCost(0, 0, 0, 0), ContextWindow: 128000, MaxTokens: 4096);
+
+    [Fact]
+    public async Task CompactAsync_CloudModel_AppliesIdleCap()
+    {
+        SimpleStreamOptions? captured = null;
+        var compactor = CreateCompactor(CloudModel, opts => captured = opts, "compacted ok");
+
+        var options = OptionsFor(CloudModel);
+        var result = await compactor.CompactAsync(CreateLargeSession(300), options);
+
+        result.Succeeded.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        // Default CronLlmIdleTimeoutMs is 60000; a cloud model must carry it.
+        captured!.StreamSetupTimeoutMs.ShouldBe(60000);
+    }
+
+    [Fact]
+    public async Task CompactAsync_LocalModel_LeavesIdleCapDisabled()
+    {
+        SimpleStreamOptions? captured = null;
+        var compactor = CreateCompactor(LocalModel, opts => captured = opts, "compacted ok");
+
+        var options = OptionsFor(LocalModel);
+        var result = await compactor.CompactAsync(CreateLargeSession(300), options);
+
+        result.Succeeded.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        // A localhost endpoint is legitimately slow; the setup-phase cap must stay disabled.
+        captured!.StreamSetupTimeoutMs.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task CompactAsync_CloudModel_HonoursConfiguredCap()
+    {
+        SimpleStreamOptions? captured = null;
+        var compactor = CreateCompactor(CloudModel, opts => captured = opts, "compacted ok");
+
+        // A custom (smaller) cap from config must flow through to the provider call.
+        var options = OptionsFor(CloudModel) with { CronLlmIdleTimeoutMs = 15000 };
+        var result = await compactor.CompactAsync(CreateLargeSession(300), options);
+
+        result.Succeeded.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        captured!.StreamSetupTimeoutMs.ShouldBe(15000);
+    }
+
+    [Fact]
+    public async Task CompactAsync_CloudModel_CapDisabledWhenConfigZero()
+    {
+        SimpleStreamOptions? captured = null;
+        var compactor = CreateCompactor(CloudModel, opts => captured = opts, "compacted ok");
+
+        // Operators can opt out entirely by setting the cap to 0.
+        var options = OptionsFor(CloudModel) with { CronLlmIdleTimeoutMs = 0 };
+        var result = await compactor.CompactAsync(CreateLargeSession(300), options);
+
+        result.Succeeded.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        captured!.StreamSetupTimeoutMs.ShouldBe(0);
+    }
+
+    private static CompactionOptions OptionsFor(LlmModel model) => new()
+    {
+        ContextWindowTokens = 100,
+        TokenThresholdRatio = 0.01,
+        PreservedTurns = 2,
+        MaxSummaryChars = 5000,
+        SummarizationModel = model.Id,
+        SummarizationProvider = model.Provider
+    };
+
+    private static LlmStream SuccessStream(string summary)
+    {
+        var stream = new LlmStream();
+        var completion = new AssistantMessage(
+            Content: [new TextContent(summary)],
+            Api: "any", Provider: "any", ModelId: "any",
+            Usage: Usage.Empty(), StopReason: StopReason.Stop,
+            ErrorMessage: null, ResponseId: null,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        stream.Push(new DoneEvent(StopReason.Stop, completion));
+        stream.End(completion);
+        return stream;
+    }
+
+    private static LlmSessionCompactor CreateCompactor(
+        LlmModel registeredModel,
+        Action<SimpleStreamOptions?> captureOptions,
+        string summary)
+    {
+        var providers = new ApiProviderRegistry();
+        var models = new ModelRegistry();
+        models.Register(registeredModel.Provider, registeredModel);
+
+        var provider = new Mock<IApiProvider>();
+        provider.SetupGet(p => p.Api).Returns(registeredModel.Api);
+        provider.Setup(p => p.StreamSimple(
+                It.IsAny<LlmModel>(), It.IsAny<Context>(), It.IsAny<SimpleStreamOptions?>()))
+            .Returns((LlmModel _, Context _, SimpleStreamOptions? o) =>
+            {
+                captureOptions(o);
+                return SuccessStream(summary);
+            });
+        providers.Register(provider.Object);
+
+        var llmClient = new LlmClient(providers, models);
+        // No endpoint override (null resolver) so the registered BaseUrl reaches the provider as-is.
+        return new LlmSessionCompactor(
+            llmClient,
+            NullLogger<LlmSessionCompactor>.Instance,
+            endpointResolver: null);
+    }
+
+    private static GatewaySession CreateLargeSession(int entryCount)
+    {
+        var session = new GatewaySession
+        {
+            SessionId = SessionId.From(Guid.NewGuid().ToString("N")),
+            AgentId = AgentId.From("agent")
+        };
+        var entries = new List<SessionEntry>();
+        for (var i = 0; i < entryCount; i++)
+        {
+            entries.Add(new SessionEntry
+            {
+                Role = i % 2 == 0 ? "user" : "assistant",
+                Content = $"message {i} " + new string('x', 50)
+            });
+        }
+        session.AddEntries(entries);
+        return session;
+    }
+}


### PR DESCRIPTION
Closes #1652

## Summary

`StreamSetupTimeoutMs` (src/agent/BotNexus.Agent.Providers.Core/StreamOptions.cs,
default 0 = disabled) is the per-call first-token setup-phase watchdog. Both the
Anthropic and Copilot providers already honour it (they gate on
`setupTimeoutMs > 0`), but a repo-wide search confirmed **nothing ever set it
non-zero** -- so a cron/compaction cloud-model call that stalled mid-stream (or
never emitted a first token) was never aborted early.

This PR wires it for the highest-value, always-background site -- the compaction
summary call -- with a cloud-vs-local distinction and a tunable config knob.

## Changes

- **New helper** `ProviderEndpointClassifier.IsLocalProviderBaseUrl(string?)`
  (src/agent/BotNexus.Agent.Providers.Core/ProviderEndpointClassifier.cs):
  classifies a model BaseUrl as local/self-hosted (`localhost` / `127.0.0.1`,
  case-insensitive, URL- or bare-host-aware) vs cloud. Null/empty is treated as
  cloud (conservative -- an unknown host should still get the safety cap).
  Mirrors the localhost detection in OpenAICompat.CompatDetector without taking
  a dependency on it.
- **Config knob** `CompactionOptions.CronLlmIdleTimeoutMs` (int, default 60000;
  src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionOptions.cs) with a
  full XML-doc rationale, bound from `gateway:compaction:cronLlmIdleTimeoutMs`
  in GatewayServiceCollectionExtensions.cs. Values <= 0 disable the cap.
  Mirrors OpenClaw's CRON_LLM_IDLE_TIMEOUT_MS = 60s.
- **Wiring in LlmSessionCompactor** (TryCallModelAsync): the compaction
  `SimpleStreamOptions` now sets `StreamSetupTimeoutMs` via a small
  `ResolveStreamSetupTimeoutMs(model, options)` helper -- the configured cap for
  cloud providers, 0 for local/self-hosted. The options object is now ALWAYS
  constructed (previously it was null when no API key resolved, which would have
  dropped the cap); a null `ApiKey` behaves exactly as before because the
  provider falls back to environment keys (`options?.ApiKey ?? Environment...`),
  so the auth path is unchanged -- the only added behaviour is the setup-phase
  timeout.

The cap is intentionally small relative to the outer per-attempt watchdog
(`CompactionOptions.TimeoutSeconds`, default 90s): a stream stall must fail well
inside that window so the model fallback chain still has time to try the next
candidate rather than the whole attempt timing out.

### Deferred (honesty over scope-creep)

`InProcessIsolationStrategy` (~L511, the `SimpleStreamOptions` for
`GenerationSettings`) was **NOT wired**. That options object is built once at
agent-handle creation and is shared across BOTH interactive `StreamAsync` turns
AND background cron/heartbeat `PromptAsync` turns (the handle is reused -- see
the comments around InProcessAgentHandle.PromptAsync), and
`AgentExecutionContext` carries no clean cron-vs-interactive trigger flag.
Capping there would either regress interactive turns or require a larger refactor
to plumb a trigger flag through the isolation path, so it is left for a
follow-up. The optional "model-failover-on-stall policy" (listed as "Consider"
in the issue) is also explicitly out of scope.

## Merge Notes

File-disjoint from the other open PRs (#1679 / #1680 / #1682 / #1683 / #1684 /
#1686). This PR only touches:
- a new provider-core helper (ProviderEndpointClassifier.cs) + its test,
- CompactionOptions (config DTO) + the compaction config binding,
- LlmSessionCompactor (compaction wiring) + a new test.

No shared file with those PRs, so it should merge cleanly alongside them.

## Test evidence

TDD -- failing tests written first, RED proven, then implemented to GREEN.

RED (before implementation):
- `dotnet build BotNexus.Agent.Providers.Core.Tests --no-incremental` =>
  3x CS0103 "ProviderEndpointClassifier does not exist".
- `dotnet build BotNexus.Gateway.Tests --no-incremental` =>
  2x CS0117 "CompactionOptions does not contain a definition for
  CronLlmIdleTimeoutMs".
- After the config field was added but before the compactor wiring, the 4
  compaction tests failed at runtime: the captured `SimpleStreamOptions` was
  null (the old code dropped options when no API key resolved), proving the cap
  was not being applied.

GREEN (after implementation, with stale-DLL discipline -- rebuilt src then test
`--no-incremental` then `dotnet test --no-build`):
- ProviderEndpointClassifierTests: 16/16 passed (cloud hosts => not-local,
  localhost/127.0.0.1 incl. case-insensitive/bare => local, null/empty =>
  not-local).
- LlmSessionCompactorStreamIdleCapTests: 4/4 passed (cloud => 60000, local => 0,
  custom configured cap => 15000, configured 0 => 0).
- Broader compaction/compactor suite (LlmSessionCompactor*, Compaction*):
  135/135 passed -- no regression to existing endpoint-override / resilience /
  race / timeout behaviour.

Full gate -- `scripts/repo/test-impacted.ps1` from inside the worktree:
final line **"All impacted tests passed."** (32 impacted test projects,
including BotNexus.Gateway.Tests 3314 passed and
BotNexus.Agent.Providers.Core.Tests 336 passed; 0 failures).
