### PR TITLE
fix(#1751): guard stored-column JSON reads in SQLite stores against corrupt rows

### DIFF
--- a/src/gateway/BotNexus.Cron/SqliteCronStore.cs
+++ b/src/gateway/BotNexus.Cron/SqliteCronStore.cs
@@ -542,20 +542,21 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
         command.Parameters.AddWithValue("$deleteAfterRun", job.DeleteAfterRun ? 1 : 0);
     }
 
-    private static CronJob ReadJob(SqliteDataReader reader)
+    private CronJob ReadJob(SqliteDataReader reader)
     {
+        var jobId = JobId.From(reader.GetString(0));
         var templateParametersJson = reader.IsDBNull(7) ? null : reader.GetString(7);
         var metadataJson = reader.IsDBNull(20) ? null : reader.GetString(20);
         return new CronJob
         {
-            Id = JobId.From(reader.GetString(0)),
+            Id = jobId,
             Name = reader.GetString(1),
             Schedule = reader.GetString(2),
             ActionType = reader.GetString(3),
             AgentId = reader.IsDBNull(4) ? null : AgentId.From(reader.GetString(4)),
             Message = reader.IsDBNull(5) ? null : reader.GetString(5),
             TemplateName = reader.IsDBNull(6) ? null : reader.GetString(6),
-            TemplateParameters = DeserializeTemplateParameters(templateParametersJson),
+            TemplateParameters = DeserializeTemplateParameters(templateParametersJson, jobId),
             Model = reader.IsDBNull(8) ? null : reader.GetString(8),
             WebhookUrl = reader.IsDBNull(9) ? null : reader.GetString(9),
             ShellCommand = reader.IsDBNull(10) ? null : reader.GetString(10),
@@ -568,7 +569,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
             NextRunAt = reader.IsDBNull(17) ? null : ParseDate(reader.GetString(17)),
             LastRunStatus = reader.IsDBNull(18) ? null : reader.GetString(18),
             LastRunError = reader.IsDBNull(19) ? null : reader.GetString(19),
-            Metadata = DeserializeMetadata(metadataJson),
+            Metadata = DeserializeMetadata(metadataJson, jobId),
             ConversationId = reader.IsDBNull(21) ? null : ConversationId.From(reader.GetString(21)),
             DeleteAfterRun = !reader.IsDBNull(22) && reader.GetInt32(22) != 0
         };
@@ -600,20 +601,47 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
     private static object SerializeTemplateParameters(IReadOnlyDictionary<string, string?>? parameters)
         => parameters is null ? DBNull.Value : JsonSerializer.Serialize(parameters, JsonOptions);
 
-    private static IReadOnlyDictionary<string, object?>? DeserializeMetadata(string? metadataJson)
+    // #1751: guard stored-column JSON reads. A single corrupt metadata_json / template_parameters_json
+    // value must not throw JsonException out of ReadJob and abort the whole ListAsync/GetAsync scan
+    // (that would leave the scheduler unable to enumerate ANY jobs). On parse failure we log a warning
+    // with the job id and degrade the property to null - the columns are already nullable, so the job
+    // still loads with null metadata rather than poisoning the entire load.
+    private IReadOnlyDictionary<string, object?>? DeserializeMetadata(string? metadataJson, JobId jobId)
     {
         if (string.IsNullOrWhiteSpace(metadataJson))
             return null;
 
-        return JsonSerializer.Deserialize<Dictionary<string, object?>>(metadataJson, JsonOptions);
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, object?>>(metadataJson, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Skipping corrupt metadata_json for cron job '{JobId}'; the job will load with null metadata.",
+                jobId.Value);
+            return null;
+        }
     }
 
