### PR TITLE
fix(sessions): fence stale post-run session writes after delete/reset mid-run

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionStore.cs
@@ -41,6 +41,50 @@ public interface ISessionStore
     Task SaveAsync(GatewaySession session, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Persists the session state <b>only if</b> the on-disk row still matches the run identity
+    /// captured in <paramref name="fence"/>. When the row was deleted, sealed by a competing
+    /// reset, or rebound to a different conversation while the run was in flight, the write is
+    /// skipped and <see cref="SessionSaveOutcome.Rebound"/> is returned instead of resurrecting
+    /// or clobbering the row. See issue #1518 and <see cref="SessionWriteFence"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the write path the gateway's post-run finalizer uses (turn-transcript
+    /// persistence, compaction record, metadata patch). The plain
+    /// <see cref="SaveAsync(GatewaySession, CancellationToken)"/> overload keeps its
+    /// unconditional create-or-update semantics for pre-run write-ahead saves (the user
+    /// message and crash sentinel) that must be able to create the row.
+    /// </para>
+    /// <para>
+    /// The default implementation re-reads the session via <see cref="GetAsync"/> and applies
+    /// the fence before delegating to the unfenced <see cref="SaveAsync(GatewaySession, CancellationToken)"/>.
+    /// Stores that can perform the re-read and the write under a single lock (e.g. the SQLite
+    /// store) override this to close the check-then-write window atomically.
+    /// </para>
+    /// </remarks>
+    /// <param name="session">The session to persist.</param>
+    /// <param name="fence">The run identity captured at run start.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// <see cref="SessionSaveOutcome.Persisted"/> when the fence passed and the session was
+    /// written; <see cref="SessionSaveOutcome.Rebound"/> when the write was skipped.
+    /// </returns>
+    async Task<SessionSaveOutcome> SaveAsync(
+        GatewaySession session,
+        SessionWriteFence fence,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        var current = await GetAsync(fence.ExpectedSessionId, cancellationToken).ConfigureAwait(false);
+        if (!SessionFenceEvaluator.Passes(fence, current))
+            return SessionSaveOutcome.Rebound;
+
+        await SaveAsync(session, cancellationToken).ConfigureAwait(false);
+        return SessionSaveOutcome.Persisted;
+    }
+
+    /// <summary>
     /// Deletes a session and its history.
     /// </summary>
     Task DeleteAsync(SessionId sessionId, CancellationToken cancellationToken = default);

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/SessionFenceEvaluator.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/SessionFenceEvaluator.cs
@@ -1,0 +1,53 @@
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Abstractions.Sessions;
+
+/// <summary>
+/// Single source of truth for the post-run session-write fence decision (issue #1518).
+/// Both the default <see cref="ISessionStore.SaveAsync(GatewaySession, SessionWriteFence, System.Threading.CancellationToken)"/>
+/// implementation and store-specific overrides (e.g. the SQLite store, which re-reads under a
+/// lock) evaluate the fence through this method so the "session-rebound" semantics cannot drift
+/// between implementations.
+/// </summary>
+public static class SessionFenceEvaluator
+{
+    /// <summary>
+    /// Returns <c>true</c> when a fenced finalizer write is allowed to proceed - i.e. the
+    /// on-disk row still represents the same run identity that was captured at run start.
+    /// Returns <c>false</c> (rebound - suppress the write) when the row was deleted, was sealed
+    /// or expired by a competing reset, or was rebound to a different conversation while the run
+    /// was in flight.
+    /// </summary>
+    /// <param name="fence">The identity captured at run start.</param>
+    /// <param name="current">
+    /// The session as it currently exists on disk, or <c>null</c> when the row no longer exists.
+    /// </param>
+    /// <returns><c>true</c> to persist; <c>false</c> to skip as rebound.</returns>
+    public static bool Passes(SessionWriteFence fence, GatewaySession? current)
+    {
+        // (a) Row deleted mid-run: the unconditional upsert would resurrect it.
+        if (current is null)
+            return false;
+
+        // (b) Rebound to a different conversation mid-run: the same session id now belongs to
+        //     another conversation, so the finalizer would clobber the fresh binding. Only
+        //     compare when the captured conversation id was initialised - a run that started
+        //     before its conversation was stamped has nothing meaningful to compare against and
+        //     must not be skipped on that basis alone (it is still guarded by (a) and (c)).
+        if (fence.ExpectedConversationId.IsInitialized()
+            && current.ConversationId.IsInitialized()
+            && current.ConversationId != fence.ExpectedConversationId)
+        {
+            return false;
+        }
+
+        // (c) Sealed/expired by a competing reset mid-run: DefaultConversationResetService seals
+        //     the row (Status = Sealed) and clears Conversation.ActiveSessionId. The in-memory
+        //     finalizer still believes the session is Active, so an unconditional upsert would
+        //     revert Sealed -> Active, un-sealing a session the user intentionally reset. Suppress.
+        if (current.Status is SessionStatus.Sealed or SessionStatus.Expired)
+            return false;
+
+        return true;
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/SessionWriteFence.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/SessionWriteFence.cs
@@ -1,0 +1,79 @@
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Gateway.Abstractions.Sessions;
+
+/// <summary>
+/// Captures the authoritative identity of a session at the moment a run starts, so that
+/// post-run finalizer writes (turn-transcript persistence, compaction record, metadata patch)
+/// can be fenced against a session that was <b>deleted or reset while the run was in flight</b>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #1518. The gateway persists the completed turn <i>after</i> the agent run returns
+/// (see <c>GatewayHost</c> finalizer save, <c>StreamingSessionHelper.ProcessAndSaveAsync</c>,
+/// and <c>SessionCompactionCoordinator.CompactAsync</c>). If the session/conversation was
+/// deleted (<see cref="ISessionStore.DeleteAsync"/>) or reset
+/// (<c>DefaultConversationResetService</c> seals the row and clears
+/// <see cref="Conversation.ActiveSessionId"/>) <b>during</b> the run, a stale finalizer write
+/// can:
+/// </para>
+/// <list type="bullet">
+///   <item><b>Resurrect</b> a just-deleted row - <c>SqliteSessionStore.UpsertSessionAsync</c>
+///   uses an unconditional <c>INSERT ... ON CONFLICT DO UPDATE</c>, so a save after a delete
+///   re-inserts the row the operator/agent intentionally removed.</item>
+///   <item><b>Clobber</b> a competing reset - the in-memory session still believes it is
+///   <see cref="SessionStatus.Active"/>, so the upsert reverts the persisted
+///   <see cref="SessionStatus.Sealed"/> back to Active, un-sealing a reset session.</item>
+///   <item><b>Rebind</b> - if the same session id has been re-pointed at a different
+///   conversation, the finalizer would overwrite the fresh replacement.</item>
+/// </list>
+/// <para>
+/// A fenced save re-reads the authoritative store immediately before writing and
+/// <b>no-ops</b> (returns <see cref="SessionSaveOutcome.Rebound"/>) when the on-disk row no
+/// longer matches the captured identity. The fence is opt-in: the plain
+/// <see cref="ISessionStore.SaveAsync(GatewaySession, System.Threading.CancellationToken)"/>
+/// overload keeps its unconditional create-or-update semantics, which the write-ahead
+/// pre-run saves (user message, crash sentinel) rely on to create the row in the first place.
+/// </para>
+/// </remarks>
+/// <param name="ExpectedSessionId">
+/// The session id owned by the run, captured at run start. A save is rebound when no row with
+/// this id survives, or when the surviving row has diverged (see <see cref="ExpectedConversationId"/>).
+/// </param>
+/// <param name="ExpectedConversationId">
+/// The conversation the session belonged to at run start. A save is rebound when the on-disk
+/// row's conversation id differs (an intentional rebind/rotation).
+/// </param>
+public readonly record struct SessionWriteFence(
+    SessionId ExpectedSessionId,
+    ConversationId ExpectedConversationId)
+{
+    /// <summary>
+    /// Captures the fence identity from a live session at run start.
+    /// </summary>
+    /// <param name="session">The session whose identity to capture.</param>
+    /// <returns>A fence pinned to the session's current id and conversation.</returns>
+    public static SessionWriteFence Capture(GatewaySession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        return new SessionWriteFence(session.SessionId, session.ConversationId);
+    }
+}
+
+/// <summary>
+/// Result of a fenced <see cref="ISessionStore.SaveAsync(GatewaySession, SessionWriteFence, System.Threading.CancellationToken)"/>.
+/// </summary>
+public enum SessionSaveOutcome
+{
+    /// <summary>The session was persisted normally - the fence passed.</summary>
+    Persisted = 0,
+
+    /// <summary>
+    /// The write was skipped because the on-disk session no longer matches the captured run
+    /// identity (it was deleted, sealed by a reset, or rebound to another conversation while
+    /// the run was in flight). No row was created or modified - the finalizer must treat this
+    /// as a "session-rebound" short-circuit and suppress all downstream persistence.
+    /// </summary>
+    Rebound = 1
+}

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
@@ -29,6 +29,30 @@ public abstract class SessionStoreBase : ISessionStore
 
     public abstract Task SaveAsync(GatewaySession session, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Fenced post-run finalizer save (issue #1518). Default implementation re-reads the session
+    /// via <see cref="GetAsync"/> and evaluates the fence through
+    /// <see cref="SessionFenceEvaluator.Passes"/> before delegating to the unfenced
+    /// <see cref="SaveAsync(GatewaySession, CancellationToken)"/>. This closes the resurrect/clobber
+    /// window for File and InMemory stores. <see cref="SqliteSessionStore"/> overrides this to
+    /// perform the re-read and the write under a single per-session lock so the check-then-write
+    /// is atomic against a concurrent delete/reset.
+    /// </summary>
+    public virtual async Task<SessionSaveOutcome> SaveAsync(
+        GatewaySession session,
+        SessionWriteFence fence,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        var current = await GetAsync(fence.ExpectedSessionId, cancellationToken).ConfigureAwait(false);
+        if (!SessionFenceEvaluator.Passes(fence, current))
+            return SessionSaveOutcome.Rebound;
+
+        await SaveAsync(session, cancellationToken).ConfigureAwait(false);
+        return SessionSaveOutcome.Persisted;
+    }
+
     public abstract Task DeleteAsync(SessionId sessionId, CancellationToken cancellationToken = default);
 
     public abstract Task ArchiveAsync(SessionId sessionId, CancellationToken cancellationToken = default);

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -168,6 +168,118 @@ public sealed class SqliteSessionStore : SessionStoreBase
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Issue #1518: fenced post-run finalizer write. Unlike the base-interface default (which
+    /// re-reads via <see cref="GetAsync"/> and then calls the unfenced save - two separate lock
+    /// acquisitions), this override performs the identity re-read and the upsert under a
+    /// <b>single</b> striped session lock, so a concurrent
+    /// <see cref="DeleteAsync"/>/<see cref="ArchiveAsync"/> cannot slip between the check and the
+    /// write. The re-read deliberately hits SQLite directly (not the in-memory cache): the cache
+    /// may still hold the pre-delete session, whereas the authoritative row is what a competing
+    /// delete/reset mutated. When the fence fails the cache entry for the (now rebound) session is
+    /// evicted so a subsequent read does not serve the stale, resurrected view.
+    /// </remarks>
+    public override async Task<SessionSaveOutcome> SaveAsync(
+        GatewaySession session,
+        SessionWriteFence fence,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        using var activity = ActivitySource.StartActivity("session.save.fenced", ActivityKind.Internal);
+        activity?.SetTag("botnexus.session.id", session.SessionId);
+        activity?.SetTag("botnexus.agent.id", session.AgentId);
+
+        await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+        // Backfill before the per-session lock so the resolver's per-agent lock does not
+        // interleave with concurrent saves of the same session (mirrors the unfenced SaveAsync).
+        await EnsureConversationIdStampedAsync(session, cancellationToken).ConfigureAwait(false);
+
+        var sessionLock = await AcquireSessionLockAsync(session.SessionId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var persisted = await RetryOnTransientAsync(async () =>
+            {
+                await using var connection = CreateConnection();
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                // Re-read the authoritative row identity (conversation + status) directly from
+                // SQLite, inside the lock, before deciding whether to write. A NULL result means
+                // the row was deleted mid-run; a diverged conversation_id or a sealed/expired
+                // status means a competing reset rebound/sealed it. Either way the fence fails.
+                var snapshot = await ReadFenceSnapshotAsync(connection, session.SessionId, cancellationToken).ConfigureAwait(false);
+                if (!SessionFenceEvaluator.Passes(fence, snapshot))
+                {
+                    activity?.SetTag("botnexus.session.fence.rebound", true);
+                    return false;
+                }
+
+                await UpsertSessionAsync(connection, session, cancellationToken).ConfigureAwait(false);
+                await ReplaceHistoryAsync(connection, session, cancellationToken).ConfigureAwait(false);
+                return true;
+            }, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (persisted)
+            {
+                // Only refresh the cache on a real write. On a rebound, evict any stale entry so a
+                // later read re-materialises the authoritative (deleted/sealed/rebound) state.
+                _cache.Set(session.SessionId, session);
+                return SessionSaveOutcome.Persisted;
+            }
+
+            _cache.Remove(session.SessionId);
+            _logger.LogInformation(
+                "Fenced session save for {SessionId} skipped as rebound: the on-disk row was deleted, sealed, " +
+                "or rebound to another conversation while the run was in flight (#1518).",
+                session.SessionId);
+            return SessionSaveOutcome.Rebound;
+        }
+        finally { sessionLock.Dispose(); }
+    }
+
+    /// <summary>
+    /// Lightweight, lock-scoped read of just the fence-relevant fields (conversation_id + status)
+    /// for issue #1518. Returns a synthetic <see cref="GatewaySession"/> carrying only those two
+    /// values (never touches history or the conversation store) so
+    /// <see cref="SessionFenceEvaluator.Passes"/> can evaluate it, or <c>null</c> when the row no
+    /// longer exists. Deliberately avoids <see cref="LoadSessionAsync(SqliteConnection, SessionId, CancellationToken)"/>,
+    /// which hydrates AgentId from the conversation store and would throw if a competing reset had
+    /// already removed the conversation - the fence must observe "row gone" as a clean skip, not an
+    /// exception.
+    /// </summary>
+    private async Task<GatewaySession?> ReadFenceSnapshotAsync(
+        SqliteConnection connection,
+        SessionId sessionId,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT status, conversation_id
+            FROM sessions
+            WHERE id = $sessionId
+            """;
+        command.Parameters.AddWithValue("$sessionId", sessionId.Value);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            return null;
+
+        var status = reader.IsDBNull(0) ? null : reader.GetString(0);
+        var conversationIdValue = reader.IsDBNull(1) ? null : reader.GetString(1);
+
+        // Build a minimal session carrying only the fence-relevant fields. AgentId is left
+        // unhydrated on purpose - SessionFenceEvaluator only inspects ConversationId and Status.
+        var snapshot = new GatewaySession(new Session { SessionId = sessionId }, _redactor)
+        {
+            Status = ParseStatus(status)
+        };
+        if (conversationIdValue is not null)
+            snapshot.ConversationId = ConversationId.From(conversationIdValue);
+
+        return snapshot;
+    }
+
+    /// <inheritdoc />
     public override async Task DeleteAsync(SessionId sessionId, CancellationToken cancellationToken = default)
     {
         using var activity = ActivitySource.StartActivity("session.delete", ActivityKind.Internal);

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -420,6 +420,12 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
             // so applying it here preserves the prior control flow and side-effect ordering.
             await PrepareTurnAsync(session, message, typedAgentId, typedSessionId, sessionId, cancellationToken);
 
+            // #1518: capture the run's authoritative session identity (id + conversation) NOW,
+            // before the agent run starts. Every post-run finalizer write below is fenced against
+            // it so a delete/reset that lands while the run is in flight cannot be undone by the
+            // finalizer resurrecting or clobbering the row.
+            var runFence = SessionWriteFence.Capture(session);
+
             try
             {
                 var handle = await _supervisor.GetOrCreateAsync(typedAgentId, typedSessionId, cancellationToken);
@@ -561,7 +567,8 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                             },
                         MaxPersistedToolResultBytes: maxPersistedToolResultBytes),
                         _sessionLifecycleEvents,
-                        cancellationToken);
+                        finalSaveFence: runFence,
+                        cancellationToken: cancellationToken);
                     }
                     finally
                     {
@@ -647,7 +654,17 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                     saveActivity?.SetTag("botnexus.agent.id", session.AgentId);
                     try
                     {
-                        await _sessions.SaveAsync(session, cancellationToken);
+                        // #1518: fenced finalizer write. If the session was deleted, sealed by a
+                        // reset, or rebound while this (non-streaming) turn ran, the save no-ops
+                        // instead of resurrecting/clobbering the row.
+                        var finalizerOutcome = await _sessions.SaveAsync(session, runFence, cancellationToken);
+                        if (finalizerOutcome == SessionSaveOutcome.Rebound)
+                        {
+                            _logger.LogInformation(
+                                "Session transcript save skipped as rebound for session '{SessionId}': the session was " +
+                                "deleted or reset while the turn was in flight; the completed turn was not persisted (#1518).",
+                                sessionId);
+                        }
                     }
                     catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {

--- a/src/gateway/BotNexus.Gateway/Sessions/SessionCompactionCoordinator.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/SessionCompactionCoordinator.cs
@@ -58,6 +58,12 @@ public sealed class SessionCompactionCoordinator : ISessionCompactionCoordinator
         }
         var sessionId = session.SessionId;
 
+        // #1518: capture the run's authoritative session identity BEFORE the (potentially
+        // long-running) summarization call. The post-run persistence at step 3 is then fenced
+        // against it so a delete/reset that lands while we are summarising cannot be undone by
+        // the compaction record write resurrecting or un-sealing the row.
+        var fence = SessionWriteFence.Capture(session);
+
         // 1. Optional pre-compaction memory flush. Best-effort: failures are logged
         //    and swallowed so compaction always proceeds (mirrors auto-compact path).
         if (_memoryFlusher is not null && _memoryFlusher.ShouldFlush(session.Session, options))
@@ -120,7 +126,27 @@ public sealed class SessionCompactionCoordinator : ISessionCompactionCoordinator
             }
         }
 
-        await _sessions.SaveAsync(session, cancellationToken).ConfigureAwait(false);
+        var saveOutcome = await _sessions.SaveAsync(session, fence, cancellationToken).ConfigureAwait(false);
+        if (saveOutcome == SessionSaveOutcome.Rebound)
+        {
+            // #1518: the session was deleted, sealed, or rebound while we summarised. Do NOT
+            // resurrect it and do NOT evict the agent handle (there is nothing to rebuild) -
+            // surface an aborted outcome so channel callers see the compaction did not land.
+            _logger.LogInformation(
+                "Session {SessionId} compaction discarded as rebound: the session was deleted or reset " +
+                "while compaction was in flight; the compaction record was not persisted (#1518).",
+                sessionId);
+            return new SessionCompactionOutcome(
+                Succeeded: result.Succeeded,
+                Applied: false,
+                HistoryOutcome: HistoryReplaceOutcome.Aborted,
+                EntriesSummarized: result.EntriesSummarized,
+                EntriesPreserved: result.EntriesPreserved,
+                TokensBefore: result.TokensBefore,
+                TokensAfter: result.TokensAfter,
+                FailureReason: "Compaction was discarded because the session was deleted or reset while it was in progress.");
+        }
+
         _logger.LogInformation(
             "Session {SessionId} compacted: {Summarized} entries summarized, {Preserved} preserved (applied={Applied}, outcome={Outcome}).",
             sessionId, result.EntriesSummarized, result.EntriesPreserved, applied, historyOutcome);

--- a/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
+++ b/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
@@ -19,6 +19,14 @@ public static class StreamingSessionHelper
     /// <param name="sessionStore">The session store used to persist changes.</param>
     /// <param name="options">Optional behavior overrides.</param>
     /// <param name="lifecycleEvents">Optional lifecycle event publisher.</param>
+    /// <param name="finalSaveFence">
+    /// Optional run-identity fence (issue #1518). When supplied, the <b>final authoritative
+    /// post-run write</b> is fenced against it: if the session was deleted, sealed by a reset,
+    /// or rebound to another conversation while the stream was in flight, the final save (and
+    /// the <c>Closed</c> lifecycle publish) is skipped instead of resurrecting or clobbering the
+    /// row. The eager mid-run write-ahead flushes (tool-start / turn-end) remain best-effort and
+    /// unfenced - they only ever run while the session is still the run's live session.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The accumulated streaming result details.</returns>
     public static async Task<StreamingSessionResult> ProcessAndSaveAsync(
@@ -27,6 +35,7 @@ public static class StreamingSessionHelper
         ISessionStore sessionStore,
         StreamingSessionOptions? options = null,
         SessionLifecycleEvents? lifecycleEvents = null,
+        SessionWriteFence? finalSaveFence = null,
         CancellationToken cancellationToken = default)
     {
         options ??= new StreamingSessionOptions();
@@ -198,8 +207,16 @@ public static class StreamingSessionHelper
 
         // Remove crash sentinel on clean completion (#363).
         session.RemoveCrashSentinels();
-        await sessionStore.SaveAsync(session, cancellationToken);
-        if (lifecycleEvents is not null)
+
+        // #1518: the final write is the authoritative post-run finalizer save. When a fence was
+        // supplied, honour it so a delete/reset that landed mid-stream cannot be undone here. On
+        // a rebound we skip the save AND the Closed lifecycle publish - the session this run owned
+        // no longer exists (or belongs to someone else), so emitting Closed for it would be wrong.
+        var finalOutcome = finalSaveFence is { } fence
+            ? await sessionStore.SaveAsync(session, fence, cancellationToken)
+            : await SaveUnfencedAsync(sessionStore, session, cancellationToken);
+
+        if (finalOutcome == SessionSaveOutcome.Persisted && lifecycleEvents is not null)
         {
             await lifecycleEvents.PublishAsync(
                 new SessionLifecycleEvent(
@@ -211,6 +228,20 @@ public static class StreamingSessionHelper
         }
 
         return new StreamingSessionResult(streamedContent.ToString(), allHistoryEntries);
+    }
+
+    /// <summary>
+    /// Performs an unfenced final save and reports it as <see cref="SessionSaveOutcome.Persisted"/>,
+    /// so the caller can treat the fenced and unfenced paths uniformly. Used when no
+    /// <see cref="SessionWriteFence"/> was supplied (issue #1518 back-compat for existing callers).
+    /// </summary>
+    private static async Task<SessionSaveOutcome> SaveUnfencedAsync(
+        ISessionStore sessionStore,
+        GatewaySession session,
+        CancellationToken cancellationToken)
+    {
+        await sessionStore.SaveAsync(session, cancellationToken);
+        return SessionSaveOutcome.Persisted;
     }
 
     /// <summary>

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionFenceEvaluatorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionFenceEvaluatorTests.cs
@@ -1,0 +1,93 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+
+namespace BotNexus.Gateway.Tests.Sessions;
+
+/// <summary>
+/// Unit tests for the issue #1518 fence decision logic in <see cref="SessionFenceEvaluator"/>.
+/// This is the single source of truth every fenced-save implementation delegates to, so its three
+/// rebound branches (row deleted, conversation rebound, sealed/expired by reset) are pinned here.
+/// </summary>
+public sealed class SessionFenceEvaluatorTests
+{
+    private static SessionWriteFence Fence(string sessionId, ConversationId conversationId)
+        => new(SessionId.From(sessionId), conversationId);
+
+    private static GatewaySession SessionRow(string sessionId, ConversationId conversationId, SessionStatus status)
+    {
+        var session = new GatewaySession(new Session { SessionId = SessionId.From(sessionId) })
+        {
+            Status = status
+        };
+        session.ConversationId = conversationId;
+        return session;
+    }
+
+    [Fact]
+    public void Passes_WhenRowMatchesAndActive_ReturnsTrue()
+    {
+        var conv = ConversationId.Create();
+        var fence = Fence("s1", conv);
+        var current = SessionRow("s1", conv, SessionStatus.Active);
+
+        SessionFenceEvaluator.Passes(fence, current).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Passes_WhenRowDeleted_ReturnsFalse()
+    {
+        var fence = Fence("s1", ConversationId.Create());
+
+        // A null current row models a delete that landed mid-run.
+        SessionFenceEvaluator.Passes(fence, current: null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Passes_WhenConversationRebound_ReturnsFalse()
+    {
+        var fence = Fence("s1", ConversationId.Create());
+        var current = SessionRow("s1", ConversationId.Create(), SessionStatus.Active);
+
+        SessionFenceEvaluator.Passes(fence, current).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(SessionStatus.Sealed)]
+    [InlineData(SessionStatus.Expired)]
+    public void Passes_WhenSealedOrExpiredByReset_ReturnsFalse(SessionStatus status)
+    {
+        var conv = ConversationId.Create();
+        var fence = Fence("s1", conv);
+        var current = SessionRow("s1", conv, status);
+
+        SessionFenceEvaluator.Passes(fence, current).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Passes_WhenSuspended_ReturnsTrue()
+    {
+        // Suspended is a resumable state, not a reset/delete signal, so a finalizer write is allowed.
+        var conv = ConversationId.Create();
+        var fence = Fence("s1", conv);
+        var current = SessionRow("s1", conv, SessionStatus.Suspended);
+
+        SessionFenceEvaluator.Passes(fence, current).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Passes_WhenCapturedConversationUninitialized_DoesNotFalselyRebound()
+    {
+        // A run that started before its conversation was stamped has no meaningful conversation to
+        // compare; it must still be allowed (guarded only by the deleted/sealed branches). The
+        // uninitialized sentinel is read from a fresh session (Vogen forbids constructing it via
+        // `default` in user code, VOG009).
+        var uninitializedConversationId = new GatewaySession().ConversationId;
+        uninitializedConversationId.IsInitialized().ShouldBeFalse("precondition: sentinel is uninitialized");
+
+        var fence = new SessionWriteFence(SessionId.From("s1"), uninitializedConversationId);
+        var current = SessionRow("s1", ConversationId.Create(), SessionStatus.Active);
+
+        SessionFenceEvaluator.Passes(fence, current).ShouldBeTrue();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SqliteSessionStorePostRunFenceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SqliteSessionStorePostRunFenceTests.cs
@@ -1,0 +1,188 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Tests.Sessions;
+
+/// <summary>
+/// Issue #1518 regression tests: the post-run finalizer must not resurrect a session that was
+/// deleted mid-run, nor clobber a session that was sealed/rebound by a competing reset while the
+/// run was in flight. These exercise the fenced
+/// <see cref="ISessionStore.SaveAsync(GatewaySession, SessionWriteFence, System.Threading.CancellationToken)"/>
+/// overload directly against <see cref="SqliteSessionStore"/> (the production store, whose
+/// unconditional <c>INSERT ... ON CONFLICT DO UPDATE</c> upsert is the resurrection vector) so the
+/// gap is proven closed at the store layer that every finalizer path funnels through.
+/// </summary>
+public sealed class SqliteSessionStorePostRunFenceTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly string _connectionString;
+    private readonly InMemoryConversationStore _conversations = new();
+
+    public SqliteSessionStorePostRunFenceTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"botnexus-fence-tests-{Guid.NewGuid():N}.db");
+        _connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = _dbPath,
+            Pooling = false
+        }.ToString();
+    }
+
+    private SqliteSessionStore CreateStore()
+        => new(_connectionString, NullLogger<SqliteSessionStore>.Instance, _conversations);
+
+    private async Task<(SqliteSessionStore Store, GatewaySession Session, SessionWriteFence Fence)> ArrangeSavedSessionAsync(
+        string sessionIdValue,
+        string agentIdValue,
+        ConversationId conversationId)
+    {
+        var agentId = AgentId.From(agentIdValue);
+        // P9-I (#674): the conversation must exist before AgentId hydration runs on reload.
+        await _conversations.CreateAsync(new Conversation
+        {
+            ConversationId = conversationId,
+            AgentId = agentId
+        });
+
+        var store = CreateStore();
+        var session = await store.GetOrCreateAsync(SessionId.From(sessionIdValue), agentId);
+        session.Session.ConversationId = conversationId;
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "first" });
+        await store.SaveAsync(session);
+
+        // Capture the run identity exactly as the gateway does at run start.
+        var fence = SessionWriteFence.Capture(session);
+        return (store, session, fence);
+    }
+
+    [Fact]
+    public async Task FencedSave_AfterDeleteMidRun_DoesNotResurrectRow()
+    {
+        var conversationId = ConversationId.Create();
+        var (store, session, fence) = await ArrangeSavedSessionAsync("s-delete", "agent-a", conversationId);
+
+        // A competing delete lands while the "run" is in flight.
+        await store.DeleteAsync(session.SessionId);
+        (await store.GetAsync(session.SessionId)).ShouldBeNull("precondition: the row is deleted");
+
+        // The finalizer now tries to persist the completed turn against the captured identity.
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "late-turn" });
+        var outcome = await store.SaveAsync(session, fence);
+
+        outcome.ShouldBe(SessionSaveOutcome.Rebound, "a delete mid-run must short-circuit the finalizer write");
+
+        // The row must NOT have been resurrected - not in this store, and not via a cold store.
+        (await store.GetAsync(session.SessionId)).ShouldBeNull("the deleted session must stay deleted");
+        (await CreateStore().GetAsync(session.SessionId)).ShouldBeNull("cold read must also see no resurrected row");
+    }
+
+    [Fact]
+    public async Task FencedSave_AfterSealByResetMidRun_DoesNotUnseal()
+    {
+        var conversationId = ConversationId.Create();
+        var (store, session, fence) = await ArrangeSavedSessionAsync("s-seal", "agent-b", conversationId);
+
+        // A competing reset seals the row (DefaultConversationResetService step 4) mid-run.
+        // Seal through a SEPARATE cold store so the run's in-memory `session` (served from the
+        // first store's cache) is not mutated by reference - modelling two independent actors.
+        var resetStore = CreateStore();
+        var sealer = await resetStore.GetAsync(session.SessionId);
+        sealer.ShouldNotBeNull();
+        sealer!.Status = SessionStatus.Sealed;
+        await resetStore.SaveAsync(sealer);
+
+        // The in-memory finalizer still believes the session is Active and appends its turn.
+        session.Status.ShouldBe(SessionStatus.Active, "precondition: the run's copy is still Active");
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "late-turn" });
+        var outcome = await store.SaveAsync(session, fence);
+
+        outcome.ShouldBe(SessionSaveOutcome.Rebound, "a seal-by-reset mid-run must short-circuit the finalizer write");
+
+        // The persisted row must remain Sealed - the finalizer must not revert it to Active.
+        var reloaded = await CreateStore().GetAsync(session.SessionId);
+        reloaded.ShouldNotBeNull();
+        reloaded!.Status.ShouldBe(SessionStatus.Sealed, "the finalizer must not un-seal a reset session");
+        reloaded.GetHistorySnapshot().ShouldNotContain(e => e.Content == "late-turn", "the late turn must not be persisted");
+    }
+
+    [Fact]
+    public async Task FencedSave_AfterConversationRebindMidRun_DoesNotClobber()
+    {
+        var originalConversationId = ConversationId.Create();
+        var (store, session, fence) = await ArrangeSavedSessionAsync("s-rebind", "agent-c", originalConversationId);
+
+        // A competing path rebinds the same session id to a different conversation mid-run.
+        var rebindConversationId = ConversationId.Create();
+        await _conversations.CreateAsync(new Conversation
+        {
+            ConversationId = rebindConversationId,
+            AgentId = session.AgentId
+        });
+        var rebinder = await CreateStore().GetAsync(session.SessionId);
+        rebinder.ShouldNotBeNull();
+        rebinder!.Session.ConversationId = rebindConversationId;
+        await CreateStore().SaveAsync(rebinder);
+
+        // The finalizer still holds the ORIGINAL conversation identity.
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "late-turn" });
+        var outcome = await store.SaveAsync(session, fence);
+
+        outcome.ShouldBe(SessionSaveOutcome.Rebound, "a conversation rebind mid-run must short-circuit the finalizer write");
+
+        var reloaded = await CreateStore().GetAsync(session.SessionId);
+        reloaded.ShouldNotBeNull();
+        reloaded!.Session.ConversationId.ShouldBe(rebindConversationId, "the fresh binding must survive; the finalizer must not clobber it");
+    }
+
+    [Fact]
+    public async Task FencedSave_WhenSessionUnchanged_PersistsNormally()
+    {
+        var conversationId = ConversationId.Create();
+        var (store, session, fence) = await ArrangeSavedSessionAsync("s-ok", "agent-d", conversationId);
+
+        // Normal happy path: nothing deleted or reset; the finalizer's turn must land.
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "clean-turn" });
+        var outcome = await store.SaveAsync(session, fence);
+
+        outcome.ShouldBe(SessionSaveOutcome.Persisted, "an unchanged session must persist the completed turn");
+
+        var reloaded = await CreateStore().GetAsync(session.SessionId);
+        reloaded.ShouldNotBeNull();
+        reloaded!.GetHistorySnapshot().ShouldContain(e => e.Content == "clean-turn", "the completed turn must be persisted");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(_dbPath))
+            {
+                for (var attempt = 0; attempt < 5; attempt++)
+                {
+                    try
+                    {
+                        File.Delete(_dbPath);
+                        return;
+                    }
+                    catch (IOException)
+                    {
+                        if (attempt >= 4)
+                            break;
+                        Thread.Sleep(50);
+                    }
+                }
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; SQLite file locks can linger briefly on Windows.
+        }
+    }
+}


### PR DESCRIPTION
Closes #1518

## Problem
After a session is deleted or reset **mid-run**, the gateway's post-run finalizer (turn-transcript persistence, compaction record, metadata patch) could:
- **Resurrect** a just-deleted row -- `SqliteSessionStore.UpsertSessionAsync` uses an unconditional `INSERT ... ON CONFLICT DO UPDATE`, so a save after a delete re-inserts the row the operator/agent intentionally removed.
- **Clobber a competing reset** -- the in-memory session still believes it is `Active`, so the upsert reverts the persisted `Sealed` status back to Active, un-sealing a reset session.
- **Rebind** -- if the session id was re-pointed at a different conversation, the finalizer would overwrite the fresh replacement.

This is the same delete-mid-run-finalizer-resurrects-row class flagged by OpenClaw `402c85b07a92` (verify-the-gap port; the C# crash shape differs but the data-integrity gap is real).

## Changes
- **`SessionWriteFence`** (new, `BotNexus.Gateway.Contracts/Sessions`, namespace `BotNexus.Gateway.Abstractions.Sessions`): captures the authoritative session identity (`SessionId` + `ConversationId`) at run start via `Capture(session)`.
- **`SessionFenceEvaluator.Passes(fence, current)`**: the single source of truth for the fence decision -- passes only when the on-disk row still exists, is not `Sealed`/`Expired`, and its conversation id has not been rebound away from the captured identity. Delegated to by every fenced-save implementation so the "session-rebound" semantics cannot drift.
- **Fenced `SaveAsync(session, fence, ct)` overload** on `ISessionStore` (default interface method) / `SessionStoreBase` (virtual, for File + InMemory) / `SqliteSessionStore` (override): the SQLite override re-reads the authoritative row **directly from SQLite (not the cache) under a single striped session lock** -- closing the TOCTOU gap between check and write -- and **no-ops** returning `SessionSaveOutcome.Rebound` when the row was deleted, sealed by a reset, or rebound. On rebound it evicts the stale cache entry so a later read re-materialises the true state.
- The plain unconditional `SaveAsync(session, ct)` is **unchanged** -- the pre-run write-ahead saves (user message, crash sentinel) still create the row.
- Finalizer call sites -- `GatewayHost` (non-streaming + streaming via `StreamingSessionHelper.ProcessAndSaveAsync`'s new `finalSaveFence` param) and `SessionCompactionCoordinator` -- capture the fence at run start and short-circuit all downstream persistence (including the `Closed` lifecycle publish and the compaction record) on a `Rebound` outcome.

`ReadFenceSnapshotAsync` deliberately reads only `status` + `conversation_id` (never hydrates from the conversation store) so a concurrent reset that already removed the conversation surfaces as a clean "row gone" skip, not an exception.

## Tests
- `SessionFenceEvaluatorTests` (7) -- the pure predicate: matches+Active persists; deleted / sealed / expired / conversation-rebound suppress; Suspended still persists; uninitialized captured conversation does not falsely rebound.
- `SqliteSessionStorePostRunFenceTests` (4) -- against the production `SqliteSessionStore`: delete-mid-run does **not** resurrect the row (verified via a cold store too), seal-by-reset-mid-run does **not** un-seal and drops the late turn, conversation-rebind-mid-run does **not** clobber the fresh binding, and the unchanged happy path persists the completed turn.

## Verification
- `dotnet build BotNexus.slnx --no-restore` -- **0 warnings, 0 errors** (TreatWarningsAsErrors on).
- `scripts/repo/test-impacted.ps1` -- **GREEN, exit 0**: 19 impacted projects, zero failures. Includes the mandatory safety nets Architecture.Tests (212) + Scenarios.Tests (29), plus Gateway.Tests (3484 passed / 1 pre-existing skip -- includes the 11 new fence tests), Gateway.Sessions.Tests (61), Gateway.Conversations.Tests (277), and Memory.Tests (179).

## Merge Notes
Disjoint from the sibling PR in this cycle (#1651 assistant-role render -- Channels/Portal, different assemblies). Touches only `BotNexus.Gateway.Contracts/Sessions` + `BotNexus.Gateway.Sessions` + the `BotNexus.Gateway` finalizer path. No config/schema/API change. Safe to merge in any order relative to #1651.
