### PR TITLE
refactor(copilot): resolve the copilot mcp endpoint at the registration seam

### DIFF
--- a/src/extensions/BotNexus.Extensions.WebTools/WebToolsContributor.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/WebToolsContributor.cs
@@ -40,7 +40,7 @@ public sealed class WebToolsContributor : IAgentToolContributor
             if (useCopilotProvider || hasApiKey)
             {
                 var copilotApiEndpoint = useCopilotProvider
-                    ? ResolveCopilotMcpEndpoint(context.GetProviderEndpoint(context.Descriptor.ApiProvider))
+                    ? context.CopilotMcpEndpoint
                     : null;
 
                 tools.Add(new WebSearchTool(
@@ -71,31 +71,5 @@ public sealed class WebToolsContributor : IAgentToolContributor
         }
 
         return null;
-    }
-
-    private static string ResolveCopilotMcpEndpoint(string? baseEndpoint)
-    {
-        const string fallbackEndpoint = "https://api.githubcopilot.com/mcp";
-        if (string.IsNullOrWhiteSpace(baseEndpoint))
-            return fallbackEndpoint;
-
-        if (Uri.TryCreate(baseEndpoint, UriKind.Absolute, out var absoluteUri))
-        {
-            var path = absoluteUri.AbsolutePath.TrimEnd('/');
-            if (path.EndsWith("/mcp", StringComparison.OrdinalIgnoreCase))
-                return absoluteUri.ToString().TrimEnd('/');
-
-            var builder = new UriBuilder(absoluteUri)
-            {
-                Path = string.IsNullOrEmpty(path) || path == "/" ? "/mcp" : $"{path}/mcp"
-            };
-
-            return builder.Uri.ToString().TrimEnd('/');
-        }
-
-        var trimmed = baseEndpoint.TrimEnd('/');
-        return trimmed.EndsWith("/mcp", StringComparison.OrdinalIgnoreCase)
-            ? trimmed
-            : $"{trimmed}/mcp";
     }
 }

--- a/src/gateway/BotNexus.Gateway.Abstractions/Agents/IAgentToolContributor.cs
+++ b/src/gateway/BotNexus.Gateway.Abstractions/Agents/IAgentToolContributor.cs
@@ -25,14 +25,20 @@ public interface IAgentToolContributor
 /// <param name="ExecutionContext">Execution context containing session metadata/history.</param>
 /// <param name="WorkspacePath">Resolved workspace directory for the agent.</param>
 /// <param name="PathValidator">Path policy validator for workspace-safe file access.</param>
-/// <param name="GetProviderEndpoint">Resolves the configured API endpoint for a provider key.</param>
+/// <param name="CopilotMcpEndpoint">
+/// The fully resolved GitHub Copilot MCP endpoint for this agent: the enterprise MCP host when an
+/// endpoint override is configured for the provider, otherwise the individual/fallback host
+/// (<c>https://api.githubcopilot.com/mcp</c>). Resolved once at the registration seam so extensions
+/// consume a ready-to-use value instead of re-deriving it from a raw provider-endpoint override (#1797).
+/// <c>null</c> when the agent's provider has no Copilot MCP endpoint.
+/// </param>
 /// <param name="GetProviderApiKeyAsync">Resolves an API key for a provider key.</param>
 public sealed record AgentToolContributionContext(
     AgentDescriptor Descriptor,
     AgentExecutionContext ExecutionContext,
     string WorkspacePath,
     IPathValidator PathValidator,
-    Func<string, string?> GetProviderEndpoint,
+    string? CopilotMcpEndpoint,
     Func<string, CancellationToken, Task<string?>> GetProviderApiKeyAsync);
 
 /// <summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/GatewayAuthManager.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/GatewayAuthManager.cs
@@ -54,6 +54,48 @@ public sealed class GatewayAuthManager
         return null;
     }
 
