### PR TITLE
feat(mobile): add auto-retrying reconnect overlay for mobile client

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Components/ReconnectOverlay.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Components/ReconnectOverlay.razor
@@ -1,0 +1,165 @@
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Services
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services
+@implements IDisposable
+@inject IPortalLoadService PortalLoad
+
+@* #1839: the auto-retrying reconnect overlay is the user-facing experience for a transient
+   background/foreground drop on the mobile client -- it replaces the raw #blazor-error-ui banner.
+   It only appears once a connection that was previously live has dropped (not during the initial
+   connect handshake), shows a friendly "Reconnecting..." state, auto-retries on an exponential
+   backoff (MobileReconnectBackoff), and dismisses automatically the moment the hub is live again.
+   The retry path delegates to PortalLoad.ResumeAsync so it inherits PBI1's (#1838) liveness probe
+   + rebuild rather than trusting a possibly-zombie iOS socket. errorReporting.js diagnostics stay
+   intact; this only changes the *user-visible* surface, not the genuine-failure reporting. *@
+@if (_visible)
+{
+    <div class="reconnect-overlay" data-testid="reconnect-overlay" role="alertdialog" aria-live="polite" aria-label="Reconnecting to BotNexus">
+        <div class="reconnect-overlay-card">
+            <div class="reconnect-overlay-spinner" aria-hidden="true"></div>
+            <div class="reconnect-overlay-title">Reconnecting&#x2026;</div>
+            <div class="reconnect-overlay-detail">
+                Lost connection to BotNexus. We&#x2019;ll keep trying automatically.
+            </div>
+            <button class="reconnect-overlay-btn"
+                    data-testid="reconnect-retry-btn"
+                    @onclick="RetryNowAsync"
+                    disabled="@_retrying">
+                @(_retrying ? "Retrying\u2026" : "Retry now")
+            </button>
+        </div>
+    </div>
+}
+
+@code {
+    // Blazor's default reconnect budget gives up after ~15s; this overlay retries indefinitely on
+    // an exponential backoff (2s -> 30s cap) so a returning backgrounded PWA self-heals.
+    private bool _visible;
+    private bool _retrying;
+    // Only surface the overlay for a *re*connect: a connection must have been live at least once
+    // before a drop is treated as reconnectable. This prevents flashing the overlay during the
+    // initial connect handshake, which is "connecting", not "reconnecting".
+    private bool _everConnected;
+    private int _attempt;
+    private Timer? _retryTimer;
+
+    protected override void OnInitialized()
+    {
+        PortalLoad.OnConnectionStateChanged += HandleConnectionStateChanged;
+        SyncState();
+    }
+
+    private void HandleConnectionStateChanged() =>
+        _ = InvokeAsync(() =>
+        {
+            SyncState();
+            StateHasChanged();
+        });
+
+    // Reconcile visibility + the auto-retry timer with the current connection state.
+    private void SyncState()
+    {
+        if (PortalLoad.IsSignalRConnected)
+        {
+            _everConnected = true;
+            if (_visible)
+            {
+                // Live again -- self-dismiss and reset the backoff for any future drop.
+                _visible = false;
+                _attempt = 0;
+                StopTimer();
+            }
+            return;
+        }
+
+        // Disconnected. Only show the reconnect overlay if we had an established connection that
+        // dropped; the very first connect is handled by the page's own loading state.
+        if (_everConnected && !_visible)
+        {
+            _visible = true;
+            _attempt = 0;
+            ScheduleNextRetry();
+        }
+    }
+
+    /// <summary>
+    /// One auto-retry tick: while still disconnected, drive a liveness-verified resume (#1838) and
+    /// schedule the next attempt on the widened backoff. A no-op once the hub is live again so a
+    /// stale timer callback cannot trigger a spurious resume. Public so the retry cadence is unit
+    /// testable without real timers.
+    /// </summary>
+    public async Task RetryTickAsync()
+    {
+        if (PortalLoad.IsSignalRConnected)
+        {
+            SyncState();
+            return;
+        }
+
+        await ResumeOnceAsync();
+
+        // If the resume did not restore the connection, back off and try again.
+        if (!PortalLoad.IsSignalRConnected)
+        {
+            _attempt++;
+            ScheduleNextRetry();
+        }
+    }
+
+    // Manual "Retry now" tap: same liveness-verified path, but resets the backoff so the next
+    // automatic attempt starts fresh rather than at the current (possibly long) interval.
+    private async Task RetryNowAsync()
+    {
+        _attempt = 0;
+        StopTimer();
+        await ResumeOnceAsync();
+        if (!PortalLoad.IsSignalRConnected)
+            ScheduleNextRetry();
+    }
+
+    private async Task ResumeOnceAsync()
+    {
+        if (_retrying)
+            return;
+        _retrying = true;
+        StateHasChanged();
+        try
+        {
+            // #1838: probe-then-rebuild; never a bare RefreshAsync that trusts a zombie socket.
+            await PortalLoad.ResumeAsync();
+        }
+        catch
+        {
+            // A failed resume is expected while the network is still down -- the backoff loop will
+            // try again. Genuine unrecoverable failures are still reported by errorReporting.js.
+        }
+        finally
+        {
+            _retrying = false;
+            SyncState();
+            StateHasChanged();
+        }
+    }
+
+    private void ScheduleNextRetry()
+    {
+        StopTimer();
+        if (PortalLoad.IsSignalRConnected)
+            return;
+
+        var delay = MobileReconnectBackoff.GetDelay(_attempt);
+        // One-shot timer; RetryTickAsync reschedules the next tick so the interval widens each time.
+        _retryTimer = new Timer(_ => _ = InvokeAsync(RetryTickAsync), null, delay, Timeout.InfiniteTimeSpan);
+    }
+
+    private void StopTimer()
+    {
+        _retryTimer?.Dispose();
+        _retryTimer = null;
+    }
+
+    public void Dispose()
+    {
+        PortalLoad.OnConnectionStateChanged -= HandleConnectionStateChanged;
+        StopTimer();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Layout/MobileLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Layout/MobileLayout.razor
@@ -4,3 +4,6 @@
 <GlobalErrorBoundary>
     @Body
 </GlobalErrorBoundary>
+@* #1839: friendly auto-retrying reconnect overlay, rendered app-wide so a transient
+   background/foreground drop shows "Reconnecting..." instead of the raw #blazor-error-ui bar. *@
+<ReconnectOverlay />

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileReconnectBackoff.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileReconnectBackoff.cs
@@ -1,0 +1,45 @@
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Services;
+
+/// <summary>
+/// Exponential-backoff schedule for the mobile auto-retrying reconnect overlay (#1839).
+/// </summary>
+/// <remarks>
+/// Blazor's default WASM reconnect budget gives up after ~5 retries x 3s (~15s) and then paints
+/// the raw <c>#blazor-error-ui</c> banner. On iOS a standalone PWA can be suspended for far longer
+/// than that before the user returns, so trusting the default budget turns a transient background
+/// drop into a dead-end error bar. This schedule widens the retry window: it starts at 2s, doubles
+/// each attempt, and caps at 30s, then holds at the cap indefinitely so a returning backgrounded
+/// app keeps trying and self-heals rather than surfacing a terminal error.
+///
+/// The schedule is a pure function of the attempt index so it can be unit tested without timers,
+/// and the overlay drives it forward one tick at a time while the hub remains unreachable.
+/// </remarks>
+public static class MobileReconnectBackoff
+{
+    // 2s first retry keeps the returning-app case snappy without hammering the gateway.
+    private static readonly TimeSpan BaseDelay = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// The ceiling for a single retry interval. Attempts beyond the doubling range hold here so the
+    /// overlay keeps retrying forever at a steady, low-frequency cadence instead of giving up.
+    /// </summary>
+    public static readonly TimeSpan MaxDelay = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Returns the delay to wait before reconnect attempt number <paramref name="attempt"/>
+    /// (zero-based): 2s, 4s, 8s, 16s, then capped at <see cref="MaxDelay"/> (30s) for every
+    /// subsequent attempt. Never returns a terminal/zero delay -- retries continue indefinitely.
+    /// </summary>
+    /// <param name="attempt">The zero-based attempt index. Must be non-negative.</param>
+    /// <returns>The backoff delay for that attempt, capped at <see cref="MaxDelay"/>.</returns>
+    public static TimeSpan GetDelay(int attempt)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(attempt);
+
+        // Cap the exponent before shifting so large attempt indices cannot overflow; once the
+        // computed delay reaches the cap, everything past it clamps to MaxDelay anyway.
+        var seconds = BaseDelay.TotalSeconds * Math.Pow(2, Math.Min(attempt, 30));
+        var delay = TimeSpan.FromSeconds(seconds);
+        return delay < MaxDelay ? delay : MaxDelay;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/_Imports.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/_Imports.razor
@@ -12,4 +12,4 @@
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Components
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components
-
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Services

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/css/mobile.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/css/mobile.css
@@ -990,3 +990,86 @@ body {
     text-align: center;
     color: #7a9cbf;
 }
+
+/* ── Auto-retrying reconnect overlay (#1839) ──────────────────────────────────
+   The user-facing experience for a transient background/foreground connection drop
+   on the mobile client. Replaces the raw #blazor-error-ui banner: a friendly, centered
+   "Reconnecting..." card with a spinner and a manual "Retry now" affordance. It sits
+   above all app chrome (below only modal z-indexes) and self-dismisses once the hub is
+   live again. Styled to match the mobile dark chat theme. */
+.reconnect-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(6, 14, 26, 0.72);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+    animation: reconnectFadeIn 0.2s ease;
+}
+
+.reconnect-overlay-card {
+    background: #111d2e;
+    border: 1px solid rgba(100, 160, 220, 0.25);
+    border-radius: 16px;
+    padding: 24px 22px;
+    max-width: 320px;
+    width: 100%;
+    text-align: center;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
+.reconnect-overlay-spinner {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    border: 3px solid rgba(100, 160, 220, 0.25);
+    border-top-color: #64a0dc;
+    animation: reconnectSpin 0.9s linear infinite;
+}
+
+.reconnect-overlay-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #d0dff0;
+}
+
+.reconnect-overlay-detail {
+    font-size: 13px;
+    line-height: 1.45;
+    color: #8aa6c8;
+}
+
+.reconnect-overlay-btn {
+    margin-top: 4px;
+    background: #1a4a80;
+    border: none;
+    border-radius: 8px;
+    color: #d0dff0;
+    font-size: 14px;
+    font-weight: 600;
+    padding: 9px 18px;
+    cursor: pointer;
+    touch-action: manipulation;
+    min-width: 120px;
+}
+
+.reconnect-overlay-btn:hover:not(:disabled) { background: #235a99; }
+.reconnect-overlay-btn:disabled { opacity: 0.55; cursor: default; }
+
+@keyframes reconnectSpin {
+    to { transform: rotate(360deg); }
+}
+
+@keyframes reconnectFadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileReconnectBackoffTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileReconnectBackoffTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Linq;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Services;
+using Xunit;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Tests for the mobile reconnect backoff schedule (#1839). The schedule must widen
+/// beyond Blazor's default 5x3s (15s) budget so a backgrounded PWA that returns after a
+/// long suspension keeps auto-retrying rather than surfacing a dead-end error bar.
+/// </summary>
+public sealed class MobileReconnectBackoffTests
+{
+    [Fact]
+    public void First_attempt_uses_base_delay()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(2), MobileReconnectBackoff.GetDelay(0));
+    }
+
+    [Theory]
+    [InlineData(0, 2)]
+    [InlineData(1, 4)]
+    [InlineData(2, 8)]
+    [InlineData(3, 16)]
+    public void Delay_grows_exponentially_until_capped(int attempt, int expectedSeconds)
+    {
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), MobileReconnectBackoff.GetDelay(attempt));
+    }
+
+    [Theory]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(10)]
+    [InlineData(50)]
+    public void Delay_is_capped_at_max(int attempt)
+    {
+        Assert.Equal(MobileReconnectBackoff.MaxDelay, MobileReconnectBackoff.GetDelay(attempt));
+    }
+
+    [Fact]
+    public void Max_delay_is_thirty_seconds()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(30), MobileReconnectBackoff.MaxDelay);
+    }
+
+    [Fact]
+    public void Delay_never_exceeds_max()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            Assert.True(MobileReconnectBackoff.GetDelay(i) <= MobileReconnectBackoff.MaxDelay);
+        }
+    }
+
+    [Fact]
+    public void Negative_attempt_throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => MobileReconnectBackoff.GetDelay(-1));
+    }
+
+    [Fact]
+    public void Schedule_is_widened_well_beyond_the_default_five_by_three_second_budget()
+    {
+        // Blazor's default reconnect budget is 5 retries x 3s = ~15s. The mobile schedule must
+        // cover realistic background-return latency, so the cumulative window across the early
+        // attempts must be substantially longer than that default.
+        var cumulativeFirstEight = Enumerable.Range(0, 8)
+            .Select(MobileReconnectBackoff.GetDelay)
+            .Aggregate(TimeSpan.Zero, (acc, d) => acc + d);
+
+        Assert.True(
+            cumulativeFirstEight > TimeSpan.FromSeconds(60),
+            $"Expected the first 8 attempts to span more than 60s, but was {cumulativeFirstEight.TotalSeconds}s.");
+    }
+
+    [Fact]
+    public void Schedule_keeps_retrying_indefinitely_so_a_returning_app_self_heals()
+    {
+        // There is no terminal "give up" attempt: every attempt yields a positive delay so the
+        // overlay never becomes a dead-end. A returning backgrounded PWA keeps trying until the
+        // hub is reachable again.
+        Assert.True(MobileReconnectBackoff.GetDelay(1000) > TimeSpan.Zero);
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileReconnectOverlayTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileReconnectOverlayTests.cs
@@ -1,0 +1,146 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Components;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Tests for the mobile auto-retrying reconnect overlay (#1839). The overlay replaces the raw
+/// <c>#blazor-error-ui</c> banner as the user-facing experience for a transient background drop:
+/// it shows a friendly "Reconnecting..." state, auto-retries via the liveness-verified resume
+/// path (#1838), and dismisses automatically once the hub is live again.
+/// </summary>
+public sealed class MobileReconnectOverlayTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly IPortalLoadService _portalLoad = Substitute.For<IPortalLoadService>();
+
+    public MobileReconnectOverlayTests()
+    {
+        _portalLoad.ResumeAsync(Arg.Any<CancellationToken>()).Returns(HubResumeOutcome.Alive);
+        _portalLoad.RefreshAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        _ctx.Services.AddSingleton(_portalLoad);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    [Fact]
+    public void Overlay_is_hidden_while_connected()
+    {
+        _portalLoad.IsSignalRConnected.Returns(true);
+        var cut = _ctx.Render<ReconnectOverlay>();
+        Assert.Empty(cut.FindAll("[data-testid='reconnect-overlay']"));
+    }
+
+    [Fact]
+    public void Overlay_is_hidden_on_initial_load_before_first_connect()
+    {
+        // A fresh page that has never connected yet must NOT flash the reconnect overlay during
+        // the initial connect handshake -- that path is "connecting", not "reconnecting".
+        _portalLoad.IsSignalRConnected.Returns(false);
+        var cut = _ctx.Render<ReconnectOverlay>();
+        Assert.Empty(cut.FindAll("[data-testid='reconnect-overlay']"));
+    }
+
+    [Fact]
+    public void Overlay_appears_after_an_established_connection_drops()
+    {
+        _portalLoad.IsSignalRConnected.Returns(true);
+        var cut = _ctx.Render<ReconnectOverlay>();
+        Assert.Empty(cut.FindAll("[data-testid='reconnect-overlay']"));
+
+        // Simulate a transient background drop of a previously-live connection.
+        _portalLoad.IsSignalRConnected.Returns(false);
+        _portalLoad.OnConnectionStateChanged += Raise.Event<Action>();
+
+        cut.WaitForAssertion(() =>
+            Assert.NotEmpty(cut.FindAll("[data-testid='reconnect-overlay']")));
+    }
+
+    [Fact]
+    public void Overlay_shows_friendly_reconnecting_text_not_the_raw_banner()
+    {
+        _portalLoad.IsSignalRConnected.Returns(true);
+        var cut = _ctx.Render<ReconnectOverlay>();
+        _portalLoad.IsSignalRConnected.Returns(false);
+        _portalLoad.OnConnectionStateChanged += Raise.Event<Action>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var overlay = cut.Find("[data-testid='reconnect-overlay']");
+            Assert.Contains("Reconnecting", overlay.TextContent);
+            Assert.DoesNotContain("unhandled error", overlay.TextContent, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    [Fact]
+    public void Overlay_dismisses_automatically_once_the_hub_is_live_again()
+    {
+        _portalLoad.IsSignalRConnected.Returns(true);
+        var cut = _ctx.Render<ReconnectOverlay>();
+
+        _portalLoad.IsSignalRConnected.Returns(false);
+        _portalLoad.OnConnectionStateChanged += Raise.Event<Action>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[data-testid='reconnect-overlay']")));
+
+        // Hub live again -> overlay must self-dismiss.
+        _portalLoad.IsSignalRConnected.Returns(true);
+        _portalLoad.OnConnectionStateChanged += Raise.Event<Action>();
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindAll("[data-testid='reconnect-overlay']")));
+    }
+
+    [Fact]
+    public async Task Retry_button_drives_the_liveness_verified_resume_path()
+    {
+        _portalLoad.IsSignalRConnected.Returns(true);
+        var cut = _ctx.Render<ReconnectOverlay>();
+        _portalLoad.IsSignalRConnected.Returns(false);
+        _portalLoad.OnConnectionStateChanged += Raise.Event<Action>();
+        cut.WaitForAssertion(() => cut.Find("[data-testid='reconnect-retry-btn']"));
+
+        await cut.InvokeAsync(() => cut.Find("[data-testid='reconnect-retry-btn']").Click());
+
+        // #1838: reconnect must go through ResumeAsync (probe-then-rebuild), never a bare
+        // RefreshAsync that trusts a possibly-zombie socket.
+        await _portalLoad.Received().ResumeAsync(Arg.Any<CancellationToken>());
+        await _portalLoad.DidNotReceive().RefreshAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Auto_retry_tick_resumes_while_disconnected()
+    {
+        _portalLoad.IsSignalRConnected.Returns(true);
+        var cut = _ctx.Render<ReconnectOverlay>();
+        _portalLoad.IsSignalRConnected.Returns(false);
+        _portalLoad.OnConnectionStateChanged += Raise.Event<Action>();
+
+        await cut.InvokeAsync(() => cut.Instance.RetryTickAsync());
+
+        await _portalLoad.Received().ResumeAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Auto_retry_tick_is_a_no_op_once_connected()
+    {
+        _portalLoad.IsSignalRConnected.Returns(true);
+        var cut = _ctx.Render<ReconnectOverlay>();
+
+        await cut.InvokeAsync(() => cut.Instance.RetryTickAsync());
+
+        await _portalLoad.DidNotReceive().ResumeAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void Dispose_unsubscribes_from_connection_state_changes()
+    {
+        _portalLoad.IsSignalRConnected.Returns(true);
+        var cut = _ctx.Render<ReconnectOverlay>();
+        cut.Instance.Dispose();
+
+        // Raising after dispose must not throw.
+        _portalLoad.OnConnectionStateChanged += Raise.Event<Action>();
+    }
+}


### PR DESCRIPTION
Closes #1839

Part of epic #1836 (mobile PWA reconnect resilience). This is PBI2 — the user-visible UX half, building on PBI1 (#1838, `HubResumeCoordinator`, already merged).

## Problem

On the mobile Blazor client, a transient background/foreground connection drop (iOS silently recycling a suspended PWA's WebSocket) exhausts Blazor's default WASM reconnect budget (~5 retries × 3s ≈ 15s) and paints the raw `#blazor-error-ui` banner — a dead-end error bar the user cannot recover from without a manual reload.

## Changes

- **`ReconnectOverlay.razor`** (mobile `Components/`) — a friendly, centered "Reconnecting…" overlay that replaces the raw `#blazor-error-ui` banner as the *user-facing* experience. It:
  - only appears once a connection that was previously live has dropped (never flashes during the initial connect handshake),
  - auto-retries on a widened exponential backoff,
  - self-dismisses automatically the moment the hub is live again,
  - exposes a manual **Retry now** affordance.
- **`MobileReconnectBackoff.cs`** (mobile `Services/`) — pure, unit-testable exponential-backoff schedule: **2s → 4s → 8s → 16s → 30s cap**, then holds at the 30s cap **indefinitely** so a returning backgrounded app keeps trying and self-heals rather than giving up. This is deliberately widened well beyond the default 5×3s (~15s) budget to cover realistic background-return latency.
- **`MobileLayout.razor`** — renders `<ReconnectOverlay />` app-wide.
- **`mobile.css`** — overlay styling matched to the mobile dark chat theme (spinner, card, retry button).
- Tests: `MobileReconnectBackoffTests` (schedule/cap/monotonicity/widened-budget) and `MobileReconnectOverlayTests` (bUnit: hidden while connected, hidden on first connect, appears after an established drop, friendly text not the raw banner, auto-dismiss on reconnect, retry drives the liveness path, auto-retry tick behavior, dispose unsubscribes).

The retry path delegates to `IPortalLoadService.ResumeAsync` (PBI1 #1838) so it inherits the liveness probe + rebuild rather than trusting a possibly-zombie iOS socket. `errorReporting.js` diagnostics remain intact — genuine unrecoverable failures still POST `channel-error`; only the *user-facing* surface changes.

## Testing

- `dotnet build` + `dotnet test` on the Mobile test project: **104 passed, 0 failed**.
- `scripts/repo/test-impacted.ps1`: Architecture.Tests, Mobile.Tests, Scenarios.Tests all **green**.
- The only red in the full impacted run was the known `Cli_Install_ClonesCurrentRepoIntoSandbox` clone-timeout flake, unrelated to this change.

## Merge Notes (file-disjoint)

Scoped strictly to the overlay / reconnect-UI surface on the mobile client. Intentionally **does not** touch:
- SignalR timeout **config** values — that is PBI3 (#1840),
- `appResume.js` lifecycle events — that is PBI4 (#1841).

This keeps the PR file-disjoint from its sibling PBIs so they can land independently.
