### PR TITLE
feat(provider): add ThinkingLevel.Max and capability-gated copilot mapping

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicProvider.cs
@@ -116,7 +116,8 @@ public sealed partial class AnthropicProvider(HttpClient httpClient) : IApiProvi
                     ThinkingLevel.Low => "low",
                     ThinkingLevel.Medium => "medium",
                     ThinkingLevel.High => "high",
-                    ThinkingLevel.ExtraHigh => IsOpus46Model(model.Id) ? "max" : "high",
+                    ThinkingLevel.ExtraHigh => ModelRegistry.SupportsExtraHigh(model) ? "max" : "high",
+                    ThinkingLevel.Max => ModelRegistry.SupportsExtraHigh(model) ? "max" : "high",
                     _ => "high"
                 };
             }
@@ -360,10 +361,8 @@ public sealed partial class AnthropicProvider(HttpClient httpClient) : IApiProvi
     internal static bool IsAdaptiveThinkingModel(string modelId) =>
         modelId.Contains("opus-4-6", StringComparison.OrdinalIgnoreCase) ||
         modelId.Contains("opus-4.6", StringComparison.OrdinalIgnoreCase) ||
+        modelId.Contains("opus-4-8", StringComparison.OrdinalIgnoreCase) ||
+        modelId.Contains("opus-4.8", StringComparison.OrdinalIgnoreCase) ||
         modelId.Contains("sonnet-4-6", StringComparison.OrdinalIgnoreCase) ||
         modelId.Contains("sonnet-4.6", StringComparison.OrdinalIgnoreCase);
-
-    private static bool IsOpus46Model(string modelId) =>
-        modelId.Contains("opus-4-6", StringComparison.OrdinalIgnoreCase) ||
-        modelId.Contains("opus-4.6", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesOptions.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesOptions.cs
@@ -14,7 +14,7 @@ public record class CopilotMessagesOptions : Core.StreamOptions
 
     /// <summary>
     /// Adaptive thinking effort level: "low", "medium", "high", "max".
-    /// Used with Opus 4.6 and Sonnet 4.6 models served via GitHub Copilot.
+    /// Used with Opus 4.6/4.8 and Sonnet 4.6 adaptive-thinking models served via GitHub Copilot.
     /// </summary>
     public string? Effort { get; set; }
 

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesProvider.cs
@@ -110,13 +110,15 @@ public sealed partial class CopilotMessagesProvider(HttpClient httpClient) : IAp
             if (IsAdaptiveThinkingModel(model.Id))
             {
                 copilotOpts.ThinkingEnabled = true;
+                var maxCapable = ModelRegistry.SupportsExtraHigh(model);
                 copilotOpts.Effort = reasoning switch
                 {
                     ThinkingLevel.Minimal => "low",
                     ThinkingLevel.Low => "low",
                     ThinkingLevel.Medium => "medium",
                     ThinkingLevel.High => "high",
-                    ThinkingLevel.ExtraHigh => IsOpus46Model(model.Id) ? "max" : "high",
+                    ThinkingLevel.ExtraHigh => maxCapable ? "max" : "high",
+                    ThinkingLevel.Max => maxCapable ? "max" : "high",
                     _ => "high"
                 };
             }
@@ -326,10 +328,8 @@ public sealed partial class CopilotMessagesProvider(HttpClient httpClient) : IAp
     internal static bool IsAdaptiveThinkingModel(string modelId) =>
         modelId.Contains("opus-4-6", StringComparison.OrdinalIgnoreCase) ||
         modelId.Contains("opus-4.6", StringComparison.OrdinalIgnoreCase) ||
+        modelId.Contains("opus-4-8", StringComparison.OrdinalIgnoreCase) ||
+        modelId.Contains("opus-4.8", StringComparison.OrdinalIgnoreCase) ||
         modelId.Contains("sonnet-4-6", StringComparison.OrdinalIgnoreCase) ||
         modelId.Contains("sonnet-4.6", StringComparison.OrdinalIgnoreCase);
-
-    private static bool IsOpus46Model(string modelId) =>
-        modelId.Contains("opus-4-6", StringComparison.OrdinalIgnoreCase) ||
-        modelId.Contains("opus-4.6", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesProvider.cs
@@ -93,6 +93,7 @@ public sealed class CopilotResponsesProvider(
         ThinkingLevel.Medium => "medium",
         ThinkingLevel.High => "high",
         ThinkingLevel.ExtraHigh => "xhigh",
+        ThinkingLevel.Max => "xhigh",
         _ => "medium"
     };
 }

--- a/src/agent/BotNexus.Agent.Providers.Core/Compatibility/CompatResolver.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Compatibility/CompatResolver.cs
@@ -139,7 +139,8 @@ public static class CompatResolver
                 [ThinkingLevel.Low] = "default",
                 [ThinkingLevel.Medium] = "default",
                 [ThinkingLevel.High] = "default",
-                [ThinkingLevel.ExtraHigh] = "default"
+                [ThinkingLevel.ExtraHigh] = "default",
+                [ThinkingLevel.Max] = "default"
             };
         }
 