+    // #1797: the individual/fallback GitHub Copilot MCP host. Distinct from the chat BaseUrl host
+    // (api.individual.githubcopilot.com) - the MCP surface lives on api.githubcopilot.com.
+    private const string CopilotMcpFallbackEndpoint = "https://api.githubcopilot.com/mcp";
+
+    /// <summary>
+    /// Resolves the ready-to-use GitHub Copilot MCP endpoint for a provider (#1797).
+    /// Derives the MCP host from the provider's configured endpoint override (enterprise host)
+    /// and falls back to the individual host (<c>https://api.githubcopilot.com/mcp</c>) when no
+    /// override is declared. This is the single seam for extension-facing Copilot MCP endpoint
+    /// resolution - contributors consume the resolved value rather than re-deriving it from a raw
+    /// endpoint override.
+    /// </summary>
+    public string GetCopilotMcpEndpoint(string provider)
+        => DeriveCopilotMcpEndpoint(GetApiEndpoint(provider));
+
+    // Turns a raw provider endpoint override (the chat host) into the MCP endpoint by appending the
+    // /mcp path, or returns the individual fallback when no override is present. Pure and null-safe.
+    private static string DeriveCopilotMcpEndpoint(string? baseEndpoint)
+    {
+        if (string.IsNullOrWhiteSpace(baseEndpoint))
+            return CopilotMcpFallbackEndpoint;
+
+        if (Uri.TryCreate(baseEndpoint, UriKind.Absolute, out var absoluteUri))
+        {
+            var path = absoluteUri.AbsolutePath.TrimEnd('/');
+            if (path.EndsWith("/mcp", StringComparison.OrdinalIgnoreCase))
+                return absoluteUri.ToString().TrimEnd('/');
+
+            var builder = new UriBuilder(absoluteUri)
+            {
+                Path = string.IsNullOrEmpty(path) || path == "/" ? "/mcp" : $"{path}/mcp"
+            };
+
+            return builder.Uri.ToString().TrimEnd('/');
+        }
+
+        var trimmed = baseEndpoint.TrimEnd('/');
+        return trimmed.EndsWith("/mcp", StringComparison.OrdinalIgnoreCase)
+            ? trimmed
+            : $"{trimmed}/mcp";
+    }
+
     /// <summary>
     /// Resolves an API key from <c>~/.botnexus/auth.json</c>, environment variables, or platform config.
     /// </summary>

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -410,7 +410,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             context,
             workspacePath,
             pathValidator,
-            provider => _authManager.GetApiEndpoint(provider),
+            _authManager.GetCopilotMcpEndpoint(descriptor.ApiProvider),
             (provider, ct) => _authManager.GetApiKeyAsync(provider, ct));
 
         foreach (var contributor in _toolContributors)

--- a/tests/extensions/BotNexus.Extensions.DataStore.Tests/DataStoreToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.DataStore.Tests/DataStoreToolTests.cs
@@ -503,7 +503,7 @@ public sealed class DataStoreToolContributorTests
             new AgentExecutionContext { SessionId = SessionId.Create() },
             Path.Combine(Path.GetTempPath(), "test-workspace"),
             new AllowAllPathValidator(),
-            _ => null,
+            null,
             (_, _) => Task.FromResult<string?>(null));
     }
 

--- a/tests/extensions/BotNexus.Extensions.DebugTool.Tests/DebugToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.DebugTool.Tests/DebugToolTests.cs
@@ -922,7 +922,7 @@ public sealed class DebugToolTests : IDisposable
             executionContext,
             Path.GetTempPath(),
             null!,
-            _ => null,
+            null,
             (_, _) => Task.FromResult<string?>(null));
     }
 

--- a/tests/extensions/BotNexus.Extensions.Mcp.Tests/McpAuthReferenceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Mcp.Tests/McpAuthReferenceTests.cs
@@ -38,7 +38,7 @@ public sealed class McpAuthReferenceTests
             new AgentExecutionContext { SessionId = SessionId.Create() },
             Path.GetTempPath(),
             new AllowAllPathValidator(),
-            _ => null,
+            null,
             getApiKey ?? ((_, _) => Task.FromResult<string?>(null)));
 
     private sealed class AllowAllPathValidator : IPathValidator

--- a/tests/extensions/BotNexus.Extensions.Mcp.Tests/McpServerManagerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Mcp.Tests/McpServerManagerTests.cs
@@ -319,7 +319,7 @@ public class McpServerManagerTests
             new AgentExecutionContext { SessionId = SessionId.Create() },
             Path.GetTempPath(),
             new AllowAllPathValidator(),
-            _ => null,
+            null,
             (_, _) => Task.FromResult<string?>(null));
 
     private sealed class AllowAllPathValidator : IPathValidator

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdToolContributorMemoryTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdToolContributorMemoryTests.cs
@@ -30,7 +30,7 @@ public sealed class QmdToolContributorMemoryTests
             new AgentExecutionContext { SessionId = BotNexus.Domain.Primitives.SessionId.From("sess1") },
             "/tmp/workspace",
             Mock.Of<BotNexus.Gateway.Abstractions.Security.IPathValidator>(),
-            _ => null,
+            null,
             (_, _) => Task.FromResult<string?>(null));
 
         var contributor = new QmdToolContributor(null, registry.Object);
@@ -63,7 +63,7 @@ public sealed class QmdToolContributorMemoryTests
             new AgentExecutionContext { SessionId = BotNexus.Domain.Primitives.SessionId.From("sess1") },
             "/tmp/workspace",
             Mock.Of<BotNexus.Gateway.Abstractions.Security.IPathValidator>(),
-            _ => null,
+            null,
             (_, _) => Task.FromResult<string?>(null));
 
         var contributor = new QmdToolContributor(null, registry.Object);
