### PR TITLE
refactor(#1625): collapse gateway hub boilerplate behind an application-service facade

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -18,7 +18,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace BotNexus.Extensions.Channels.SignalR;
 
@@ -31,66 +30,54 @@ namespace BotNexus.Extensions.Channels.SignalR;
 /// When no authentication scheme is registered, the hub permits anonymous access
 /// for backward compatibility during the Phase 1 transition.
 /// </summary>
+/// <remarks>
+/// The hub is a thin transport adapter: SignalR-context-bound collaborators (supervisor,
+/// session store, activity broadcaster, conversation router/store, ask-user registry) are
+/// injected directly, while the gateway's inbound-dispatch, warmup, conversation-resolution,
+/// compaction, and conversation-reset operations are grouped behind
+/// <see cref="IGatewayHubApplicationService"/>. Every client-callable control method resolves
+/// its ids once through <see cref="ResolveCallContext"/> and publishes activity through the
+/// shared <see cref="PublishActivityAsync"/> path so id-normalisation and envelope construction
+/// live in one place.
+/// </remarks>
 [Authorize(Policy = SignalRAuthPolicy.PolicyName)]
 public sealed class GatewayHub : Hub<IGatewayHubClient>
 {
     private readonly IAgentSupervisor _supervisor;
     private readonly IAgentRegistry _registry;
     private readonly ISessionStore _sessions;
-    private readonly IInboundMessageOrchestrator _orchestrator;
     private readonly IActivityBroadcaster _activity;
-    private readonly ISessionCompactor _compactor;
-    private readonly ISessionWarmupService _warmup;
-    private readonly IConversationDispatcher _conversationDispatcher;
     private readonly IConversationRouter _conversationRouter;
     private readonly IConversationStore? _conversationStore;
     private readonly IAskUserResponseRegistry? _askUserResponseRegistry;
-    private readonly IOptionsMonitor<CompactionOptions> _compactionOptions;
-    private readonly IConversationResetService? _resetService;
-    private readonly ISessionCompactionCoordinator _compactionCoordinator;
+    private readonly IGatewayHubApplicationService _app;
     private readonly ILogger<GatewayHub> _logger;
 
     public GatewayHub(
         IAgentSupervisor supervisor,
         IAgentRegistry registry,
         ISessionStore sessions,
-        IInboundMessageOrchestrator orchestrator,
         IActivityBroadcaster activity,
-        ISessionCompactor compactor,
-        ISessionWarmupService warmup,
-        IConversationDispatcher conversationDispatcher,
         IConversationRouter conversationRouter,
-        IOptionsMonitor<CompactionOptions> compactionOptions,
+        IGatewayHubApplicationService app,
         ILogger<GatewayHub> logger,
         IConversationStore? conversationStore = null,
-        IAskUserResponseRegistry? askUserResponseRegistry = null,
-        IConversationResetService? resetService = null,
-        ISessionCompactionCoordinator? compactionCoordinator = null)
+        IAskUserResponseRegistry? askUserResponseRegistry = null)
     {
         _supervisor = supervisor;
         _registry = registry;
         _sessions = sessions;
-        _orchestrator = orchestrator;
         _activity = activity;
-        _compactor = compactor;
-        _warmup = warmup;
-        _conversationDispatcher = conversationDispatcher;
         _conversationRouter = conversationRouter;
-        _compactionOptions = compactionOptions;
+        _app = app;
         _logger = logger;
         _conversationStore = conversationStore;
         _askUserResponseRegistry = askUserResponseRegistry;
-        _resetService = resetService;
-        // Required for the /compact RPC path. Tests constructing the hub directly
-        // must pass one (see SignalRHubTests.CreateHub which uses TestSessionCompactionCoordinator).
-        _compactionCoordinator = compactionCoordinator
-            ?? throw new ArgumentNullException(nameof(compactionCoordinator),
-                "ISessionCompactionCoordinator is required. Production hosts get it from DI; tests must inject one.");
     }
 
     /// <summary>
     /// Subscribes the connection to every conversation it currently has access to, so it
-    /// receives streaming and event payloads for any session in those conversations —
+    /// receives streaming and event payloads for any session in those conversations --
     /// including sessions that are created later (e.g. after compaction within the
     /// conversation). Conversation-keyed groups are stable across compaction; the
     /// previous session-keyed groups dropped post-compaction deliveries (#682).
@@ -98,11 +85,11 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <returns>The available sessions at subscribe time, for UI initialisation.</returns>
     public async Task<SubscribeAllResult> SubscribeAll()
     {
-        var sessions = await _warmup.GetAvailableSessionsAsync(Context.ConnectionAborted);
+        var sessions = await _app.GetAvailableSessionsAsync(Context.ConnectionAborted);
 
         // Distinct conversation group keys across the returned sessions. Each session
         // contributes:
-        //   1) the real "conversation:{conversationId}" group (production routing key —
+        //   1) the real "conversation:{conversationId}" group (production routing key --
         //      the conversation survives compaction so the connection keeps receiving),
         //   2) a back-compat "conversation:{sessionId}" synonym, so any caller that
         //      builds a ChannelStreamTarget from the sessionId only (legacy code paths
@@ -158,7 +145,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         // Resolve the (sessionId, conversationId) the inbound message will land on so the
         // caller is in the conversation group before the orchestrator's worker emits stream
         // events. Session-row mutation (status / channel / participants) is owned by
-        // GatewayHost.ProcessAsync downstream — see #721.
+        // GatewayHost.ProcessAsync downstream -- see #721.
         var resolution = await ResolveOrCreateSessionAsync(typedAgentId, typedChannelType, normalizedConversationId);
         // The router's GetOrCreate+SaveAsync (called inside the dispatcher) pins ConversationId
         // on the session row; subscribe by conversation so streams reach this connection even
@@ -255,13 +242,13 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         var parts = contentParts.Select(ConvertToDomainContentPart).ToList();
 
         _ = SafeDispatchAsync(
-            () => _orchestrator.AcceptAsync(
+            () => _app.AcceptAsync(
                 new InboundMessage
                 {
                     ChannelType = ChannelKey.From("signalr"),
                     SenderId = connectionId,
                     Sender = CitizenId.Of(UserId.From(GetAuthenticatedUserId())),
-                    ChannelAddress = ChannelAddress.From(typedAgentId.Value), // stable per-agent address — one portal conversation per agent
+                    ChannelAddress = ChannelAddress.From(typedAgentId.Value), // stable per-agent address -- one portal conversation per agent
                     RoutingHints = new InboundMessageRoutingHints(
                         RequestedAgentId: typedAgentId,
                         RequestedSessionId: resolution.SessionId,
@@ -286,13 +273,13 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
 
     private Task DispatchMessageAsync(AgentId typedAgentId, SessionId typedSessionId, string content,
         string messageType, string senderId, string? conversationId = null)
-        => _orchestrator.AcceptAsync(
+        => _app.AcceptAsync(
             new InboundMessage
             {
                 ChannelType = ChannelKey.From("signalr"),
                 SenderId = senderId,
                 Sender = CitizenId.Of(UserId.From(GetAuthenticatedUserId())),
-                ChannelAddress = ChannelAddress.From(typedAgentId.Value), // stable per-agent address — one portal conversation per agent
+                ChannelAddress = ChannelAddress.From(typedAgentId.Value), // stable per-agent address -- one portal conversation per agent
                 RoutingHints = new InboundMessageRoutingHints(
                     RequestedAgentId: typedAgentId,
                     RequestedSessionId: typedSessionId,
@@ -326,15 +313,12 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
 
             try
             {
-                await _activity.PublishAsync(
-                    new GatewayActivity
-                    {
-                        Type = GatewayActivityType.Error,
-                        AgentId = agentId.Value,
-                        SessionId = sessionId.Value,
-                        Message = $"Agent dispatch failed: {ex.Message}"
-                    },
-                    CancellationToken.None);
+                await PublishActivityAsync(
+                    agentId,
+                    sessionId,
+                    GatewayActivityType.Error,
+                    CancellationToken.None,
+                    message: $"Agent dispatch failed: {ex.Message}");
             }
             catch
             {
@@ -368,13 +352,12 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <returns>The steer result.</returns>
     public async Task<SendMessageResult> Steer(AgentId agentId, SessionId sessionId, string content, string? conversationId)
     {
-        var typedAgentId = NormalizeAgentId(agentId);
-        var typedSessionId = NormalizeClientSessionId(sessionId);
+        var ctx = ResolveCallContext(agentId, sessionId);
         var typedChannelType = ChannelKey.From("signalr");
         ArgumentException.ThrowIfNullOrWhiteSpace(content);
 
         // Subscribe so post-compaction streams continue to arrive. #682
-        await SubscribeInternalAsync(typedSessionId);
+        await SubscribeInternalAsync(ctx.SessionId);
 
         // Steering bypasses the per-session orchestrator queue entirely and injects
         // directly into the agent's PendingMessageQueue via handle.SteerAsync().
@@ -401,28 +384,27 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         // be routing/registering the handle (the original #-rationale for GetOrCreate). After that,
         // if the resolved handle still isn't running, treat it as a non-delivery rather than
         // dead-lettering the message.
-        IAgentHandle? handle = _supervisor.GetHandle(typedAgentId, typedSessionId);
+        IAgentHandle? handle = _supervisor.GetHandle(ctx.AgentId, ctx.SessionId);
         if (handle is null || !handle.IsRunning)
         {
             try
             {
-                handle = await _supervisor.GetOrCreateAsync(typedAgentId, typedSessionId, Context.ConnectionAborted);
+                handle = await _supervisor.GetOrCreateAsync(ctx.AgentId, ctx.SessionId, Context.ConnectionAborted);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to resolve agent handle for steering: agent {AgentId} session {SessionId}",
-                    typedAgentId.Value, typedSessionId.Value);
+                    ctx.AgentId.Value, ctx.SessionId.Value);
 
-                await _activity.PublishAsync(new GatewayActivity
-                {
-                    Type = GatewayActivityType.Error,
-                    AgentId = typedAgentId.Value,
-                    SessionId = typedSessionId.Value,
-                    ConversationId = conversationId,
-                    Message = $"Steering failed: {ex.Message}"
-                }, Context.ConnectionAborted);
+                await PublishActivityAsync(
+                    ctx.AgentId,
+                    ctx.SessionId,
+                    GatewayActivityType.Error,
+                    Context.ConnectionAborted,
+                    conversationId: conversationId,
+                    message: $"Steering failed: {ex.Message}");
 
-                return new SendMessageResult(typedSessionId.Value, typedAgentId.Value, typedChannelType.Value);
+                return new SendMessageResult(ctx.SessionId.Value, ctx.AgentId.Value, typedChannelType.Value);
             }
         }
 
@@ -431,24 +413,23 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         // Surface a clear, user-visible signal so the steer isn't silently lost.
         if (!handle.IsRunning)
         {
-            await _activity.PublishAsync(new GatewayActivity
-            {
-                Type = GatewayActivityType.Error,
-                AgentId = typedAgentId.Value,
-                SessionId = typedSessionId.Value,
-                ConversationId = conversationId,
-                Message = "Steering not applied: the agent isn't currently running in this conversation. Send the message instead to start a new turn."
-            }, Context.ConnectionAborted);
+            await PublishActivityAsync(
+                ctx.AgentId,
+                ctx.SessionId,
+                GatewayActivityType.Error,
+                Context.ConnectionAborted,
+                conversationId: conversationId,
+                message: "Steering not applied: the agent isn't currently running in this conversation. Send the message instead to start a new turn.");
 
             _logger.LogInformation(
                 "Steering skipped (agent not running) for agent {AgentId} session {SessionId}",
-                typedAgentId.Value, typedSessionId.Value);
+                ctx.AgentId.Value, ctx.SessionId.Value);
 
-            return new SendMessageResult(typedSessionId.Value, typedAgentId.Value, typedChannelType.Value);
+            return new SendMessageResult(ctx.SessionId.Value, ctx.AgentId.Value, typedChannelType.Value);
         }
 
         // Record steering message in session history
-        var session = await _sessions.GetOrCreateAsync(typedSessionId, typedAgentId, Context.ConnectionAborted);
+        var session = await _sessions.GetOrCreateAsync(ctx.SessionId, ctx.AgentId, Context.ConnectionAborted);
         session.AddEntry(new SessionEntry
         {
             Role = BotNexus.Domain.Primitives.MessageRole.User,
@@ -459,19 +440,18 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         // Inject into agent's steering queue
         await handle.SteerAsync(content, Context.ConnectionAborted);
 
-        await _activity.PublishAsync(new GatewayActivity
-        {
-            Type = GatewayActivityType.SteeringInjected,
-            AgentId = typedAgentId.Value,
-            SessionId = typedSessionId.Value,
-            ConversationId = conversationId
-        }, Context.ConnectionAborted);
+        await PublishActivityAsync(
+            ctx.AgentId,
+            ctx.SessionId,
+            GatewayActivityType.SteeringInjected,
+            Context.ConnectionAborted,
+            conversationId: conversationId);
 
         _logger.LogInformation(
             "Steering injected for agent {AgentId} session {SessionId} (running={IsRunning})",
-            typedAgentId.Value, typedSessionId.Value, handle.IsRunning);
+            ctx.AgentId.Value, ctx.SessionId.Value, handle.IsRunning);
 
-        return new SendMessageResult(typedSessionId.Value, typedAgentId.Value, typedChannelType.Value);
+        return new SendMessageResult(ctx.SessionId.Value, ctx.AgentId.Value, typedChannelType.Value);
     }
 
     /// <summary>
@@ -484,10 +464,9 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     public async Task<bool> InterruptAndSteer(AgentId agentId, SessionId sessionId, string message)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(message);
-        var typedAgentId = NormalizeAgentId(agentId);
-        var typedSessionId = NormalizeClientSessionId(sessionId);
+        var ctx = ResolveCallContext(agentId, sessionId);
 
-        var handle = _supervisor.GetHandle(typedAgentId, typedSessionId);
+        var handle = _supervisor.GetHandle(ctx.AgentId, ctx.SessionId);
         if (handle is null)
             return false;
 
@@ -504,8 +483,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <returns>The follow up result.</returns>
     public Task FollowUp(AgentId agentId, SessionId sessionId, string content)
     {
-        var typedAgentId = NormalizeAgentId(agentId);
-        var typedSessionId = NormalizeClientSessionId(sessionId);
+        var ctx = ResolveCallContext(agentId, sessionId);
         var connectionId = Context.ConnectionId;
         ArgumentException.ThrowIfNullOrWhiteSpace(content);
         _ = SafeDispatchAsync(
@@ -514,11 +492,11 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 // Late-subscribe by conversation so stream events emitted by the
                 // follow-up reach the connection even if SubscribeAll has not been
                 // invoked recently. #682
-                await SubscribeInternalAsync(typedSessionId);
-                await DispatchMessageAsync(typedAgentId, typedSessionId, content, "message", connectionId);
+                await SubscribeInternalAsync(ctx.SessionId);
+                await DispatchMessageAsync(ctx.AgentId, ctx.SessionId, content, "message", connectionId);
             },
-            typedAgentId,
-            typedSessionId);
+            ctx.AgentId,
+            ctx.SessionId);
         return Task.CompletedTask;
     }
 
@@ -530,13 +508,12 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <returns>The abort result.</returns>
     public async Task Abort(AgentId agentId, SessionId sessionId)
     {
-        var typedAgentId = NormalizeAgentId(agentId);
-        var typedSessionId = NormalizeClientSessionId(sessionId);
-        var instance = _supervisor.GetInstance(typedAgentId, typedSessionId);
+        var ctx = ResolveCallContext(agentId, sessionId);
+        var instance = _supervisor.GetInstance(ctx.AgentId, ctx.SessionId);
         if (instance is null)
             return;
 
-        var handle = await _supervisor.GetOrCreateAsync(typedAgentId, typedSessionId, CancellationToken.None);
+        var handle = await _supervisor.GetOrCreateAsync(ctx.AgentId, ctx.SessionId, CancellationToken.None);
         await handle.AbortAsync(CancellationToken.None);
     }
 
@@ -547,52 +524,51 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// message creates a fresh session inside the same conversation.
     /// </summary>
     /// <remarks>
-    /// Delegates to <see cref="IConversationResetService"/> when a conversation is bound,
-    /// guarding against stale <paramref name="sessionId"/> values by passing it as the
-    /// expected active session. Sessions without a conversation (legacy/orphans) are
-    /// sealed in place — no transcript-destroying <see cref="ISessionStore.ArchiveAsync"/>.
+    /// Delegates to the conversation-reset operation on <see cref="IGatewayHubApplicationService"/>
+    /// when a conversation is bound, guarding against stale <paramref name="sessionId"/> values by
+    /// passing it as the expected active session. Sessions without a conversation (legacy/orphans)
+    /// are sealed in place -- no transcript-destroying <see cref="ISessionStore.ArchiveAsync"/>.
     /// </remarks>
     /// <param name="agentId">The agent id.</param>
     /// <param name="sessionId">The session id known to the caller.</param>
     /// <returns>A task that completes when the caller has been notified.</returns>
     public async Task ResetSession(AgentId agentId, SessionId sessionId)
     {
-        var typedAgentId = NormalizeAgentId(agentId);
-        var typedSessionId = NormalizeClientSessionId(sessionId);
+        var ctx = ResolveCallContext(agentId, sessionId);
 
-        var gatewaySession = await _sessions.GetAsync(typedSessionId, CancellationToken.None);
+        var gatewaySession = await _sessions.GetAsync(ctx.SessionId, CancellationToken.None);
 
-        if (gatewaySession is not null && gatewaySession.ConversationId.IsInitialized() && _resetService is not null)
-        {
-            await _resetService.ResetActiveSessionAsync(
+        var resetViaService = gatewaySession is not null
+            && gatewaySession.ConversationId.IsInitialized()
+            && await _app.TryResetActiveSessionAsync(
                 gatewaySession.ConversationId,
-                expectedActiveSessionId: typedSessionId,
-                CancellationToken.None).ConfigureAwait(false);
-        }
-        else if (gatewaySession is not null)
+                expectedActiveSessionId: ctx.SessionId,
+                CancellationToken.None);
+
+        if (!resetViaService && gatewaySession is not null)
         {
-            // Orphan/legacy session with no conversation link: stop the agent and seal
-            // the session in place (Status=Sealed + SaveAsync). Deliberately avoids
-            // ArchiveAsync because the InMemory implementation deletes the row and the
-            // file store renames files out of normal lookup — both destroy transcript
+            // Orphan/legacy session with no conversation link (or no reset service configured):
+            // stop the agent and seal the session in place (Status=Sealed + SaveAsync).
+            // Deliberately avoids ArchiveAsync because the InMemory implementation deletes the
+            // row and the file store renames files out of normal lookup -- both destroy transcript
             // readability for any UI that lists historical sessions.
             try
             {
-                await _supervisor.StopAsync(typedAgentId, typedSessionId, CancellationToken.None).ConfigureAwait(false);
+                await _supervisor.StopAsync(ctx.AgentId, ctx.SessionId, CancellationToken.None);
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Supervisor stop failed for orphan session {SessionId}; reset will proceed.", typedSessionId);
+                _logger.LogWarning(ex, "Supervisor stop failed for orphan session {SessionId}; reset will proceed.", ctx.SessionId);
             }
 
             gatewaySession.Status = GatewaySessionStatus.Sealed;
             gatewaySession.UpdatedAt = DateTimeOffset.UtcNow;
-            await _sessions.SaveAsync(gatewaySession, CancellationToken.None).ConfigureAwait(false);
+            await _sessions.SaveAsync(gatewaySession, CancellationToken.None);
         }
 
         await Clients.Caller.SessionReset(new SessionResetPayload(
-            typedAgentId.Value,
-            typedSessionId.Value,
+            ctx.AgentId.Value,
+            ctx.SessionId.Value,
             gatewaySession is not null && gatewaySession.ConversationId.IsInitialized()
                 ? gatewaySession.ConversationId.Value
                 : null));
@@ -606,18 +582,20 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <returns>The compact session result.</returns>
     public async Task<CompactSessionResult> CompactSession(AgentId agentId, SessionId sessionId)
     {
-        var typedAgentId = NormalizeAgentId(agentId);
-        var typedSessionId = NormalizeClientSessionId(sessionId);
-        var session = await _sessions.GetAsync(typedSessionId, CancellationToken.None);
+        var ctx = ResolveCallContext(agentId, sessionId);
+        var session = await _sessions.GetAsync(ctx.SessionId, CancellationToken.None);
         if (session is null)
-            throw new HubException($"Session '{typedSessionId.Value}' not found.");
+            throw new HubException($"Session '{ctx.SessionId.Value}' not found.");
 
         // Resolve through the request services so test hosts can substitute the
-        // coordinator. Falls back to the singleton injected at hub construction.
+        // coordinator. Falls back to the application-service facade composed at hub
+        // construction when the request scope does not override it.
         var requestServices = Context.GetHttpContext()?.RequestServices;
-        var coordinator = requestServices?.GetService<ISessionCompactionCoordinator>() ?? _compactionCoordinator;
+        var coordinator = requestServices?.GetService<ISessionCompactionCoordinator>();
 
-        var outcome = await coordinator.CompactAsync(typedAgentId, session, CancellationToken.None, force: true).ConfigureAwait(false);
+        var outcome = coordinator is not null
+            ? await coordinator.CompactAsync(ctx.AgentId, session, CancellationToken.None, force: true)
+            : await _app.CompactAsync(ctx.AgentId, session, CancellationToken.None, force: true);
 
         return new CompactSessionResult(
             outcome.Succeeded && outcome.Applied,
@@ -642,7 +620,10 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <param name="sessionId">The session id.</param>
     /// <returns>The get agent status result.</returns>
     public AgentInstance? GetAgentStatus(AgentId agentId, SessionId sessionId)
-        => _supervisor.GetInstance(NormalizeAgentId(agentId), NormalizeClientSessionId(sessionId));
+    {
+        var ctx = ResolveCallContext(agentId, sessionId);
+        return _supervisor.GetInstance(ctx.AgentId, ctx.SessionId);
+    }
 
     /// <summary>
     /// Executes on connected async.
@@ -715,8 +696,47 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         await base.OnDisconnectedAsync(exception);
     }
 
-    // GetSessionGroup is gone — the hub now subscribes/unsubscribes via SignalRChannelAdapter.GetConversationGroup.
+    // GetSessionGroup is gone -- the hub now subscribes/unsubscribes via SignalRChannelAdapter.GetConversationGroup.
     // Removing this prevents future regressions back to session-keyed routing (#682).
+
+    /// <summary>
+    /// Resolves the caller-supplied agent and session ids into a single normalized
+    /// <see cref="HubCallContext"/> so every client-callable control method runs the same
+    /// id-normalisation and reserved-namespace guard once, rather than repeating the
+    /// <see cref="NormalizeAgentId"/> / <see cref="NormalizeClientSessionId"/> pair inline.
+    /// </summary>
+    private static HubCallContext ResolveCallContext(AgentId agentId, SessionId sessionId)
+        => new(NormalizeAgentId(agentId), NormalizeClientSessionId(sessionId));
+
+    /// <summary>
+    /// Publishes a control-path <see cref="GatewayActivity"/> for the given call context through
+    /// the single activity path so the envelope shape (agent id, session id, optional conversation
+    /// id and message) is constructed in one place. Callers decide <em>whether</em> to publish;
+    /// this centralises only the construction and dispatch.
+    /// </summary>
+    private ValueTask PublishActivityAsync(
+        AgentId agentId,
+        SessionId sessionId,
+        GatewayActivityType type,
+        CancellationToken cancellationToken,
+        string? conversationId = null,
+        string? message = null)
+        => _activity.PublishAsync(
+            new GatewayActivity
+            {
+                Type = type,
+                AgentId = agentId.Value,
+                SessionId = sessionId.Value,
+                ConversationId = conversationId,
+                Message = message
+            },
+            cancellationToken);
+
+    /// <summary>
+    /// Normalized caller ids shared by the control methods. Produced once per call by
+    /// <see cref="ResolveCallContext"/> after the reserved-namespace guard has run.
+    /// </summary>
+    private readonly record struct HubCallContext(AgentId AgentId, SessionId SessionId);
 
     // AgentId is a Vogen value object; the parameter cannot be default(AgentId) (compile-time
     // VOG009) and is already validated and trimmed at construction. The defensive re-construction
@@ -851,7 +871,8 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
 
     /// <summary>
     /// Resolves the (sessionId, conversationId) pair the inbound message will land on by
-    /// delegating to the shared <see cref="IConversationDispatcher"/>. Returns a lightweight
+    /// delegating to the shared conversation-resolution operation on
+    /// <see cref="IGatewayHubApplicationService"/>. Returns a lightweight
     /// <see cref="HubInboundResolution"/> that carries just the IDs the hub needs to
     /// (a) populate the synchronous <see cref="SendMessageResult"/> contract and
     /// (b) join the caller connection to the conversation group before the orchestrator's
@@ -860,7 +881,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <remarks>
     /// <para>
     /// This is a pure resolution call. Session row materialisation, ChannelType / SessionType
-    /// stamping, Expired→Active reactivation, transcript SaveAsync, and caller participant
+    /// stamping, Expired->Active reactivation, transcript SaveAsync, and caller participant
     /// registration are owned by <c>GatewayHost.ProcessAsync</c> inside the orchestrator's
     /// per-session worker (#721). The router invoked by the dispatcher already calls
     /// <c>SessionStore.GetOrCreateAsync</c> + <c>SaveAsync</c> as a side-effect of binding
@@ -894,7 +915,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 SenderId = Context.ConnectionId,
                 Sender = CitizenId.Of(UserId.From(GetAuthenticatedUserId())),
                 Content = string.Empty,
-                // RoutingHints intentionally omitted — the outer InboundMessageContext below
+                // RoutingHints intentionally omitted -- the outer InboundMessageContext below
                 // carries the typed RequestedAgentId + RequestedConversationId explicitly.
             },
             new ChannelSource(
@@ -904,7 +925,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             RequestedConversationId: typedConversationId,
             RequestedAgentId: agentId);
 
-        var dispatchResult = await _conversationDispatcher.DispatchAsync(context, Context.ConnectionAborted);
+        var dispatchResult = await _app.ResolveSessionAsync(context, Context.ConnectionAborted);
         return new HubInboundResolution(
             dispatchResult.Resolution.SessionId,
             dispatchResult.Resolution.ConversationId,
@@ -927,7 +948,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
 
     /// <summary>
     /// Returns <see langword="true"/> for exceptions that are expected side-effects of a
-    /// WebSocket client disconnecting before (or during) the SignalR handshake — e.g.
+    /// WebSocket client disconnecting before (or during) the SignalR handshake -- e.g.
     /// the browser navigating away, a network blip, or a rapid reconnect cycle. These
     /// are logged at Debug level instead of Warning to avoid Application Insights noise.
     /// </summary>
@@ -949,4 +970,3 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         return false;
     }
 }
-

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHubApplicationService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHubApplicationService.cs
@@ -1,0 +1,80 @@
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Dispatching;
+using AgentId = BotNexus.Domain.Primitives.AgentId;
+using ConversationId = BotNexus.Domain.Primitives.ConversationId;
+using SessionId = BotNexus.Domain.Primitives.SessionId;
+
+namespace BotNexus.Extensions.Channels.SignalR;
+
+/// <summary>
+/// Default <see cref="IGatewayHubApplicationService"/> that forwards each hub-facing gateway
+/// operation to the concrete collaborator. Holds no state and no SignalR context, so it is a
+/// singleton composed once from the gateway's singleton collaborators.
+/// </summary>
+internal sealed class GatewayHubApplicationService : IGatewayHubApplicationService
+{
+    private readonly IInboundMessageOrchestrator _orchestrator;
+    private readonly ISessionWarmupService _warmup;
+    private readonly IConversationDispatcher _conversationDispatcher;
+    private readonly ISessionCompactionCoordinator _compactionCoordinator;
+    private readonly IConversationResetService? _resetService;
+
+    /// <summary>
+    /// Composes the facade from the gateway's inbound-dispatch, warmup, conversation-resolution,
+    /// compaction, and (optional) conversation-reset collaborators.
+    /// </summary>
+    /// <param name="orchestrator">Single inbound entry point for injecting messages into the gateway.</param>
+    /// <param name="warmup">Provides the sessions available to a connection at subscribe time.</param>
+    /// <param name="conversationDispatcher">Resolves conversation/session targets for inbound messages.</param>
+    /// <param name="compactionCoordinator">Runs the full session-compaction pipeline.</param>
+    /// <param name="resetService">Canonical conversation active-session reset; <see langword="null"/>
+    /// when the host does not register one, in which case the hub seals orphan sessions in place.</param>
+    public GatewayHubApplicationService(
+        IInboundMessageOrchestrator orchestrator,
+        ISessionWarmupService warmup,
+        IConversationDispatcher conversationDispatcher,
+        ISessionCompactionCoordinator compactionCoordinator,
+        IConversationResetService? resetService = null)
+    {
+        _orchestrator = orchestrator;
+        _warmup = warmup;
+        _conversationDispatcher = conversationDispatcher;
+        _compactionCoordinator = compactionCoordinator;
+        _resetService = resetService;
+    }
+
+    /// <inheritdoc />
+    public Task<InboundDispatchResult> AcceptAsync(InboundMessage message, CancellationToken cancellationToken = default)
+        => _orchestrator.AcceptAsync(message, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<SessionSummary>> GetAvailableSessionsAsync(CancellationToken cancellationToken = default)
+        => _warmup.GetAvailableSessionsAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public Task<DispatchResult> ResolveSessionAsync(InboundMessageContext context, CancellationToken cancellationToken = default)
+        => _conversationDispatcher.DispatchAsync(context, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<SessionCompactionOutcome> CompactAsync(
+        AgentId agentId,
+        GatewaySession session,
+        CancellationToken cancellationToken,
+        bool force = false)
+        => _compactionCoordinator.CompactAsync(agentId, session, cancellationToken, force);
+
+    /// <inheritdoc />
+    public async Task<bool> TryResetActiveSessionAsync(
+        ConversationId conversationId,
+        SessionId? expectedActiveSessionId,
+        CancellationToken cancellationToken)
+    {
+        if (_resetService is null)
+            return false;
+
+        await _resetService.ResetActiveSessionAsync(conversationId, expectedActiveSessionId, cancellationToken);
+        return true;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/IGatewayHubApplicationService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/IGatewayHubApplicationService.cs
@@ -1,0 +1,84 @@
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Dispatching;
+using AgentId = BotNexus.Domain.Primitives.AgentId;
+using ConversationId = BotNexus.Domain.Primitives.ConversationId;
+using SessionId = BotNexus.Domain.Primitives.SessionId;
+
+namespace BotNexus.Extensions.Channels.SignalR;
+
+/// <summary>
+/// Application-service facade that collapses the gateway's inbound-dispatch, warmup,
+/// conversation-resolution, compaction, and conversation-reset collaborators behind a
+/// single dependency so <see cref="GatewayHub"/> stays a thin transport adapter.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The hub previously injected these five gateway operations individually
+/// (<c>IInboundMessageOrchestrator</c>, <c>ISessionWarmupService</c>,
+/// <c>IConversationDispatcher</c>, <c>ISessionCompactionCoordinator</c>, and the optional
+/// <c>IConversationResetService</c>). Grouping them here shrinks the hub constructor to the
+/// SignalR-context-bound services it genuinely coordinates (supervisor, session store,
+/// activity broadcaster, conversation router/store, ask-user registry) and gives the
+/// control methods one shared application boundary.
+/// </para>
+/// <para>
+/// This is a pure pass-through boundary: every member forwards to the underlying gateway
+/// collaborator with identical semantics. It carries no SignalR context and performs no
+/// routing policy of its own, so hub control methods remain individually testable by
+/// substituting the underlying collaborators when the facade is constructed.
+/// </para>
+/// <para>
+/// The interface is public because it appears in the public <see cref="GatewayHub"/>
+/// constructor signature; the default implementation stays internal and is composed in DI.
+/// </para>
+/// </remarks>
+public interface IGatewayHubApplicationService
+{
+    /// <summary>
+    /// Enqueues an inbound message on its per-session queue via the gateway orchestrator and
+    /// awaits the processing outcome. Forwards to <see cref="IInboundMessageOrchestrator.AcceptAsync"/>.
+    /// </summary>
+    Task<InboundDispatchResult> AcceptAsync(InboundMessage message, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the sessions currently available to the caller for UI initialisation at
+    /// subscribe time. Forwards to <see cref="ISessionWarmupService.GetAvailableSessionsAsync(CancellationToken)"/>.
+    /// </summary>
+    Task<IReadOnlyList<SessionSummary>> GetAvailableSessionsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves the conversation and session an inbound message will land on so the hub can
+    /// join the caller connection to the conversation group and populate its synchronous
+    /// result contract. Forwards to <see cref="IConversationDispatcher.DispatchAsync"/>.
+    /// </summary>
+    Task<DispatchResult> ResolveSessionAsync(InboundMessageContext context, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Runs the full compaction pipeline for a session (force-compaction from the portal
+    /// <c>/compact</c> RPC). Forwards to <see cref="ISessionCompactionCoordinator.CompactAsync"/>.
+    /// </summary>
+    Task<SessionCompactionOutcome> CompactAsync(
+        AgentId agentId,
+        GatewaySession session,
+        CancellationToken cancellationToken,
+        bool force = false);
+
+    /// <summary>
+    /// Resets the conversation's active session (stop agent, flush session-end memory, cancel
+    /// pending ask-user waits, seal the session, clear the active session pointer) when a
+    /// conversation-reset service is configured. Returns <see langword="false"/> when reset is
+    /// not available so the hub falls back to sealing an orphan session in place.
+    /// </summary>
+    /// <param name="conversationId">The conversation whose active session is being reset.</param>
+    /// <param name="expectedActiveSessionId">Guard against stale caller session ids; the reset
+    /// only proceeds when it matches the conversation's current active session.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true"/> when a conversation-reset service handled the reset;
+    /// <see langword="false"/> when none is configured.</returns>
+    Task<bool> TryResetActiveSessionAsync(
+        ConversationId conversationId,
+        SessionId? expectedActiveSessionId,
+        CancellationToken cancellationToken);
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRServiceContributor.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRServiceContributor.cs
@@ -1,4 +1,7 @@
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Extensions;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Dispatching;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -7,8 +10,10 @@ namespace BotNexus.Extensions.Channels.SignalR;
 /// <summary>
 /// Registers the SignalR channel's host-level services that the extension loader's
 /// contract-based auto-discovery cannot express: the <see cref="SignalRAuthPolicy.PolicyName"/>
-/// authorization policy required by <see cref="GatewayHub"/>'s <c>[Authorize]</c> attribute, and
-/// the claims-based <see cref="IUserIdProvider"/> that overrides SignalR's connection-id default.
+/// authorization policy required by <see cref="GatewayHub"/>'s <c>[Authorize]</c> attribute, the
+/// claims-based <see cref="IUserIdProvider"/> that overrides SignalR's connection-id default, and
+/// the <see cref="IGatewayHubApplicationService"/> facade the hub resolves in place of its former
+/// five individual gateway collaborators.
 /// </summary>
 /// <remarks>
 /// Without this contributor the <c>SignalRHubAuth</c> policy is never registered in a production
@@ -26,5 +31,18 @@ public sealed class SignalRServiceContributor : IServiceContributor
         // Override SignalR's DefaultUserIdProvider (registered via TryAdd by AddSignalR) so the
         // hub's UserIdentifier is derived from authenticated claims rather than the connection id.
         services.AddSingleton<IUserIdProvider, ClaimsUserIdProvider>();
+
+        // Facade over the gateway's inbound-dispatch, warmup, conversation-resolution,
+        // compaction, and (optional) conversation-reset collaborators. All are registered as
+        // singletons by the gateway core, so the facade is a stateless singleton composed from
+        // them. IConversationResetService is resolved optionally so hosts that do not register
+        // one still start (the hub then seals orphan sessions in place).
+        services.AddSingleton<IGatewayHubApplicationService>(serviceProvider =>
+            new GatewayHubApplicationService(
+                serviceProvider.GetRequiredService<IInboundMessageOrchestrator>(),
+                serviceProvider.GetRequiredService<ISessionWarmupService>(),
+                serviceProvider.GetRequiredService<IConversationDispatcher>(),
+                serviceProvider.GetRequiredService<ISessionCompactionCoordinator>(),
+                serviceProvider.GetService<IConversationResetService>()));
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Helpers/SignalRTestServiceExtensions.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Helpers/SignalRTestServiceExtensions.cs
@@ -1,6 +1,9 @@
 using BotNexus.Extensions.Channels.SignalR;
 using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Extensions;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Dispatching;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,6 +22,18 @@ public static class SignalRTestServiceExtensions
         services.AddSingleton<IEndpointContributor, SignalREndpointContributor>();
         services.AddSingleton<IUserIdProvider, ClaimsUserIdProvider>();
         services.AddSignalRAuthPolicy();
+
+        // GatewayHub now resolves the gateway application collaborators through a single facade
+        // (registered in production by SignalRServiceContributor). Register the same facade here
+        // so the test host can construct the hub. IConversationResetService is optional, matching
+        // production, so hosts that do not register one still start.
+        services.AddSingleton<IGatewayHubApplicationService>(sp =>
+            new GatewayHubApplicationService(
+                sp.GetRequiredService<IInboundMessageOrchestrator>(),
+                sp.GetRequiredService<ISessionWarmupService>(),
+                sp.GetRequiredService<IConversationDispatcher>(),
+                sp.GetRequiredService<ISessionCompactionCoordinator>(),
+                sp.GetService<IConversationResetService>()));
         return services;
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -249,20 +249,23 @@ public sealed class SignalRHubTests
                 new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
                 NullLogger<SessionCompactionCoordinator>.Instance);
 
+        // Facade grouping the gateway application collaborators the hub delegates to.
+        GatewayHubApplicationService NewApp()
+            => new(
+                orchestrator,
+                Mock.Of<ISessionWarmupService>(),
+                conversationDispatcher,
+                NewCoordinator(sessionStore));
+
         // Two hubs with different connection IDs but same underlying stores/router
         var hub1 = new GatewayHub(
             Mock.Of<IAgentSupervisor>(),
             Mock.Of<IAgentRegistry>(),
             sessionStore,
-            orchestrator,
             Mock.Of<IActivityBroadcaster>(),
-            Mock.Of<ISessionCompactor>(),
-            Mock.Of<ISessionWarmupService>(),
-            conversationDispatcher,
             router,
-            new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
-            NullLogger<GatewayHub>.Instance,
-            compactionCoordinator: NewCoordinator(sessionStore))
+            NewApp(),
+            NullLogger<GatewayHub>.Instance)
         {
             Clients = Mock.Of<IHubCallerClients<IGatewayHubClient>>(),
             Groups = Mock.Of<IGroupManager>(),
@@ -273,15 +276,10 @@ public sealed class SignalRHubTests
             Mock.Of<IAgentSupervisor>(),
             Mock.Of<IAgentRegistry>(),
             sessionStore,
-            orchestrator,
             Mock.Of<IActivityBroadcaster>(),
-            Mock.Of<ISessionCompactor>(),
-            Mock.Of<ISessionWarmupService>(),
-            conversationDispatcher,
             router,
-            new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
-            NullLogger<GatewayHub>.Instance,
-            compactionCoordinator: NewCoordinator(sessionStore))
+            NewApp(),
+            NullLogger<GatewayHub>.Instance)
         {
             Clients = Mock.Of<IHubCallerClients<IGatewayHubClient>>(),
             Groups = Mock.Of<IGroupManager>(),
@@ -472,6 +470,35 @@ public sealed class SignalRHubTests
         activity.Verify(a => a.PublishAsync(
             It.Is<GatewayActivity>(ga => ga.Type == GatewayActivityType.SteeringInjected),
             It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GatewayHub_Steer_SharedDispatchPath_PublishesActivityWithNormalizedIds()
+    {
+        // Structural guard (#1625): every control method routes its ids through the single
+        // ResolveCallContext normalize step and publishes via the shared PublishActivityAsync
+        // envelope path. A padded agent id must surface trimmed on the published activity, and
+        // the centralized envelope must still carry the conversation id the caller supplied.
+        var idleHandle = new Mock<IAgentHandle>();
+        idleHandle.SetupGet(h => h.IsRunning).Returns(false);
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetHandle(It.IsAny<AgentId>(), It.IsAny<SessionId>()))
+            .Returns(idleHandle.Object);
+        supervisor.Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(idleHandle.Object);
+        var activity = new Mock<IActivityBroadcaster>();
+
+        var hub = CreateHub(supervisor: supervisor.Object, activity: activity.Object, connectionId: "conn-1");
+
+        await hub.Steer(AgentId.From("  agent-a  "), SessionId.From("sess-shared"), "nudge", "conv-shared");
+
+        activity.Verify(a => a.PublishAsync(
+            It.Is<GatewayActivity>(ga =>
+                ga.Type == GatewayActivityType.Error &&
+                ga.AgentId == "agent-a" &&
+                ga.SessionId == "sess-shared" &&
+                ga.ConversationId == "conv-shared"),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -968,22 +995,26 @@ public sealed class SignalRHubTests
             optionsImpl,
             NullLogger<SessionCompactionCoordinator>.Instance);
 
+        // The gateway's inbound-dispatch, warmup, conversation-resolution, compaction, and
+        // conversation-reset collaborators now live behind IGatewayHubApplicationService. Compose
+        // it from the same substitutes so each hub control method stays individually testable.
+        var app = new GatewayHubApplicationService(
+            orchestrator ?? new CapturingInboundMessageOrchestrator(),
+            warmup ?? Mock.Of<ISessionWarmupService>(),
+            dispatcherForHub,
+            coordinator,
+            resetService);
+
         var hub = new GatewayHub(
             supervisorImpl,
             registry ?? Mock.Of<IAgentRegistry>(),
             sessionStore,
-            orchestrator ?? new CapturingInboundMessageOrchestrator(),
             activity ?? Mock.Of<IActivityBroadcaster>(),
-            compactorImpl,
-            warmup ?? Mock.Of<ISessionWarmupService>(),
-            dispatcherForHub,
             router,
-            optionsImpl,
+            app,
             logger ?? NullLogger<GatewayHub>.Instance,
             convStore,
-            askUserResponseRegistry,
-            resetService,
-            coordinator)
+            askUserResponseRegistry)
         {
             Clients = clients ?? Mock.Of<IHubCallerClients<IGatewayHubClient>>(),
             Groups = groups ?? Mock.Of<IGroupManager>(),


### PR DESCRIPTION
## Summary
Refactor of `GatewayHub` per #1625: the hub injected 15 collaborators and repeated two boilerplate shapes across every client-callable control method:
- the `NormalizeAgentId` + `NormalizeClientSessionId` id-normalisation pair, and
- a 5-6 line `_activity.PublishAsync(new GatewayActivity { ... })` envelope.

This groups the five gateway operations the hub only forwards to -- inbound dispatch, warmup, conversation resolution, compaction, and the optional conversation reset -- behind a new `IGatewayHubApplicationService` facade, and routes every control method through a single `ResolveCallContext` + `PublishActivityAsync` pair.

## What changed
- **New `IGatewayHubApplicationService` + `GatewayHubApplicationService`** (SignalR extension): a stateless singleton that forwards each member to the concrete collaborator with identical semantics. Composed in DI from the gateway's existing singletons (`SignalRServiceContributor`), with `IConversationResetService` resolved optionally so hosts that do not register one still start.
- **`GatewayHub` constructor shrinks**: drops `IInboundMessageOrchestrator`, `ISessionWarmupService`, `IConversationDispatcher`, `ISessionCompactionCoordinator`, `IOptionsMonitor<CompactionOptions>`, `IConversationResetService`, and the injected-but-unused `ISessionCompactor` -- all replaced by the single facade. The awkward `compactionCoordinator ?? throw` guard is gone (the facade owns it).
- **Boilerplate collapse**: new `ResolveCallContext` (returns a `HubCallContext` record struct) and `PublishActivityAsync` centralise id-normalisation and envelope construction; every control method (Steer / InterruptAndSteer / FollowUp / Abort / ResetSession / CompactSession / GetAgentStatus) uses them.

## Behaviour preservation
Pure refactor -- no semantic change:
- `ResetSession` keeps the reset-via-service **or** seal-orphan-in-place fallback (now via `TryResetActiveSessionAsync` returning `false` when no reset service is configured).
- `CompactSession` keeps the request-services `ISessionCompactionCoordinator` override (test hook), falling back to the facade.
- The facade is a plain factory-composed singleton from already-registered singletons, so it introduces **no DI cycle**.
- Pre-existing CP437-mangled em-dashes in comments were corrected to ASCII along the way.

## Tests
- New structural guard `GatewayHub_Steer_SharedDispatchPath_PublishesActivityWithNormalizedIds`: a padded agent id (` "  agent-a  " `) must surface **trimmed** through `ResolveCallContext`, and the centralized envelope must still carry the caller-supplied conversation id.
- Test host + `CreateHub` updated to compose the facade from the same substitutes, preserving per-method testability.
- `test-impacted.ps1` GREEN: Architecture 212, Gateway.Conversations 275, Gateway.Tests 3458 (+1 pre-existing skip), Scenarios 29. Full `BotNexus.slnx` build 0 warnings / 0 errors (warnings-as-errors).

Closes #1625