-    private static IReadOnlyDictionary<string, string?>? DeserializeTemplateParameters(string? parametersJson)
+    private IReadOnlyDictionary<string, string?>? DeserializeTemplateParameters(string? parametersJson, JobId jobId)
     {
         if (string.IsNullOrWhiteSpace(parametersJson))
             return null;
 
-        return JsonSerializer.Deserialize<Dictionary<string, string?>>(parametersJson, JsonOptions);
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, string?>>(parametersJson, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Skipping corrupt template_parameters_json for cron job '{JobId}'; the job will load with null template parameters.",
+                jobId.Value);
+            return null;
+        }
     }
 
     /// <inheritdoc />

--- a/src/gateway/BotNexus.Gateway.Conversations/ConversationRowMapper.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/ConversationRowMapper.cs
@@ -37,17 +37,18 @@ internal static class ConversationRowMapper
     /// paths hydrate identically. Child collections (bindings / participants) are NOT populated
     /// here - the caller attaches them.
     /// </summary>
-    internal static Conversation MapConversation(SqliteDataReader reader)
+    internal static Conversation MapConversation(SqliteDataReader reader, ILogger? logger = null)
     {
+        var conversationId = ConversationId.From(reader.GetString(reader.GetOrdinal("id")));
         var conversation = new Conversation
         {
-            ConversationId = ConversationId.From(reader.GetString(reader.GetOrdinal("id"))),
+            ConversationId = conversationId,
             AgentId = AgentId.From(reader.GetString(reader.GetOrdinal("agent_id"))),
             Title = reader.GetString(reader.GetOrdinal("title")),
             Purpose = GetNullableString(reader, "purpose"),
             IsDefault = reader.GetInt64(reader.GetOrdinal("is_default")) != 0,
             Status = ParseConversationStatus(reader.GetString(reader.GetOrdinal("status"))),
-            Metadata = DeserializeMetadata(GetNullableString(reader, "metadata")),
+            Metadata = DeserializeMetadata(GetNullableString(reader, "metadata"), conversationId, logger),
             CreatedAt = ParseTimestamp(reader.GetString(reader.GetOrdinal("created_at"))),
             UpdatedAt = ParseTimestamp(reader.GetString(reader.GetOrdinal("updated_at"))),
             Instructions = GetNullableString(reader, "instructions"),
@@ -179,12 +180,27 @@ internal static class ConversationRowMapper
             ? parsed
             : ThreadingMode.Single;
 
-    private static Dictionary<string, object?> DeserializeMetadata(string? metadataJson)
+    // #1751: guard the stored metadata column read. A single corrupt value must not throw
+    // JsonException out of MapConversation and abort the whole list/scan (one bad row would poison
+    // every conversation load). On parse failure we log a warning with the conversation id and fall
+    // back to an empty metadata dictionary so the row still hydrates.
+    private static Dictionary<string, object?> DeserializeMetadata(string? metadataJson, ConversationId conversationId, ILogger? logger)
     {
         if (string.IsNullOrWhiteSpace(metadataJson))
             return [];
 
-        return JsonSerializer.Deserialize<Dictionary<string, object?>>(metadataJson, SqliteConversationStore.JsonOptions) ?? [];
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, object?>>(metadataJson, SqliteConversationStore.JsonOptions) ?? [];
+        }
+        catch (JsonException ex)
+        {
+            logger?.LogWarning(
+                ex,
+                "Skipping corrupt metadata for conversation '{ConversationId}'; hydrating with empty metadata.",
+                conversationId.Value);
+            return [];
+        }
     }
 
     private static CitizenId? DeserializeInitiator(string? raw)

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -1084,7 +1084,7 @@ public sealed class SqliteConversationStore : IConversationStore
         if (!await reader.ReadAsync(ct).ConfigureAwait(false))
             return null;
 
-        var conversation = ConversationRowMapper.MapConversation(reader);
+        var conversation = ConversationRowMapper.MapConversation(reader, logger);
 
         await reader.DisposeAsync().ConfigureAwait(false);
         conversation.ChannelBindings = await LoadBindingsAsync(connection, conversation.ConversationId, ct).ConfigureAwait(false);
@@ -1166,7 +1166,7 @@ public sealed class SqliteConversationStore : IConversationStore
             await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
             while (await reader.ReadAsync(ct).ConfigureAwait(false))
             {
-                var conversation = ConversationRowMapper.MapConversation(reader);
+                var conversation = ConversationRowMapper.MapConversation(reader, _logger);
                 conversation.ChannelBindings = [];
                 conversation.Participants = [];
                 byId[conversation.ConversationId.Value] = conversation;
@@ -1448,7 +1448,7 @@ public sealed class SqliteConversationStore : IConversationStore
             CreatedAt = conversation.CreatedAt,
             UpdatedAt = conversation.UpdatedAt,
             ActiveSessionId = conversation.ActiveSessionId,
-            Metadata = JsonSerializer.Deserialize<Dictionary<string, object?>>(JsonSerializer.Serialize(conversation.Metadata, JsonOptions), JsonOptions) ?? [],
+            Metadata = CloneMetadata(conversation.Metadata),
             ChannelBindings = conversation.ChannelBindings.Select(binding => new ChannelBinding
             {
                 BindingId = binding.BindingId,
@@ -1470,6 +1470,25 @@ public sealed class SqliteConversationStore : IConversationStore
                 .Select(p => new SessionParticipant { CitizenId = p.CitizenId, Role = p.Role })
                 .ToList()
         };
+
+    // #1751: defensive guard for the deep-clone metadata round-trip. A round-trip of a well-formed
+    // in-memory dictionary does not normally throw, but if a value cannot be re-materialised into a
+    // Dictionary<string, object?> we fall back to an empty dictionary rather than letting the clone
+    // (and therefore every list/cache-seed path that clones) abort. This method is static and has no
+    // instance logger; the row is degraded silently to a safe default which is acceptable because the
+    // authoritative on-disk read path (ConversationRowMapper.DeserializeMetadata) already logs.
+    private static Dictionary<string, object?> CloneMetadata(IReadOnlyDictionary<string, object?> metadata)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, object?>>(
+                JsonSerializer.Serialize(metadata, JsonOptions), JsonOptions) ?? [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
 
     // ── Canvas State ───────────────────────────────────────────────────────
 

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -804,7 +804,21 @@ public sealed class SqliteSessionStore : SessionStoreBase
             {
                 var convId = reader.GetString(0);
                 var json = reader.GetString(1);
-                var participants = DeserializeParticipants(json);
+                List<SessionParticipant> participants;
+                try
+                {
+                    participants = DeserializeParticipants(json);
+                }
+                catch (JsonException ex)
+                {
+                    // #1751: skip a single corrupt participants_json row rather than aborting the
+                    // whole backfill scan. The other valid rows must still be forwarded.
+                    _logger.LogWarning(
+                        ex,
+                        "Skipping corrupt participants_json while backfilling participants for conversation '{ConversationId}'.",
+                        convId);
+                    continue;
+                }
                 if (participants.Count == 0)
                     continue;
 

--- a/tests/gateway/BotNexus.Cron.Tests/SqliteCronStoreTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/SqliteCronStoreTests.cs
@@ -134,6 +134,66 @@ public sealed class SqliteCronStoreTests
     }
 
     [Fact]
+    public async Task ListAsync_WithCorruptMetadataJsonOnOneJob_LoadsOtherJobs_AndCorruptJobHasNullMetadata()
+    {
+        // Regression (#1751): a single corrupted metadata_json value must not poison the
+        // whole scan. The bare JsonSerializer.Deserialize used to throw JsonException and
+        // abort the entire ListAsync enumeration, so the scheduler could not read ANY jobs.
+        // The guard now catches the parse failure, logs a warning with the job id, and lets
+        // the job load with null Metadata so the remaining valid jobs still enumerate.
+        await using var context = await CronStoreTestContext.CreateAsync();
+        await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-good", "agent-a"));
+        await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-bad", "agent-b"));
+
+        // Corrupt the metadata_json of exactly one row directly in SQLite.
+        await using (var connection = new SqliteConnection($"Data Source={context.DbPath}"))
+        {
+            await connection.OpenAsync();
+            await using var corrupt = connection.CreateCommand();
+            corrupt.CommandText = "UPDATE cron_jobs SET metadata_json = $bad WHERE id = 'job-bad';";
+            corrupt.Parameters.AddWithValue("$bad", "{ this is not valid json ");
+            (await corrupt.ExecuteNonQueryAsync()).ShouldBe(1);
+        }
+        SqliteConnection.ClearAllPools();
+
+        // Must NOT throw: the corrupt row is skipped-to-safe (null metadata), not fatal.
+        var jobs = await context.Store.ListAsync();
+
+        jobs.Select(job => job.Id.Value).OrderBy(id => id).ShouldBe(["job-bad", "job-good"]);
+        var good = jobs.Single(job => job.Id.Value == "job-good");
+        good.Metadata.ShouldNotBeNull();
+        good.Metadata!.ShouldContainKey("source");
+        good.Metadata!["source"]!.ToString().ShouldBe("tests");
+        var bad = jobs.Single(job => job.Id.Value == "job-bad");
+        bad.Metadata.ShouldBeNull("A corrupt metadata_json must degrade to null metadata, not abort the load.");
+    }
+
+    [Fact]
+    public async Task GetAsync_WithCorruptTemplateParametersJson_LoadsJobWithNullTemplateParameters()
+    {
+        // Regression (#1751): a corrupt template_parameters_json must not throw out of the
+        // reader. The job still loads; TemplateParameters degrades to null.
+        await using var context = await CronStoreTestContext.CreateAsync();
+        await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-tpl", "agent-a"));
+
+        await using (var connection = new SqliteConnection($"Data Source={context.DbPath}"))
+        {
+            await connection.OpenAsync();
+            await using var corrupt = connection.CreateCommand();
+            corrupt.CommandText = "UPDATE cron_jobs SET template_parameters_json = $bad WHERE id = 'job-tpl';";
+            corrupt.Parameters.AddWithValue("$bad", "[not, valid");
+            (await corrupt.ExecuteNonQueryAsync()).ShouldBe(1);
+        }
+        SqliteConnection.ClearAllPools();
+
+        var loaded = await context.Store.GetAsync(JobId.From("job-tpl"));
+
+        loaded.ShouldNotBeNull();
+        loaded!.Id.Value.ShouldBe("job-tpl");
+        loaded.TemplateParameters.ShouldBeNull("A corrupt template_parameters_json must degrade to null, not abort the load.");
+    }
+
+    [Fact]
     public async Task DeleteAsync_RemovesJob()
     {
         await using var context = await CronStoreTestContext.CreateAsync();

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreTests.cs
@@ -790,6 +790,65 @@ public sealed class SqliteConversationStoreTests
         after.ShouldBeGreaterThan(before);
     }
 
+    [Fact]
+    public async Task GetAsync_WithCorruptMetadataColumn_FallsBackToEmptyMetadata_WithoutThrowing()
+    {
+        // Regression (#1751): a corrupted metadata column value must not throw JsonException
+        // out of the row mapper and abort the load. The guard now logs a warning with the
+        // conversation id and hydrates an empty metadata dictionary so the row still loads.
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var conv = CreateConversation(Agent("agent-a"), "corrupt-meta");
+        await store.CreateAsync(conv);
+
+        await using (var connection = new SqliteConnection(fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var corrupt = connection.CreateCommand();
+            corrupt.CommandText = "UPDATE conversations SET metadata = $bad WHERE id = $id;";
+            corrupt.Parameters.AddWithValue("$bad", "{ this is not valid json ");
+            corrupt.Parameters.AddWithValue("$id", conv.ConversationId.Value);
+            (await corrupt.ExecuteNonQueryAsync()).ShouldBe(1);
+        }
+        SqliteConnection.ClearAllPools();
+
+        // Fresh store (empty cache) forces a real column read + hydrate. Must NOT throw.
+        var loaded = await fixture.CreateStore().GetAsync(conv.ConversationId);
+
+        loaded.ShouldNotBeNull();
+        loaded!.Title.ShouldBe("corrupt-meta");
+        loaded.Metadata.ShouldBeEmpty("A corrupt metadata column must degrade to an empty dictionary, not abort the load.");
+    }
+
+    [Fact]
+    public async Task ListAsync_WithCorruptMetadataOnOneRow_StillReturnsAllConversations()
+    {
+        // Regression (#1751): one corrupt metadata row must not poison a list/scan. The other
+        // valid conversations must still enumerate.
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var good = CreateConversation(Agent("agent-a"), "good-row");
+        var bad = CreateConversation(Agent("agent-a"), "bad-row");
+        await store.CreateAsync(good);
+        await store.CreateAsync(bad);
+
+        await using (var connection = new SqliteConnection(fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var corrupt = connection.CreateCommand();
+            corrupt.CommandText = "UPDATE conversations SET metadata = $bad WHERE id = $id;";
+            corrupt.Parameters.AddWithValue("$bad", "]not even close[");
+            corrupt.Parameters.AddWithValue("$id", bad.ConversationId.Value);
+            (await corrupt.ExecuteNonQueryAsync()).ShouldBe(1);
+        }
+        SqliteConnection.ClearAllPools();
+
+        var all = await fixture.CreateStore().ListAsync(Agent("agent-a"));
+
+        all.Select(c => c.Title).OrderBy(t => t).ShouldBe(["bad-row", "good-row"]);
+        all.Single(c => c.Title == "bad-row").Metadata.ShouldBeEmpty();
+    }
+
     private static string TempDb()
         => Path.Combine(Path.GetTempPath(), $"bn-conv-test-{Guid.NewGuid():N}.db");
 

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
@@ -1167,6 +1167,76 @@ public sealed class SqliteSessionStoreTests
         });
     }
 
+    [Fact]
+    public async Task BackfillParticipants_WithCorruptParticipantsJsonOnOneRow_SkipsIt_AndForwardsTheValidRows()
+    {
+        // Regression (#1751): the participants backfill scan reads participants_json row by
+        // row. A single corrupt blob used to throw JsonException out of DeserializeParticipants
+        // and abort the ENTIRE scan, so no conversation received its participants. The guard now
+        // logs a warning with the conversation/session id, skips the corrupt row, and continues
+        // the reader loop so the remaining valid rows are still forwarded.
+        using var fixture = new StoreFixture();
+
+        // Two destination conversations must exist in the (shared) conversation store, because
+        // AddParticipantsAsync no-ops when the target conversation is absent.
+        await fixture.Conversations.CreateAsync(new Conversation
+        {
+            ConversationId = ConversationId.From("conv-good"),
+            AgentId = AgentId.From("agent-a"),
+            Title = "good",
+            Status = BotNexus.Gateway.Abstractions.Models.ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+        await fixture.Conversations.CreateAsync(new Conversation
+        {
+            ConversationId = ConversationId.From("conv-bad"),
+            AgentId = AgentId.From("agent-a"),
+            Title = "bad",
+            Status = BotNexus.Gateway.Abstractions.Models.ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+
+        // First store op creates the schema (and runs an initial, empty backfill).
+        (await fixture.CreateStore().GetAsync(SessionId.From("missing"))).ShouldBeNull();
+
+        // Seed two legacy session rows carrying participants_json: one valid (legacy wire
+        // shape), one deliberately corrupt. Both are attached to a non-null conversation_id so
+        // the backfill scan picks them up.
+        await using (var connection = new SqliteConnection(fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var seed = connection.CreateCommand();
+            seed.CommandText = """
+                INSERT INTO sessions (id, status, participants_json, created_at, updated_at, conversation_id)
+                VALUES ('s-good', 'Active', $goodJson, '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z', 'conv-good');
+
+                INSERT INTO sessions (id, status, participants_json, created_at, updated_at, conversation_id)
+                VALUES ('s-bad', 'Active', $badJson, '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z', 'conv-bad');
+                """;
+            seed.Parameters.AddWithValue("$goodJson", """[{"type":"User","id":"alice","role":"initiator"}]""");
+            seed.Parameters.AddWithValue("$badJson", "[ this is not valid json ");
+            await seed.ExecuteNonQueryAsync();
+        }
+        SqliteConnection.ClearAllPools();
+
+        // A fresh store re-runs EnsureCreatedAsync -> BackfillParticipantsToConversationsAsync.
+        // Must NOT throw despite the corrupt row.
+        (await fixture.CreateStore().GetAsync(SessionId.From("s-good"))).ShouldNotBeNull();
+
+        // The valid row's participant was forwarded even though a corrupt row was present in the
+        // same scan - proving one bad blob does not abort the whole backfill.
+        var good = await fixture.Conversations.GetAsync(ConversationId.From("conv-good"));
+        good.ShouldNotBeNull();
+        good!.Participants.ShouldContain(p => p.CitizenId == CitizenId.Of(UserId.From("alice")));
+
+        // The corrupt row contributed nothing (skipped-to-empty), but did not poison the scan.
+        var bad = await fixture.Conversations.GetAsync(ConversationId.From("conv-bad"));
+        bad.ShouldNotBeNull();
+        bad!.Participants.ShouldBeEmpty("A corrupt participants_json row must be skipped, not forwarded.");
+    }
+
     private sealed class StoreFixture : IDisposable
     {
         public StoreFixture()


### PR DESCRIPTION
Closes #1751.

## Problem

Several SQLite stores hydrate rows with a bare `JsonSerializer.Deserialize` on a stored JSON column, with **no** `try/catch`. A single corrupt value throws `JsonException` out of the per-row hydrate and aborts the **entire** scan:

- `SqliteCronStore.ReadJob` -> `DeserializeMetadata` / `DeserializeTemplateParameters`: one bad `metadata_json` / `template_parameters_json` aborts `ListAsync`/`GetAsync`, so the scheduler can enumerate **no** jobs.
- `ConversationRowMapper.MapConversation` -> `DeserializeMetadata`: one bad `metadata` column poisons the whole conversation list/scan.
- `SqliteSessionStore` participants backfill loop -> `DeserializeParticipants`: one bad `participants_json` blob aborts the whole backfill so no conversation receives its participants.

Ported from the OpenClaw delivery-queue-inflate guard (`302524bbd0f1`).

## Fix

Wrap each stored-column deserialize in `try/catch (JsonException)`:
- log a warning with the row id (job / conversation / session)
- degrade to a safe default — `null` metadata/parameters (columns are already nullable) or an empty dictionary — or **skip-and-continue** in the scan loop

so the remaining valid rows still load. Also hardens the conversation deep-clone metadata round-trip (`CloneMetadata`) defensively.

Corrupt-row handling is now **skip-to-safe**, never fatal.

## Tests (TDD)

New regression coverage in all three stores that corrupts exactly one row directly in SQLite, then asserts the scan does **not** throw, the corrupt row degrades to null/empty, and the other valid rows still enumerate:
- `SqliteCronStoreTests`: `ListAsync_WithCorruptMetadataJsonOnOneJob_...`, `GetAsync_WithCorruptTemplateParametersJson_...`
- `SqliteConversationStoreTests`: `GetAsync_WithCorruptMetadataColumn_...`, `ListAsync_WithCorruptMetadataOnOneRow_...`
- `SqliteSessionStoreTests`: `BackfillParticipants_WithCorruptParticipantsJsonOnOneRow_SkipsIt_...`

## Verification

- `dotnet build BotNexus.slnx -c Release`: 0 warnings, 0 errors
- `scripts/repo/test-impacted.ps1`: **all green** — Architecture 212/212, Scenarios 29/29 (safety-net), Cron 232/232, Conversations 277/277, Gateway 3458/3459 (1 pre-existing skip), Gateway.Sessions 61/61, Cli 306/306, CodingAgent 244/244, Mcp 186/186
