### PR TITLE
feat(gateway): surface converse allow-list in agent_converse tool description

### DIFF
--- a/src/gateway/BotNexus.Gateway/Tools/AgentConverseTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/AgentConverseTool.cs
@@ -24,12 +24,12 @@ public sealed class AgentConverseTool(
 
     public Tool Definition => new(
         Name,
-        "Start a conversation with another registered agent.",
+        "Start a conversation with another registered agent. Not every agent is reachable: converse is governed by policy. Call list_agents first and only target an agent whose 'canConverse' is true -- targeting an agent with canConverse=false is a deterministic policy denial that wastes the turn and will never succeed on retry.",
         JsonDocument.Parse($$"""
             {
               "type": "object",
               "properties": {
-                "agentId": { "type": "string", "description": "The target agent's ID." },
+                "agentId": { "type": "string", "description": "The target agent's ID. Must be an agent whose 'canConverse' is true in list_agents output; otherwise the call is denied by policy." },
                 "message": { "type": "string", "description": "Opening message to send." },
                 "objective": { "type": "string", "description": "What you want to achieve." },
                 "maxTurns": {

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/AgentConverseToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/AgentConverseToolTests.cs
@@ -178,6 +178,19 @@ public sealed class AgentConverseToolTests
         maximum.ShouldBe(12);
     }
 
+    [Fact]
+    public void Definition_SurfacesConverseAllowListGuidance()
+    {
+        var tool = new AgentConverseTool(Mock.Of<IAgentExchangeService>(), new InMemorySessionStore(), AgentId.From("test-agent"), SessionId.From("session-1"));
+
+        tool.Definition.Description.ShouldContain("list_agents");
+        tool.Definition.Description.ShouldContain("canConverse");
+
+        var agentIdDescription = tool.Definition.Parameters
+            .GetProperty("properties").GetProperty("agentId").GetProperty("description").GetString();
+        agentIdDescription.ShouldContain("canConverse");
+    }
+
     private static (Mock<IAgentExchangeService> Service, StrongBox<AgentExchangeRequest?> Captured) CreateCapturingService()
     {
         var captured = new StrongBox<AgentExchangeRequest?>(null);

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/AgentConverseToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/AgentConverseToolTests.cs
@@ -188,6 +188,7 @@ public sealed class AgentConverseToolTests
 
         var agentIdDescription = tool.Definition.Parameters
             .GetProperty("properties").GetProperty("agentId").GetProperty("description").GetString();
+        agentIdDescription.ShouldNotBeNull();
         agentIdDescription.ShouldContain("canConverse");
     }
 


### PR DESCRIPTION
Closes #1755

## Problem
The efficiency audit found `agent_converse` has a ~40.9% error rate, and every sampled failure is the same deterministic policy denial (`Agent 'X' is not allowed to converse with 'Y'`). These are not transient -- retries never succeed, they just burn turns and tokens.

## Change (direction 1 of the issue)
`list_agents` already emits a `canConverse` boolean per agent, but nothing told the model to consult it before calling `agent_converse`. This surfaces the allow-list at point-of-use:
- `agent_converse` tool **description** now instructs the model to call `list_agents` first and only target an agent whose `canConverse` is true, noting a denied target is a wasted, non-retryable turn.
- The `agentId` parameter description repeats the constraint.

No behavioural/policy change -- purely guidance so the model stops attempting denied targets in the first place.

## Not in scope
Direction 2 of #1755 (reviewing/widening the converse **policy** so maintenance agents can reach more targets) is a Jon-scoped governance decision and is intentionally left out.

## Tests
Added `Definition_SurfacesConverseAllowListGuidance` asserting the description + agentId param mention `list_agents`/`canConverse`.

## Merge Notes
Single-file source change (AgentConverseTool.cs) + its test. No overlap with any open PR or worktree. Safe to merge any time.