@@ -93,7 +93,7 @@ public sealed class QmdToolContributorMemoryTests
             new AgentExecutionContext { SessionId = BotNexus.Domain.Primitives.SessionId.From("sess1") },
             "/tmp/workspace",
             Mock.Of<BotNexus.Gateway.Abstractions.Security.IPathValidator>(),
-            _ => null,
+            null,
             (_, _) => Task.FromResult<string?>(null));
 
         // No registry passed

--- a/tests/extensions/BotNexus.Extensions.WebTools.Tests/WebToolsContributorTests.cs
+++ b/tests/extensions/BotNexus.Extensions.WebTools.Tests/WebToolsContributorTests.cs
@@ -1,0 +1,102 @@
+using System.Reflection;
+using System.Text.Json;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Domain.Primitives;
+using BotNexus.Extensions.WebTools.Search;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Security;
+
+namespace BotNexus.Extensions.WebTools.Tests;
+
+/// <summary>
+/// Verifies that <see cref="WebToolsContributor"/> consumes the resolved Copilot MCP endpoint
+/// seam (<see cref="AgentToolContributionContext.CopilotMcpEndpoint"/>) rather than re-deriving
+/// it from a raw provider-endpoint override (#1797).
+/// </summary>
+[Trait("Category", "Unit")]
+public class WebToolsContributorTests
+{
+    [Fact]
+    public async Task ContributeAsync_CopilotProvider_FlowsResolvedEnterpriseEndpointToWebSearchTool()
+    {
+        const string enterpriseEndpoint = "https://api.enterprise.githubcopilot.com/mcp";
+        var context = BuildContext(searchProvider: "copilot", copilotMcpEndpoint: enterpriseEndpoint);
+
+        var contribution = await new WebToolsContributor().ContributeAsync(context);
+
+        var searchTool = contribution.Tools.OfType<WebSearchTool>().ShouldHaveSingleItem();
+        GetCopilotEndpoint(searchTool).ShouldBe(enterpriseEndpoint);
+    }
+
+    [Fact]
+    public async Task ContributeAsync_CopilotProvider_FlowsIndividualFallbackEndpointToWebSearchTool()
+    {
+        const string individualEndpoint = "https://api.githubcopilot.com/mcp";
+        var context = BuildContext(searchProvider: "copilot", copilotMcpEndpoint: individualEndpoint);
+
+        var contribution = await new WebToolsContributor().ContributeAsync(context);
+
+        var searchTool = contribution.Tools.OfType<WebSearchTool>().ShouldHaveSingleItem();
+        GetCopilotEndpoint(searchTool).ShouldBe(individualEndpoint);
+    }
+
+    [Fact]
+    public async Task ContributeAsync_NonCopilotProvider_DoesNotStampCopilotEndpoint()
+    {
+        var context = BuildContext(
+            searchProvider: "brave",
+            apiKey: "token",
+            copilotMcpEndpoint: "https://api.enterprise.githubcopilot.com/mcp");
+
+        var contribution = await new WebToolsContributor().ContributeAsync(context);
+
+        var searchTool = contribution.Tools.OfType<WebSearchTool>().ShouldHaveSingleItem();
+        GetCopilotEndpoint(searchTool).ShouldBeNull();
+    }
+
+    private static string? GetCopilotEndpoint(WebSearchTool tool)
+    {
+        var field = typeof(WebSearchTool).GetField("_copilotApiEndpoint", BindingFlags.Instance | BindingFlags.NonPublic);
+        return (string?)field!.GetValue(tool);
+    }
+
+    private static AgentToolContributionContext BuildContext(
+        string searchProvider,
+        string? apiKey = null,
+        string? copilotMcpEndpoint = null)
+    {
+        var searchJson = apiKey is null
+            ? "{\"search\":{\"provider\":\"" + searchProvider + "\"}}"
+            : "{\"search\":{\"provider\":\"" + searchProvider + "\",\"apiKey\":\"" + apiKey + "\"}}";
+
+        var extensionConfig = new Dictionary<string, JsonElement>
+        {
+            ["botnexus-web"] = JsonDocument.Parse(searchJson).RootElement
+        };
+
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = AgentId.From("test-agent"),
+            DisplayName = "Test Agent",
+            ModelId = "claude-opus-4.5",
+            ApiProvider = "github-copilot",
+            ExtensionConfig = extensionConfig
+        };
+
+        return new AgentToolContributionContext(
+            descriptor,
+            new AgentExecutionContext { SessionId = SessionId.Create() },
+            Path.Combine(Path.GetTempPath(), "webtools-contributor-tests"),
+            new AllowAllPathValidator(),
+            copilotMcpEndpoint,
+            (_, _) => Task.FromResult<string?>("copilot-token"));
+    }
+
+    private sealed class AllowAllPathValidator : IPathValidator
+    {
+        public bool CanRead(string absolutePath) => true;
+        public bool CanWrite(string absolutePath) => true;
+        public string? ValidateAndResolve(string rawPath, FileAccessMode mode) => rawPath;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayAuthManagerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayAuthManagerTests.cs
@@ -256,6 +256,59 @@ public sealed class GatewayAuthManagerTests : IDisposable
         endpoint.ShouldBeNull();
     }
 