--- a/src/agent/BotNexus.Agent.Providers.Core/Models/Enums.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Models/Enums.cs
@@ -52,7 +52,8 @@ public enum ThinkingLevel
     [JsonStringEnumMemberName("low")] Low,
     [JsonStringEnumMemberName("medium")] Medium,
     [JsonStringEnumMemberName("high")] High,
-    [JsonStringEnumMemberName("xhigh")] ExtraHigh
+    [JsonStringEnumMemberName("xhigh")] ExtraHigh,
+    [JsonStringEnumMemberName("max")] Max
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter<CacheRetention>))]

--- a/src/agent/BotNexus.Agent.Providers.Core/Models/ThinkingBudgets.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Models/ThinkingBudgets.cs
@@ -25,4 +25,8 @@ public record ThinkingBudgets
     /// Gets or sets the extra high.
     /// </summary>
     public int? ExtraHigh { get; init; }
+    /// <summary>
+    /// Gets or sets the max (top thinking tier).
+    /// </summary>
+    public int? Max { get; init; }
 }

--- a/src/agent/BotNexus.Agent.Providers.Core/Registry/ModelRegistry.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Registry/ModelRegistry.cs
@@ -92,6 +92,39 @@ public sealed class ModelRegistry
     }
 
     /// <summary>
+    /// Returns the thinking levels a model legitimately supports, so the UI can offer
+    /// only valid choices. Non-reasoning models support none; reasoning models support
+    /// the base tiers, and ExtraHigh/Max are added only when the model advertises the
+    /// extra-high capability.
+    /// </summary>
+    /// <param name="model">The model.</param>
+    /// <returns>The supported thinking levels.</returns>
+    public static IReadOnlyList<ThinkingLevel> GetSupportedThinkingLevels(LlmModel model)
+    {
+        if (!model.Reasoning)
+            return [];
+
+        if (model.SupportsExtraHighThinking)
+            return
+            [
+                ThinkingLevel.Minimal,
+                ThinkingLevel.Low,
+                ThinkingLevel.Medium,
+                ThinkingLevel.High,
+                ThinkingLevel.ExtraHigh,
+                ThinkingLevel.Max
+            ];
+
+        return
+        [
+            ThinkingLevel.Minimal,
+            ThinkingLevel.Low,
+            ThinkingLevel.Medium,
+            ThinkingLevel.High
+        ];
+    }
+
+    /// <summary>
     /// Executes models are equal.
     /// </summary>
     /// <param name="a">The a.</param>

--- a/src/agent/BotNexus.Agent.Providers.Core/Streaming/CompletionsStreamEngine.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Streaming/CompletionsStreamEngine.cs
@@ -299,6 +299,7 @@ public static class CompletionsStreamEngine
             ThinkingLevel.Medium => "medium",
             ThinkingLevel.High => "high",
             ThinkingLevel.ExtraHigh => "xhigh",
+            ThinkingLevel.Max => "xhigh",
             _ => "medium"
         };
     }

--- a/src/agent/BotNexus.Agent.Providers.Core/Utilities/SimpleOptionsHelper.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Utilities/SimpleOptionsHelper.cs
@@ -14,7 +14,8 @@ public static class SimpleOptionsHelper
         [ThinkingLevel.Low] = 2048,
         [ThinkingLevel.Medium] = 8192,
         [ThinkingLevel.High] = 16384,
-        [ThinkingLevel.ExtraHigh] = 16384
+        [ThinkingLevel.ExtraHigh] = 16384,
+        [ThinkingLevel.Max] = 32768
     };
 
     /// <summary>
@@ -40,10 +41,11 @@ public static class SimpleOptionsHelper
 
     /// <summary>
     /// Clamp reasoning level to High for models that don't support ExtraHigh.
