### PR TITLE
refactor(api): extract canvas cluster into dedicated controller

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationCanvasController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationCanvasController.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BotNexus.Gateway.Api.Controllers;
+
+/// <summary>
+/// REST API for conversation canvas rendering and canvas-state persistence. Extracted from
+/// <see cref="ConversationsController"/> (#1688) so the canvas concern can be exercised against a
+/// single-dependency surface: it touches only the conversation store and the optional canvas
+/// notifiers, which are orthogonal to conversation lifecycle, bindings, archival, and audit.
+/// All route templates are preserved verbatim from the original controller so client behaviour is
+/// unchanged.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+public sealed class ConversationCanvasController : ControllerBase
+{
+    private readonly IConversationStore _conversations;
+    private readonly IReadOnlyList<IAgentCanvasNotifier> _canvasNotifiers;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConversationCanvasController"/> class.
+    /// </summary>
+    /// <param name="conversations">The conversation store - the controller's only required dependency.</param>
+    /// <param name="canvasNotifiers">Optional notifiers that broadcast canvas state changes to connected
+    /// clients. Defaults to none so the canvas-state CRUD endpoints can be unit-tested against an in-memory
+    /// store without transport scaffolding.</param>
+    public ConversationCanvasController(
+        IConversationStore conversations,
+        IEnumerable<IAgentCanvasNotifier>? canvasNotifiers = null)
+    {
+        _conversations = conversations;
+        _canvasNotifiers = canvasNotifiers?.ToArray() ?? [];
+    }
+
+    /// <summary>Gets the current canvas HTML for a conversation.</summary>
+    [HttpGet("~/api/agents/{agentId}/conversations/{conversationId}/canvas")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> GetCanvas(string agentId, string conversationId, CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken).ConfigureAwait(false);
+        if (conversation is null)
+            return NotFound();
+        if (string.IsNullOrEmpty(conversation.CanvasHtml))
+            return NoContent();
+        return Content(conversation.CanvasHtml, "text/html");
+    }
+
+    /// <summary>Saves canvas HTML for a conversation.</summary>
+    [HttpPut("~/api/agents/{agentId}/conversations/{conversationId}/canvas")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> PutCanvas(string agentId, string conversationId, [FromBody] string html, CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken).ConfigureAwait(false);
+        if (conversation is null)
+            return NotFound();
+        conversation.CanvasHtml = string.IsNullOrEmpty(html) ? null : html;
+        await _conversations.SaveAsync(conversation, cancellationToken).ConfigureAwait(false);
+        return NoContent();
+    }
+
+    // -----------------------------------------------------------------------
+    // Canvas State CRUD (Issue #1066)
+    // -----------------------------------------------------------------------
+
+    /// <summary>Returns the full canvas state dictionary for a conversation (empty object if none).</summary>
+    [HttpGet("{conversationId}/canvas-state")]
+    [ProducesResponseType(typeof(Dictionary<string, JsonElement>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> GetCanvasState(string conversationId, CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
+        if (conversation is null)
+            return NotFound();
+        var state = await _conversations.GetCanvasStateAsync(ConversationId.From(conversationId), cancellationToken);
+        return Ok(state ?? new Dictionary<string, JsonElement>());
+    }
+
+    /// <summary>Returns a single canvas state key value, or 404 if not found.</summary>
+    [HttpGet("{conversationId}/canvas-state/{key}")]
+    [ProducesResponseType(typeof(JsonElement), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> GetCanvasStateKey(string conversationId, string key, CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
+        if (conversation is null)
+            return NotFound();
+        var state = await _conversations.GetCanvasStateAsync(ConversationId.From(conversationId), cancellationToken);
+        if (state is null || !state.TryGetValue(key, out var value))
+            return NotFound();
+        return Ok(value);
+    }
+
+    /// <summary>Upserts a canvas state key. Body is the raw JSON value.</summary>
+    [HttpPost("{conversationId}/canvas-state/{key}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> SetCanvasStateKey(
+        string conversationId,
+        string key,
+        [FromBody] JsonElement value,
+        CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
+        if (conversation is null)
+            return NotFound();
+        await _conversations.SetCanvasStateKeyAsync(ConversationId.From(conversationId), key, value, cancellationToken);
+        foreach (var notifier in _canvasNotifiers)
+            await notifier.NotifyCanvasStateChangedAsync(conversationId, key, value, cancellationToken);
+        return Ok();
+    }
+
+    /// <summary>Removes a canvas state key. Idempotent - returns 204 even if key didn't exist.</summary>
+    [HttpDelete("{conversationId}/canvas-state/{key}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> DeleteCanvasStateKey(
+        string conversationId,
+        string key,
+        CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
+        if (conversation is null)
+            return NotFound();
+        await _conversations.DeleteCanvasStateKeyAsync(ConversationId.From(conversationId), key, cancellationToken);
+        foreach (var notifier in _canvasNotifiers)
+            await notifier.NotifyCanvasStateChangedAsync(conversationId, key, null, cancellationToken);
+        return NoContent();
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -1,10 +1,8 @@
-using System.Text.Json;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
 using BotNexus.Gateway.Conversations;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Services;
 using BotNexus.Gateway.Abstractions.Models;
@@ -31,7 +29,6 @@ public sealed class ConversationsController : ControllerBase
     private readonly ILogger<ConversationsController> _logger;
     private readonly IAskUserResponseRegistry? _askUserResponseRegistry;
     private readonly IConversationResetService? _resetService;
-    private readonly IReadOnlyList<IAgentCanvasNotifier> _canvasNotifiers;
     private readonly IConversationAuditLog? _auditLog;
     private readonly IConversationHistoryAssembler _historyAssembler;
 
@@ -47,7 +44,6 @@ public sealed class ConversationsController : ControllerBase
     /// and Reset endpoints delegate the active-session seal + memory flush + ask-user cancel to it. When omitted,
     /// the controller falls back to a best-effort in-place seal — used only by tests that construct the controller
     /// directly without DI.</param>
-    /// <param name="canvasNotifiers">Optional notifiers that broadcast canvas state changes to connected clients.</param>
     /// <param name="auditLog">Optional audit log for recording conversation mutations.</param>
     /// <param name="historyAssembler">Assembles cross-session conversation history. When omitted (legacy
     /// test harnesses constructing the controller directly), a default instance over the same stores is used.</param>
@@ -58,7 +54,6 @@ public sealed class ConversationsController : ControllerBase
         ILogger<ConversationsController>? logger = null,
         IAskUserResponseRegistry? askUserResponseRegistry = null,
         IConversationResetService? resetService = null,
-        IEnumerable<IAgentCanvasNotifier>? canvasNotifiers = null,
         IConversationAuditLog? auditLog = null,
         IConversationHistoryAssembler? historyAssembler = null)
     {
@@ -68,7 +63,6 @@ public sealed class ConversationsController : ControllerBase
         _logger = logger ?? NullLogger<ConversationsController>.Instance;
         _askUserResponseRegistry = askUserResponseRegistry;
         _resetService = resetService;
-        _canvasNotifiers = canvasNotifiers?.ToArray() ?? [];
         _auditLog = auditLog;
         // When DI omits the assembler (legacy test harnesses that construct the controller
         // directly), fall back to the default implementation over the same stores so the
@@ -562,35 +556,6 @@ public sealed class ConversationsController : ControllerBase
         await _sessions.SaveAsync(session, cancellationToken);
     }
 
-    /// <summary>Gets the current canvas HTML for a conversation.</summary>
-    [HttpGet("~/api/agents/{agentId}/conversations/{conversationId}/canvas")]
-    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> GetCanvas(string agentId, string conversationId, CancellationToken cancellationToken)
-    {
-        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken).ConfigureAwait(false);
-        if (conversation is null)
-            return NotFound();
-        if (string.IsNullOrEmpty(conversation.CanvasHtml))
-            return NoContent();
-        return Content(conversation.CanvasHtml, "text/html");
-    }
-
-    /// <summary>Saves canvas HTML for a conversation.</summary>
-    [HttpPut("~/api/agents/{agentId}/conversations/{conversationId}/canvas")]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> PutCanvas(string agentId, string conversationId, [FromBody] string html, CancellationToken cancellationToken)
-    {
-        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken).ConfigureAwait(false);
-        if (conversation is null)
-            return NotFound();
-        conversation.CanvasHtml = string.IsNullOrEmpty(html) ? null : html;
-        await _conversations.SaveAsync(conversation, cancellationToken).ConfigureAwait(false);
-        return NoContent();
-    }
-
     /// <summary>
     /// Gets the current per-conversation todo state (the raw <c>TodoJson</c> payload) for a
     /// conversation, so the portal Todo panel can hydrate on initial load (#1464 step 5).
@@ -653,84 +618,6 @@ public sealed class ConversationsController : ControllerBase
         if (conversation is null) return NotFound();
         await _conversations.PinAsync(ConversationId.From(conversationId), false, cancellationToken);
         await NotifyConversationChangedBestEffortAsync("updated", conversation.AgentId.Value, conversationId, cancellationToken);
-        return NoContent();
-    }
-
-    // -----------------------------------------------------------------------
-    // Canvas State CRUD (Issue #1066)
-    // -----------------------------------------------------------------------
-
-    /// <summary>Returns the full canvas state dictionary for a conversation (empty object if none).</summary>
-    [HttpGet("{conversationId}/canvas-state")]
-    [ProducesResponseType(typeof(Dictionary<string, JsonElement>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> GetCanvasState(string conversationId, CancellationToken cancellationToken)
-    {
-        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
-        if (conversation is null)
-            return NotFound();
-
-        var state = await _conversations.GetCanvasStateAsync(ConversationId.From(conversationId), cancellationToken);
-        return Ok(state ?? new Dictionary<string, JsonElement>());
-    }
-
-    /// <summary>Returns a single canvas state key value, or 404 if not found.</summary>
-    [HttpGet("{conversationId}/canvas-state/{key}")]
-    [ProducesResponseType(typeof(JsonElement), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> GetCanvasStateKey(string conversationId, string key, CancellationToken cancellationToken)
-    {
-        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
-        if (conversation is null)
-            return NotFound();
-
-        var state = await _conversations.GetCanvasStateAsync(ConversationId.From(conversationId), cancellationToken);
-        if (state is null || !state.TryGetValue(key, out var value))
-            return NotFound();
-
-        return Ok(value);
-    }
-
-    /// <summary>Upserts a canvas state key. Body is the raw JSON value.</summary>
-    [HttpPost("{conversationId}/canvas-state/{key}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> SetCanvasStateKey(
-        string conversationId,
-        string key,
-        [FromBody] JsonElement value,
-        CancellationToken cancellationToken)
-    {
-        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
-        if (conversation is null)
-            return NotFound();
-
-        await _conversations.SetCanvasStateKeyAsync(ConversationId.From(conversationId), key, value, cancellationToken);
-
-        foreach (var notifier in _canvasNotifiers)
-            await notifier.NotifyCanvasStateChangedAsync(conversationId, key, value, cancellationToken);
-
-        return Ok();
-    }
-
-    /// <summary>Removes a canvas state key. Idempotent — returns 204 even if key didn't exist.</summary>
-    [HttpDelete("{conversationId}/canvas-state/{key}")]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> DeleteCanvasStateKey(
-        string conversationId,
-        string key,
-        CancellationToken cancellationToken)
-    {
-        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
-        if (conversation is null)
-            return NotFound();
-
-        await _conversations.DeleteCanvasStateKeyAsync(ConversationId.From(conversationId), key, cancellationToken);
-
-        foreach (var notifier in _canvasNotifiers)
-            await notifier.NotifyCanvasStateChangedAsync(conversationId, key, null, cancellationToken);
-
         return NoContent();
     }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationCanvasControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationCanvasControllerTests.cs
@@ -1,29 +1,93 @@
 using System.Text.Json;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Api.Controllers;
 using BotNexus.Gateway.Conversations;
-using BotNexus.Gateway.Sessions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BotNexus.Gateway.Tests;
 
 /// <summary>
-/// Tests for the canvas state REST API endpoints (Issue #1066).
-/// Verifies CRUD operations on conversation canvas state via ConversationsController.
+/// Tests for the canvas/canvas-state REST API endpoints (Issues #1066 + #1688).
+/// Verifies the six canvas endpoints on the dedicated <see cref="ConversationCanvasController"/>,
+/// which depends only on <see cref="IConversationStore"/> (plus optional canvas notifiers),
+/// exercising canvas-state CRUD against an in-memory store without the heavyweight
+/// conversation-CRUD dependency surface.
 /// </summary>
-public sealed class ConversationsControllerCanvasStateTests
+public sealed class ConversationCanvasControllerTests
 {
     private static readonly ConversationId TestConversationId = ConversationId.From("c_canvas_test");
+
+    // -- Canvas HTML -------------------------------------------------------
+
+    [Fact]
+    public async Task GetCanvas_NoHtml_Returns204()
+    {
+        var (controller, _) = CreateController();
+        var result = await controller.GetCanvas("test-agent", TestConversationId.Value, CancellationToken.None);
+        result.ShouldBeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task GetCanvas_WithHtml_ReturnsContent()
+    {
+        var (controller, store) = CreateController();
+        var conversation = await store.GetAsync(TestConversationId);
+        conversation!.CanvasHtml = "<h1>hi</h1>";
+        await store.SaveAsync(conversation);
+        var result = await controller.GetCanvas("test-agent", TestConversationId.Value, CancellationToken.None);
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.Content.ShouldBe("<h1>hi</h1>");
+        content.ContentType.ShouldBe("text/html");
+    }
+
+    [Fact]
+    public async Task GetCanvas_NonExistentConversation_Returns404()
+    {
+        var (controller, _) = CreateController();
+        var result = await controller.GetCanvas("test-agent", "c_nonexistent", CancellationToken.None);
+        result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task PutCanvas_SavesHtml_Returns204()
+    {
+        var (controller, store) = CreateController();
+        var result = await controller.PutCanvas("test-agent", TestConversationId.Value, "<p>x</p>", CancellationToken.None);
+        result.ShouldBeOfType<NoContentResult>();
+        var conversation = await store.GetAsync(TestConversationId);
+        conversation!.CanvasHtml.ShouldBe("<p>x</p>");
+    }
+
+    [Fact]
+    public async Task PutCanvas_EmptyHtml_ClearsToNull()
+    {
+        var (controller, store) = CreateController();
+        var conversation = await store.GetAsync(TestConversationId);
+        conversation!.CanvasHtml = "<p>x</p>";
+        await store.SaveAsync(conversation);
+        await controller.PutCanvas("test-agent", TestConversationId.Value, "", CancellationToken.None);
+        var updated = await store.GetAsync(TestConversationId);
+        updated!.CanvasHtml.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task PutCanvas_NonExistentConversation_Returns404()
+    {
+        var (controller, _) = CreateController();
+        var result = await controller.PutCanvas("test-agent", "c_nonexistent", "<p>x</p>", CancellationToken.None);
+        result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    // -- Canvas state CRUD -------------------------------------------------
 
     [Fact]
     public async Task GetCanvasState_EmptyConversation_ReturnsEmptyObject()
     {
         var (controller, _) = CreateController();
-
         var result = await controller.GetCanvasState(TestConversationId.Value, CancellationToken.None);
-
         var okResult = result.ShouldBeOfType<OkObjectResult>();
         var state = okResult.Value as Dictionary<string, JsonElement>;
         state.ShouldNotBeNull();
@@ -34,9 +98,7 @@ public sealed class ConversationsControllerCanvasStateTests
     public async Task GetCanvasState_NonExistentConversation_Returns404()
     {
         var (controller, _) = CreateController();
-
         var result = await controller.GetCanvasState("c_nonexistent", CancellationToken.None);
-
         result.ShouldBeOfType<NotFoundResult>();
     }
 
@@ -46,9 +108,7 @@ public sealed class ConversationsControllerCanvasStateTests
         var (controller, store) = CreateController();
         var value = JsonDocument.Parse("42").RootElement.Clone();
         await store.SetCanvasStateKeyAsync(TestConversationId, "counter", value);
-
         var result = await controller.GetCanvasStateKey(TestConversationId.Value, "counter", CancellationToken.None);
-
         var okResult = result.ShouldBeOfType<OkObjectResult>();
         var returnedValue = (JsonElement)okResult.Value!;
         returnedValue.GetInt32().ShouldBe(42);
@@ -58,9 +118,7 @@ public sealed class ConversationsControllerCanvasStateTests
     public async Task GetCanvasStateKey_MissingKey_Returns404()
     {
         var (controller, _) = CreateController();
-
         var result = await controller.GetCanvasStateKey(TestConversationId.Value, "missing", CancellationToken.None);
-
         result.ShouldBeOfType<NotFoundResult>();
     }
 
@@ -68,9 +126,7 @@ public sealed class ConversationsControllerCanvasStateTests
     public async Task GetCanvasStateKey_NonExistentConversation_Returns404()
     {
         var (controller, _) = CreateController();
-
         var result = await controller.GetCanvasStateKey("c_nonexistent", "key", CancellationToken.None);
-
         result.ShouldBeOfType<NotFoundResult>();
     }
 
@@ -79,12 +135,8 @@ public sealed class ConversationsControllerCanvasStateTests
     {
         var (controller, store) = CreateController();
         var value = JsonDocument.Parse("\"hello\"").RootElement.Clone();
-
         var result = await controller.SetCanvasStateKey(TestConversationId.Value, "greeting", value, CancellationToken.None);
-
         result.ShouldBeOfType<OkResult>();
-
-        // Verify persisted
         var state = await store.GetCanvasStateAsync(TestConversationId);
         state.ShouldNotBeNull();
         state!["greeting"].GetString().ShouldBe("hello");
@@ -96,10 +148,8 @@ public sealed class ConversationsControllerCanvasStateTests
         var (controller, store) = CreateController();
         var first = JsonDocument.Parse("1").RootElement.Clone();
         var second = JsonDocument.Parse("2").RootElement.Clone();
-
         await controller.SetCanvasStateKey(TestConversationId.Value, "version", first, CancellationToken.None);
         var result = await controller.SetCanvasStateKey(TestConversationId.Value, "version", second, CancellationToken.None);
-
         result.ShouldBeOfType<OkResult>();
         var state = await store.GetCanvasStateAsync(TestConversationId);
         state!["version"].GetInt32().ShouldBe(2);
@@ -110,10 +160,20 @@ public sealed class ConversationsControllerCanvasStateTests
     {
         var (controller, _) = CreateController();
         var value = JsonDocument.Parse("true").RootElement.Clone();
-
         var result = await controller.SetCanvasStateKey("c_nonexistent", "key", value, CancellationToken.None);
-
         result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task SetCanvasStateKey_NotifiesCanvasNotifiers()
+    {
+        var notifier = new RecordingCanvasNotifier();
+        var (controller, _) = CreateController(notifier);
+        var value = JsonDocument.Parse("7").RootElement.Clone();
+        await controller.SetCanvasStateKey(TestConversationId.Value, "k", value, CancellationToken.None);
+        notifier.Changes.Count.ShouldBe(1);
+        notifier.Changes[0].Key.ShouldBe("k");
+        notifier.Changes[0].Value.ShouldNotBeNull();
     }
 
     [Fact]
@@ -122,12 +182,8 @@ public sealed class ConversationsControllerCanvasStateTests
         var (controller, store) = CreateController();
         var value = JsonDocument.Parse("\"temp\"").RootElement.Clone();
         await store.SetCanvasStateKeyAsync(TestConversationId, "temp", value);
-
         var result = await controller.DeleteCanvasStateKey(TestConversationId.Value, "temp", CancellationToken.None);
-
         result.ShouldBeOfType<NoContentResult>();
-
-        // Verify deleted
         var state = await store.GetCanvasStateAsync(TestConversationId);
         state.ShouldNotBeNull();
         state!.ContainsKey("temp").ShouldBeFalse();
@@ -137,10 +193,7 @@ public sealed class ConversationsControllerCanvasStateTests
     public async Task DeleteCanvasStateKey_MissingKey_Returns204()
     {
         var (controller, _) = CreateController();
-
-        // Deleting a non-existent key is idempotent
         var result = await controller.DeleteCanvasStateKey(TestConversationId.Value, "no_such_key", CancellationToken.None);
-
         result.ShouldBeOfType<NoContentResult>();
     }
 
@@ -148,13 +201,21 @@ public sealed class ConversationsControllerCanvasStateTests
     public async Task DeleteCanvasStateKey_NonExistentConversation_Returns404()
     {
         var (controller, _) = CreateController();
-
         var result = await controller.DeleteCanvasStateKey("c_nonexistent", "key", CancellationToken.None);
-
         result.ShouldBeOfType<NotFoundResult>();
     }
 
-    private static (ConversationsController, InMemoryConversationStore) CreateController()
+    [Fact]
+    public async Task DeleteCanvasStateKey_NotifiesCanvasNotifiers_WithNullValue()
+    {
+        var notifier = new RecordingCanvasNotifier();
+        var (controller, _) = CreateController(notifier);
+        await controller.DeleteCanvasStateKey(TestConversationId.Value, "k", CancellationToken.None);
+        notifier.Changes.Count.ShouldBe(1);
+        notifier.Changes[0].Value.ShouldBeNull();
+    }
+
+    private static (ConversationCanvasController, InMemoryConversationStore) CreateController(IAgentCanvasNotifier? notifier = null)
     {
         var store = new InMemoryConversationStore();
         store.CreateAsync(new Conversation
@@ -166,9 +227,22 @@ public sealed class ConversationsControllerCanvasStateTests
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow
         }).GetAwaiter().GetResult();
-
-        var sessions = new InMemorySessionStore();
-        var controller = new ConversationsController(store, sessions);
+        var notifiers = notifier is null ? null : new[] { notifier };
+        var controller = new ConversationCanvasController(store, notifiers);
         return (controller, store);
+    }
+
+    private sealed class RecordingCanvasNotifier : IAgentCanvasNotifier
+    {
+        public List<(string Key, object? Value)> Changes { get; } = [];
+
+        public Task NotifyCanvasUpdatedAsync(string agentId, string conversationId, string html, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task NotifyCanvasStateChangedAsync(string conversationId, string key, object? value, CancellationToken cancellationToken = default)
+        {
+            Changes.Add((key, value));
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Extracts the canvas/canvas-state cluster (6 endpoints) out of the 20-endpoint
`ConversationsController` into a dedicated `ConversationCanvasController` whose only
required dependency is `IConversationStore`. Continues the #1389 history-extraction
precedent. Behaviour-preserving: route templates moved verbatim, no contract changes.

## Endpoints moved
- `GetCanvas` / `PutCanvas` (`~/api/agents/{agentId}/conversations/{conversationId}/canvas`)
- `GetCanvasState` (`{conversationId}/canvas-state`)
- `GetCanvasStateKey` / `SetCanvasStateKey` / `DeleteCanvasStateKey` (`{conversationId}/canvas-state/{key}`)

## Changes
- New `ConversationCanvasController` ([ApiController], MVC-discovered like `ChannelHistoryController`); only required dep is `IConversationStore`, with optional `IAgentCanvasNotifier` list preserved for state-change broadcast.
- `ConversationsController`: drops the now-unreferenced `IReadOnlyList<IAgentCanvasNotifier>` ctor dep and orphaned `System.Text.Json` / `Abstractions.Agents` usings; `GetTodo`/`GetPendingAskUser` kept (out of scope).
- Canvas-state CRUD tests migrated to the new 1-dependency controller (no full-controller scaffolding).

## Verification
- `test-impacted.ps1`: All impacted tests passed (Architecture.Tests + Scenarios.Tests green).
- 19/19 canvas controller tests pass; all routes preserved.

Closes #1688

<!-- farnsworth:pr-opened-1688 -->