+    [Fact]
+    public void GetCopilotMcpEndpoint_WhenEnterpriseEndpointConfigured_DerivesEnterpriseMcpHost()
+    {
+        _fileSystem.File.WriteAllText(_authFilePath, """
+                                        {
+                                          "github-copilot": {
+                                            "type": "oauth",
+                                            "refresh": "unused",
+                                            "access": "copilot-access-key",
+                                            "expires": 4102444800000,
+                                            "endpoint": "https://api.enterprise.githubcopilot.com"
+                                          }
+                                        }
+                                        """);
+
+        var manager = CreateManager(new PlatformConfig());
+
+        // The enterprise chat host must flow through to a ready-to-use MCP endpoint (#1797).
+        manager.GetCopilotMcpEndpoint("github-copilot")
+            .ShouldBe("https://api.enterprise.githubcopilot.com/mcp");
+    }
+
+    [Fact]
+    public void GetCopilotMcpEndpoint_WhenEndpointAlreadyHasMcpPath_DoesNotDoubleAppend()
+    {
+        _fileSystem.File.WriteAllText(_authFilePath, """
+                                        {
+                                          "github-copilot": {
+                                            "type": "oauth",
+                                            "refresh": "unused",
+                                            "access": "copilot-access-key",
+                                            "expires": 4102444800000,
+                                            "endpoint": "https://api.enterprise.githubcopilot.com/mcp"
+                                          }
+                                        }
+                                        """);
+
+        var manager = CreateManager(new PlatformConfig());
+
+        manager.GetCopilotMcpEndpoint("github-copilot")
+            .ShouldBe("https://api.enterprise.githubcopilot.com/mcp");
+    }
+
+    [Fact]
+    public void GetCopilotMcpEndpoint_WhenNoEndpointConfigured_ReturnsIndividualFallbackHost()
+    {
+        var manager = CreateManager(new PlatformConfig());
+
+        // No override => individual/fallback host, unchanged from prior behaviour (#1797).
+        manager.GetCopilotMcpEndpoint("github-copilot")
+            .ShouldBe("https://api.githubcopilot.com/mcp");
+    }
+
     public void Dispose()
     {
         foreach (var (name, value) in _originalEnvironmentVariables)


### PR DESCRIPTION
Closes #1797

## Changes
Follow-up to #1787/#1639. Collapses the last per-consumer Copilot endpoint-resolution path.

- Move the Copilot MCP endpoint derivation (previously `ResolveCopilotMcpEndpoint` in `WebToolsContributor`) into `GatewayAuthManager.GetCopilotMcpEndpoint(provider)`, resolved once at the tool-contribution registration seam in `InProcessIsolationStrategy`.
- `AgentToolContributionContext` now exposes a resolved `string? CopilotMcpEndpoint` value instead of the raw `Func<string,string?> GetProviderEndpoint` delegate. Extensions consume a ready-to-use MCP endpoint rather than re-deriving it.
- `WebToolsContributor` reads `context.CopilotMcpEndpoint` directly.

## Acceptance criteria
- [x] `WebToolsContributor` no longer re-derives the endpoint from a raw override — consumes the resolved seam.
- [x] `AgentToolContributionContext` no longer exposes the redundant raw delegate (exposes the resolved value only).
- [x] Copilot MCP endpoint (enterprise vs individual) still resolves correctly for `web_search` — covered by `WebToolsContributorTests.ContributeAsync_CopilotProvider_FlowsResolvedEnterpriseEndpointToWebSearchTool`.
- [x] No behavior change for the individual/fallback endpoint (`https://api.githubcopilot.com/mcp`).

## Tests
- New `GatewayAuthManagerTests`: enterprise-derives-mcp-host, already-has-mcp-path-no-double-append, no-endpoint-returns-fallback.
- New `WebToolsContributorTests`: enterprise + individual endpoints flow to `WebSearchTool`, non-copilot provider stamps null.
- Signature-updated mock setups in DataStore/DebugTool/Mcp/Qmd contributor tests.
- `test-impacted.ps1` green: WebTools 141, Gateway 3503/1-skip, Architecture 212, Scenarios 29.

## Merge Notes
Disjoint from #1796 (WebFetchTool/WebToolsConfig) and #1798 (Copilot discovery provider). Safe to merge in any order relative to those two.