+    /// Both ExtraHigh and Max collapse to High on models without the capability.
     /// </summary>
     public static ThinkingLevel? ClampReasoning(ThinkingLevel? level)
     {
-        if (level == ThinkingLevel.ExtraHigh)
+        if (level is ThinkingLevel.ExtraHigh or ThinkingLevel.Max)
             return ThinkingLevel.High;
         return level;
     }
@@ -65,6 +67,7 @@ public static class SimpleOptionsHelper
             ThinkingLevel.Medium => customBudgets.Medium,
             ThinkingLevel.High => customBudgets.High,
             ThinkingLevel.ExtraHigh => customBudgets.ExtraHigh,
+            ThinkingLevel.Max => customBudgets.Max,
             _ => null
         };
     }

--- a/src/agent/BotNexus.Agent.Providers.OpenAI/OpenAIResponsesProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.OpenAI/OpenAIResponsesProvider.cs
@@ -87,6 +87,7 @@ public sealed class OpenAIResponsesProvider(
         ThinkingLevel.Medium => "medium",
         ThinkingLevel.High => "high",
         ThinkingLevel.ExtraHigh => "xhigh",
+        ThinkingLevel.Max => "xhigh",
         _ => "medium"
     };
 }

--- a/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/AnthropicProviderTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/AnthropicProviderTests.cs
@@ -85,16 +85,16 @@ public class AnthropicProviderTests
     }
 
     [Theory]
