### PR TITLE
fix(webtools): bound web_fetch response body reads to prevent OOM/DoS

### DIFF
--- a/src/extensions/BotNexus.Extensions.WebTools/WebFetchTool.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/WebFetchTool.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Utilities;
 using BotNexus.Gateway.Abstractions.Security;
 
 namespace BotNexus.Extensions.WebTools;
@@ -195,7 +196,10 @@ public sealed class WebFetchTool : IAgentTool, IDisposable
                     $"{errorJson}\n\nHTTP {statusCode} {response.ReasonPhrase} when fetching {url}");
             }
 
-            var html = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var html = await BoundedHttpContent.ReadStringWithLimitAsync(
+                response.Content,
+                _config.MaxResponseBytes,
+                cancellationToken).ConfigureAwait(false);
 
             var content = raw ? html : HtmlToText.Convert(html);
 
@@ -232,6 +236,11 @@ public sealed class WebFetchTool : IAgentTool, IDisposable
             }
 
             return TextResult($"{metadataJson}\n\n{output}");
+        }
+        catch (ResponseContentTooLargeException ex)
+        {
+            return TextResult(
+                $"Response body exceeded the {ex.MaxBytes}-byte limit and was discarded to protect the gateway from excessive memory use.");
         }
         catch (HttpRequestException ex)
         {

--- a/src/extensions/BotNexus.Extensions.WebTools/WebToolsConfig.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/WebToolsConfig.cs
@@ -69,4 +69,13 @@ public sealed class WebFetchConfig
     /// </summary>
     [JsonPropertyName("additionalBlockedHosts")]
     public IReadOnlyList<string> AdditionalBlockedHosts { get; set; } = [];
+
+    /// <summary>
+    /// Maximum number of bytes read from a fetched response body before the read is aborted.
+    /// The fetched URL is fully agent/attacker-controlled, so an oversized or maliciously
+    /// streamed body must be capped <em>during</em> the read (not truncated after buffering the
+    /// whole thing) to prevent an out-of-memory denial of service on the gateway. Default: 16 MiB.
+    /// </summary>
+    [JsonPropertyName("maxResponseBytes")]
+    public long MaxResponseBytes { get; set; } = 16L * 1024 * 1024;
 }

--- a/tests/extensions/BotNexus.Extensions.WebTools.Tests/WebFetchToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.WebTools.Tests/WebFetchToolTests.cs
@@ -502,6 +502,42 @@ public class WebFetchToolTests
         output.ShouldContain("HTTP 404");
     }
 
+    [Fact]
+    [Trait("Category", "Security")]
+    public async Task ExecuteAsync_WithOversizedBody_DiscardsAndReturnsBoundedError()
+    {
+        // A fully agent/attacker-controlled URL that streams an oversized body must be capped
+        // during the read, not truncated after buffering, to prevent an OOM DoS on the gateway.
+        var handler = new MockHttpMessageHandler();
+        var oversized = new string('a', 4096);
+        handler.EnqueueResponse(System.Net.HttpStatusCode.OK, oversized, "text/html");
+        var httpClient = new HttpClient(handler);
+        var config = new WebFetchConfig { MaxLengthChars = 20_000, TimeoutSeconds = 5, MaxResponseBytes = 1024 };
+        using var tool = new WebFetchTool(config, httpClient);
+        var args = await tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["url"] = "https://example.com/big" });
+
+        var result = await tool.ExecuteAsync("call-1", args);
+
+        result.Content[0].Value.ShouldContain("exceeded");
+        result.Content[0].Value.ShouldContain("1024");
+        result.Content[0].Value.ShouldNotContain("aaaa");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithBodyUnderCap_ReturnsContent()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.EnqueueResponse(System.Net.HttpStatusCode.OK, "<html><body>within cap</body></html>", "text/html");
+        var httpClient = new HttpClient(handler);
+        var config = new WebFetchConfig { MaxLengthChars = 20_000, TimeoutSeconds = 5, MaxResponseBytes = 1024 };
+        using var tool = new WebFetchTool(config, httpClient);
+        var args = await tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["url"] = "https://example.com/small" });
+
+        var result = await tool.ExecuteAsync("call-1", args);
+
+        result.Content[0].Value.ShouldContain("within cap");
+    }
+
     private static WebFetchTool CreateTool(MockHttpMessageHandler handler)
     {
         var httpClient = new HttpClient(handler);


### PR DESCRIPTION
Closes #1795

## Changes
- Route the `web_fetch` body read through `BoundedHttpContent.ReadStringWithLimitAsync` (the shared streaming reader already used by the LLM providers, web-search providers #1603, and Copilot OAuth #1774) instead of raw unbounded `ReadAsStringAsync`.
- Add `WebFetchConfig.MaxResponseBytes` (default 16 MiB) so the cap is configurable per deployment; the reader aborts mid-flight when a hostile/malfunctioning endpoint streams an oversized body, and also short-circuits on an oversized declared Content-Length.
- Catch `ResponseContentTooLargeException` and return a graceful bounded-error result instead of crashing the gateway.

## Why
`web_fetch` targets a fully agent/attacker-controlled URL -- the most exposed member of the unbounded-external-body-read class. `max_length` was only a post-buffer substring, so an oversized body forced a full buffer-before-truncate and could OOM the gateway.

## Tests
- `ExecuteAsync_WithOversizedBody_DiscardsAndReturnsBoundedError` -- oversized body with a 1 KiB cap returns the bounded error and does NOT leak buffered content.
- `ExecuteAsync_WithBodyUnderCap_ReturnsContent` -- body under the cap still returns normally.
- Gate: `test-impacted.ps1` green (Architecture, WebTools.Tests, Scenarios); full `dotnet build BotNexus.slnx` 0-warn/0-err.

## Merge Notes
Disjoint from all open PRs -- only touches `BotNexus.Extensions.WebTools` (WebFetchTool.cs, WebToolsConfig.cs, WebFetchToolTests.cs). Safe to merge in any order.