### PR TITLE
docs: daily documentation grooming 2026-07-06 (SignalR ContentDelta role field)

### DIFF
--- a/docs/signalr-hub-contract.md
+++ b/docs/signalr-hub-contract.md
@@ -94,7 +94,7 @@ Events the server pushes to subscribed clients. Defined by the typed
 |---|---|
 | `MessageStart(evt)` | The agent began producing a message. |
 | `ThinkingDelta(evt)` | A chunk of reasoning/thinking output (when the provider streams it). |
-| `ContentDelta(evt)` | A chunk of assistant message content. |
+| `ContentDelta(evt)` | A chunk of assistant message content. The payload carries an optional `role` field (see note below). |
 | `ToolStart(evt)` | A tool call began. |
 | `ToolEnd(evt)` | A tool call finished. |
 | `MessageEnd(evt)` | The agent finished producing a message. |
@@ -122,6 +122,11 @@ Events the server pushes to subscribed clients. Defined by the typed
 ## Notes
 
 - All gateway-originated messages use `channelType = "signalr"`.
+- The `ContentDelta` payload carries an optional `role` field. It is `null` for ordinary
+  streamed/relayed content — the client then renders the assistant bubble, matching every
+  pre-existing payload — and is only set when an agent-post must render under a specific role
+  (e.g. an on-behalf-of-user kickoff stamped `user`). The field is trailing-optional, so older
+  clients and existing wire messages deserialize unchanged.
 - Clients should call `SubscribeAll` after connecting and on reconnect.
 - Channel switching is a client-only UI operation. Do not call join/leave methods.
 - Session fan-out uses SignalR groups: `session:{sessionId}`.


### PR DESCRIPTION
## Changes

- **SignalR hub contract:** documented the optional ole field on the `ContentDelta` payload (added in #1768, the live fan-out side of post-as-assistant / #1651). Updated the `ContentDelta` streaming-event row and added a Notes entry explaining that the field is `null` for ordinary streamed/relayed content (client renders the assistant bubble, matching every pre-existing payload) and is only set when an agent-post must render under a specific role (e.g. an on-behalf-of-user kickoff stamped `user`); it is trailing-optional so older clients deserialize unchanged.

## Structural improvements
None — 36 release pages == 36 index-table rows (0 orphan, 0 dead link), 0 sidebar orphans, `← Latest` correct on v0.17.0.

## New pages
None.

## Content fixes
- `docs/signalr-hub-contract.md` — reconciled against `HubContracts.cs` `ContentDeltaPayload` (the one real doc gap among the 10 post-v0.17.0 merges). All other surfaces verified clean: 0 CLI-command changes, 0 new public config fields (`git diff v0.17.0..HEAD` on `*Config*.cs`/`*Options*.cs` empty), speak_as already documented in `conversations.md` (#1771), no new providers/extensions.

---
Verify-heavy fresh-branch run (prior grooming PR #1771 merged). Mojibake gate clean (sig=0, box=0). VitePress build green (14.85s). Automated by the daily documentation groomer.