-    [InlineData("claude-opus-4-6", "max")]
-    [InlineData("claude-opus-4.6", "max")]
-    [InlineData("claude-sonnet-4-5", "high")]
-    [InlineData("claude-haiku-4-5", "high")]
-    public async Task StreamSimple_ExtraHigh_UsesExpectedReasoningGuard(string modelId, string expectedEffort)
+    [InlineData("claude-opus-4-6", true, "max")]
+    [InlineData("claude-opus-4.6", true, "max")]
+    [InlineData("claude-sonnet-4-5", false, "high")]
+    [InlineData("claude-haiku-4-5", false, "high")]
+    public async Task StreamSimple_ExtraHigh_UsesExpectedReasoningGuard(string modelId, bool supportsExtraHigh, string expectedEffort)
     {
         var handler = new RecordingHandler();
         var provider = new AnthropicProvider(new HttpClient(handler));
         // Use high maxTokens so thinking budget isn't clamped by model limits
-        var model = TestHelpers.MakeModel(id: modelId, reasoning: true, maxTokens: 200000);
+        var model = TestHelpers.MakeModel(id: modelId, reasoning: true, maxTokens: 200000, supportsExtraHigh: supportsExtraHigh);
         var context = TestHelpers.MakeContext();
 
         var stream = provider.StreamSimple(model, context, new Core.SimpleStreamOptions

--- a/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/TestHelpers.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/TestHelpers.cs
@@ -11,7 +11,8 @@ internal static class TestHelpers
         string api = "anthropic-messages",
         string provider = "anthropic",
         bool reasoning = true,
-        int maxTokens = 16384) => new(
+        int maxTokens = 16384,
+        bool supportsExtraHigh = false) => new(
         Id: id,
         Name: id,
         Api: api,
@@ -21,7 +22,8 @@ internal static class TestHelpers
         Input: ["text", "image"],
         Cost: new ModelCost(3.0m, 15.0m, 0.3m, 3.75m),
         ContextWindow: 200000,
-        MaxTokens: maxTokens);
+        MaxTokens: maxTokens,
+        SupportsExtraHighThinking: supportsExtraHigh);
 
     public static Context MakeContext(string? systemPrompt = "You are helpful") => new(
         SystemPrompt: systemPrompt,

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Messages/CopilotMessagesThinkingMappingTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Messages/CopilotMessagesThinkingMappingTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using BotNexus.Agent.Providers.Copilot.Messages;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests.Messages;
+
+/// <summary>
+/// Issue #1702 - adaptive thinking effort mapping for Copilot Opus models.
+/// Proves that Opus 4.8 (and 4.6) honour the Max thinking level by emitting
+/// "max" effort, that mapping is gated by the SupportsExtraHighThinking
+/// capability rather than a model-id literal, and that every thinking level
+/// maps to a valid adaptive effort string. ExtraHigh on a Max-capable model
+/// continues to map to "max" for parity with the prior 4.6 behaviour.
+/// </summary>
+public class CopilotMessagesThinkingMappingTests
+{
+    private static LlmModel BuildAdaptiveModel(string id, bool supportsExtraHigh) => new(
+        Id: id,
+        Name: id,
+        Api: "github-copilot-messages",
+        Provider: "github-copilot",
+        BaseUrl: "https://api.enterprise.githubcopilot.com",
+        Reasoning: true,
+        Input: ["text", "image"],
+        Cost: new ModelCost(0, 0, 0, 0),
+        ContextWindow: 1000000,
+        MaxTokens: 64000,
+        SupportsExtraHighThinking: supportsExtraHigh);
+
+    private static Context BuildContext() => new(
+        SystemPrompt: "test",
+        Messages: [new UserMessage(new UserMessageContent("hi"), 1_700_000_000_000L)],
+        Tools: []);
+
+    private static async Task<string?> CaptureEffortAsync(string modelId, ThinkingLevel level, bool supportsExtraHigh)
+    {
+        var handler = new RecordingHandler();
+        var provider = new CopilotMessagesProvider(new HttpClient(handler));
+        var model = BuildAdaptiveModel(modelId, supportsExtraHigh);
+
+        var stream = provider.StreamSimple(model, BuildContext(), new SimpleStreamOptions
+        {
+            ApiKey = "test-token",
+            Reasoning = level,
+        });
+        _ = await stream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        var body = JsonNode.Parse(handler.RequestBody!)!.AsObject();
+        return body["output_config"]?["effort"]?.GetValue<string>();
+    }
+
+    [Fact]
+    public async Task Opus48_Max_MapsToMaxEffort()
+    {
+        var effort = await CaptureEffortAsync("claude-opus-4.8", ThinkingLevel.Max, supportsExtraHigh: true);
+        effort.ShouldBe("max", "Opus 4.8 must honour the Max thinking level instead of downgrading to high.");
+    }
+
+    [Fact]
+    public async Task Opus46_Max_MapsToMaxEffort()
+    {
+        var effort = await CaptureEffortAsync("claude-opus-4.6", ThinkingLevel.Max, supportsExtraHigh: true);
+        effort.ShouldBe("max");
+    }
+
+    [Fact]
+    public async Task Opus48_ExtraHigh_MapsToMaxEffort()
+    {
+        var effort = await CaptureEffortAsync("claude-opus-4.8", ThinkingLevel.ExtraHigh, supportsExtraHigh: true);
+        effort.ShouldBe("max", "Max-capable models map ExtraHigh to max effort, gated by capability not model id.");
+    }
+
+    [Fact]
+    public async Task Max_OnNonCapableModel_DoesNotEmitMax()
+    {
+        // Capability gate: an adaptive model that does not advertise extra-high must not be sent "max".
+        var effort = await CaptureEffortAsync("claude-sonnet-4.6", ThinkingLevel.Max, supportsExtraHigh: false);
+        effort.ShouldBe("high");
+    }
+
+    [Theory]
+    [InlineData(ThinkingLevel.Minimal, "low")]
+    [InlineData(ThinkingLevel.Low, "low")]
+    [InlineData(ThinkingLevel.Medium, "medium")]
+    [InlineData(ThinkingLevel.High, "high")]
+    [InlineData(ThinkingLevel.ExtraHigh, "max")]
+    [InlineData(ThinkingLevel.Max, "max")]
+    public async Task AllLevels_MapToValidEffort(ThinkingLevel level, string expected)
+    {
+        var effort = await CaptureEffortAsync("claude-opus-4.8", level, supportsExtraHigh: true);
+        effort.ShouldBe(expected);
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public string? RequestBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+            const string sse =
+                "event: message_start\n" +
+                "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01Fixture\"}}\n\n" +
+                "event: message_stop\n" +
+                "data: {\"type\":\"message_stop\"}\n\n";
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(sse, Encoding.UTF8, "text/event-stream"),
+            };
+        }
+    }
+}

--- a/tests/agent/BotNexus.Agent.Providers.Core.Tests/Registry/ModelRegistryTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Core.Tests/Registry/ModelRegistryTests.cs
@@ -32,6 +32,40 @@ public class ModelRegistryTests : IDisposable
         SupportsExtraHighThinking: supportsExtraHighThinking);
 
     [Fact]
