### PR TITLE
docs(tools): surface PowerShell/Python point-of-use gotchas in shell and exec descriptions

### DIFF
--- a/src/extensions/BotNexus.Extensions.ExecTool/ExecTool.cs
+++ b/src/extensions/BotNexus.Extensions.ExecTool/ExecTool.cs
@@ -53,7 +53,11 @@ public sealed class ExecTool : IAgentTool
     /// <inheritdoc />
     public Tool Definition => new(
         Name,
-        "Execute a command with advanced process management: timeouts, background mode, stdin piping, and environment variable merging.",
+        "Execute a command with advanced process management: timeouts, background mode, stdin piping, and environment variable merging. " +
+        "On Windows PowerShell: wrap a variable followed by ':' as ${var} inside double-quoted strings (or use single quotes); " +
+        "no backtick line-continuations; for multi-line/complex scripts write a tmp/*.ps1 file and run it. Inline Python prints " +
+        "cp1252 by default (UnicodeEncodeError on emoji/em-dash/box glyphs) -- set $env:PYTHONUTF8=1 or write a tmp/*.py file " +
+        "and run 'python -X utf8 file.py'. Never pipe a here-string into an interpreter; write a temp file and execute it.",
         JsonDocument.Parse("""
             {
               "type": "object",

--- a/src/gateway/BotNexus.Tools/ShellTool.cs
+++ b/src/gateway/BotNexus.Tools/ShellTool.cs
@@ -115,7 +115,12 @@ public sealed class ShellTool : IAgentTool
     public Tool Definition => new(
         Name,
         _shellPreference == ShellPreference.Pwsh
-            ? "Execute a PowerShell command in the current working directory and return stdout/stderr."
+            ? "Execute a PowerShell command in the current working directory and return stdout/stderr. " +
+              "PowerShell gotchas (avoid ParserError): inside double-quoted strings wrap a variable followed by ':' as ${var} " +
+              "(or use single quotes); no backtick line-continuations; pass -Filter a single string, not an array; for " +
+              "multi-line or complex scripts write a tmp/*.ps1 file and run it. Inline Python on Windows prints cp1252 by " +
+              "default (UnicodeEncodeError on emoji/em-dash/box glyphs) -- set $env:PYTHONUTF8=1 or write a tmp/*.py file and " +
+              "run 'python -X utf8 file.py'. Never pipe a here-string into an interpreter; write a temp file and execute it."
             : "Execute a bash command in the current working directory and return stdout/stderr.",
         JsonDocument.Parse("""
             {

--- a/tests/BotNexus.CodingAgent.Tests/Tools/ShellToolTests.cs
+++ b/tests/BotNexus.CodingAgent.Tests/Tools/ShellToolTests.cs
@@ -211,6 +211,18 @@ public sealed class ShellToolTests
     }
 
     [Fact]
+    public void Definition_Pwsh_SurfacesPointOfUseGotchas()
+    {
+        var tool = new ShellTool(shellPreference: ShellPreference.Pwsh);
+
+        var description = tool.Definition.Description;
+
+        description.ShouldContain("${var}");
+        description.ShouldContain("PYTHONUTF8");
+        description.ShouldContain("here-string");
+    }
+
+    [Fact]
     public void FindBashExecutable_WhenGitIsInstalledOnWindows_ReturnsPath()
     {
         if (!OperatingSystem.IsWindows())

--- a/tests/extensions/BotNexus.Extensions.ExecTool.Tests/ExecToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.ExecTool.Tests/ExecToolTests.cs
@@ -35,6 +35,16 @@ public class ExecToolTests : IDisposable
     }
 
     [Fact]
+    public void Definition_SurfacesPointOfUseGotchas()
+    {
+        var description = _tool.Definition.Description;
+
+        description.ShouldContain("${var}");
+        description.ShouldContain("PYTHONUTF8");
+        description.ShouldContain("here-string");
+    }
+
+    [Fact]
     public async Task ExecuteSimpleEchoCommand()
     {
         var args = BuildArgs(GetEchoCommand("hello world"));


### PR DESCRIPTION
Closes #1557
Closes #1556

## Changes
Surfaces the two highest-frequency `shell`/`exec` failure clusters from the weekly tool-failure-forensics run (2026-06-22) at the **point of use** — the tool descriptions the model reads when composing a command. The full rules already live in WORLD.md; this adds the compressed reminder where it is actually consumed.

- **ShellTool** (pwsh preference) and **ExecTool** descriptions now include:
  - PowerShell `ParserError` avoidance (#1557): wrap a variable followed by `:` as `${var}` in double-quoted strings (or single-quote), no backtick line-continuations, `-Filter` takes a single string not an array, write a `tmp/*.ps1` for complex scripts.
  - Inline-Python cp1252 gotcha (#1556): Python prints cp1252 by default on Windows (`UnicodeEncodeError` on emoji/em-dash/box glyphs) — set `$env:PYTHONUTF8=1` or write a `tmp/*.py` and run `python -X utf8 file.py`.
  - Never pipe a here-string into an interpreter — write a temp file and execute it.
- Adds description-content tests on both tools.

Bash description is unchanged (gotchas are pwsh/Windows-specific).

## Merge Notes
Isolated to `ShellTool.cs` + `ExecTool.cs` (and their test files) — no overlap with open PRs #1787 (copilot) or #1786 (telegram docs). Safe to merge in any order.