+    public void GetSupportedThinkingLevels_NonReasoningModel_IsEmpty()
+    {
+        var model = MakeModel(supportsExtraHighThinking: false) with { Reasoning = false };
+
+        var levels = ModelRegistry.GetSupportedThinkingLevels(model);
+
+        levels.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetSupportedThinkingLevels_ReasoningWithoutExtraHigh_ExcludesExtraHighAndMax()
+    {
+        var model = MakeModel(supportsExtraHighThinking: false) with { Reasoning = true };
+
+        var levels = ModelRegistry.GetSupportedThinkingLevels(model);
+
+        levels.ShouldContain(ThinkingLevel.Minimal);
+        levels.ShouldContain(ThinkingLevel.High);
+        levels.ShouldNotContain(ThinkingLevel.ExtraHigh);
+        levels.ShouldNotContain(ThinkingLevel.Max);
+    }
+
+    [Fact]
+    public void GetSupportedThinkingLevels_ExtraHighCapable_IncludesExtraHighAndMax()
+    {
+        var model = MakeModel(supportsExtraHighThinking: true) with { Reasoning = true };
+
+        var levels = ModelRegistry.GetSupportedThinkingLevels(model);
+
+        levels.ShouldContain(ThinkingLevel.ExtraHigh);
+        levels.ShouldContain(ThinkingLevel.Max);
+    }
+
+    [Fact]
     public void Register_AndRetrieve_ReturnsModel()
     {
         var model = MakeModel();

--- a/tests/agent/BotNexus.Agent.Providers.Core.Tests/Utilities/SimpleOptionsHelperTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Core.Tests/Utilities/SimpleOptionsHelperTests.cs
@@ -171,10 +171,33 @@ public class SimpleOptionsHelperTests
     [InlineData(ThinkingLevel.Low, 2048)]
     [InlineData(ThinkingLevel.Medium, 8192)]
     [InlineData(ThinkingLevel.High, 16384)]
+    [InlineData(ThinkingLevel.ExtraHigh, 16384)]
+    [InlineData(ThinkingLevel.Max, 32768)]
     public void GetDefaultThinkingBudget_ReturnsCorrectDefaults(ThinkingLevel level, int expectedBudget)
     {
         var result = SimpleOptionsHelper.GetDefaultThinkingBudget(level);
 
         result.ShouldBe(expectedBudget);
+    }
+
+    [Fact]
+    public void ClampReasoning_ConvertsMax_ToHigh()
+    {
+        var result = SimpleOptionsHelper.ClampReasoning(ThinkingLevel.Max);
+
+        result.ShouldBe(ThinkingLevel.High);
+    }
+
+    [Fact]
+    public void GetBudgetForLevel_Max_ReturnsMatchingBudget()
+    {
+        var budgets = new ThinkingBudgets
+        {
+            Max = 50000
+        };
+
+        var result = SimpleOptionsHelper.GetBudgetForLevel(ThinkingLevel.Max, budgets);
+
+        result.ShouldBe(50000);
     }
 }


### PR DESCRIPTION
Closes #1702

## Changes
PBI1 of the model/thinking/context epic (#1701). Adds full thinking-level parity with VS Code (Max) and fixes capability-gated mapping so opus 4.8 reaches "max".

- **ThinkingLevel.Max** added as new top level (`Minimal/Low/Medium/High/ExtraHigh/Max`), JSON name `"max"`. ExtraHigh=`xhigh`, Max=`max`.
- **CopilotMessagesProvider**: adaptive-thinking effort mapping now gates on `ModelRegistry.SupportsExtraHigh(model)` (capability) instead of an `IsOpus46Model` literal. Both `ExtraHigh` and `Max` map to `"max"` on a max-capable model, `"high"` otherwise. `opus-4-8`/`opus-4.8` added to the adaptive-thinking set so 4.8 honours max.
- **ThinkingBudgets / SimpleOptionsHelper**: Max budget defined; helper defaults extended for the new level.
- **ModelRegistry**: per-model supported-thinking capability metadata so resolver/UI offer only valid levels.
- Anthropic / OpenAI providers + CompletionsStreamEngine updated for the new enum member (exhaustive switch sites covered).

## Tests
RED->GREEN proven (neutralising `Max => "max"` fails Opus48_Max + 2 mapping tests). New `CopilotMessagesThinkingMappingTests`; ModelRegistry + SimpleOptionsHelper test coverage. Full `test-impacted.ps1` green (Copilot 130, Core 354, Anthropic 125, Gateway 3360, Arch 212, Scenarios 29). ASCII clean.

## Merge Notes
Foundation PBI for #1701. File-disjoint from the 3 open PRs (#1724 gateway-config, #1725 agent-loop, #1726 router) and from the cron-noop PR (#1727). Can merge in any order; later PBIs (#1703-1707) build on this enum.
