### PR TITLE
feat(telemetry): add metrics core and OpenTelemetry SDK wiring

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -33,6 +33,7 @@
     <Project Path="src/gateway/BotNexus.Cli/BotNexus.Cli.csproj" />
     <Project Path="src/gateway/BotNexus.Cron/BotNexus.Cron.csproj" />
     <Project Path="src/gateway/BotNexus.Gateway.Abstractions/BotNexus.Gateway.Abstractions.csproj" />
+    <Project Path="src/gateway/BotNexus.Gateway.Telemetry/BotNexus.Gateway.Telemetry.csproj" />
     <Project Path="src/gateway/BotNexus.Gateway.Conversations/BotNexus.Gateway.Conversations.csproj" />
     <Project Path="src/gateway/BotNexus.Gateway.Dispatching/BotNexus.Gateway.Dispatching.csproj" />
     <Project Path="src/gateway/BotNexus.Gateway.Contracts/BotNexus.Gateway.Contracts.csproj" />
@@ -102,6 +103,7 @@
     <Project Path="tests/gateway/BotNexus.Gateway.Prompts.Tests/BotNexus.Gateway.Prompts.Tests.csproj" />
     <Project Path="tests/gateway/BotNexus.Gateway.Sessions.Tests/BotNexus.Gateway.Sessions.Tests.csproj" />
     <Project Path="tests/gateway/BotNexus.Gateway.Tests/BotNexus.Gateway.Tests.csproj" />
+    <Project Path="tests/gateway/BotNexus.Gateway.Telemetry.Tests/BotNexus.Gateway.Telemetry.Tests.csproj" />
     <Project Path="tests/gateway/BotNexus.Memory.Tests/BotNexus.Memory.Tests.csproj" />
     <Project Path="tests/gateway/BotNexus.Gateway.Webhooks.Tests/BotNexus.Gateway.Webhooks.Tests.csproj" />
     <Project Path="tests/gateway/BotNexus.Yaml.Tests/BotNexus.Yaml.Tests.csproj" />

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1038,6 +1038,24 @@ Configuration for the CodingAgent component (used when running BotNexus as a cod
 
 **Note:** The `DefaultShellTimeoutSeconds` controls the CodingAgent's `bash` tool timeout. This is separate from `Tools.Exec.Timeout` which controls the Gateway's built-in shell tool. Set to `null` to allow unlimited execution time (process runs until the agent cancels it).
 
+### Telemetry: TelemetryConfig
+
+The optional `telemetry` section controls the in-process OpenTelemetry metrics/tracing plane.
+
+```json
+{
+  "telemetry": {
+    "enabled": true
+  }
+}
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `true` | When `true`, wires the OpenTelemetry `MeterProvider`/`TracerProvider` for the canonical `"BotNexus"` meter scope. When `false`, the `IMetrics` facade is still registered (so call sites resolve) but no OpenTelemetry providers are attached. |
+
+This PBI lands only the in-process foundation; remote exporter (OTLP) configuration is deferred to a later change, so there is no egress/endpoint surface here yet.
+
 ---
 
 ## JSON Schema Validation

--- a/src/gateway/BotNexus.Gateway.Api/BotNexus.Gateway.Api.csproj
+++ b/src/gateway/BotNexus.Gateway.Api/BotNexus.Gateway.Api.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\..\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
     <ProjectReference Include="..\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
     <ProjectReference Include="..\BotNexus.Gateway\BotNexus.Gateway.csproj" />
+    <ProjectReference Include="..\BotNexus.Gateway.Telemetry\BotNexus.Gateway.Telemetry.csproj" />
     <ProjectReference Include="..\BotNexus.Cron\BotNexus.Cron.csproj" />
     <ProjectReference Include="..\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
     <ProjectReference Include="..\BotNexus.Gateway.Webhooks\BotNexus.Gateway.Webhooks.csproj" />

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -28,6 +28,7 @@ using BotNexus.Domain.World;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.OpenApi.Models;
 using OpenTelemetry.Trace;
+using BotNexus.Gateway.Telemetry;
 using Serilog;
 using System.Reflection;
 using BotNexus.Gateway.Webhooks;
@@ -101,6 +102,11 @@ catch (Exception ex) when (ex is Microsoft.Extensions.Options.OptionsValidationE
     Log.Warning(ex, "Failed to load platform config from {ConfigPath} — using defaults", resolvedConfigPath);
     startupPlatformConfig = new PlatformConfig();
 }
+
+// Telemetry foundation (metrics core + OpenTelemetry SDK wiring): registers the IMetrics
+// facade, the botnexus.host.starts smoke counter, and the "BotNexus" meter/tracing scope.
+// AddOpenTelemetry() is idempotent, so the tracing block below augments the same builder.
+builder.Services.AddBotNexusTelemetry(builder.Configuration);
 
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing =>

--- a/src/gateway/BotNexus.Gateway.Telemetry/BotNexus.Gateway.Telemetry.csproj
+++ b/src/gateway/BotNexus.Gateway.Telemetry/BotNexus.Gateway.Telemetry.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>BotNexus.Gateway.Telemetry</RootNamespace>
+    <Description>Shared telemetry primitives for BotNexus: canonical Meter/ActivitySource names, the IMetrics facade, and OpenTelemetry SDK wiring.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+  </ItemGroup>
+
+</Project>

--- a/src/gateway/BotNexus.Gateway.Telemetry/BotNexusMeters.cs
+++ b/src/gateway/BotNexus.Gateway.Telemetry/BotNexusMeters.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+
+namespace BotNexus.Gateway.Telemetry;
+
+/// <summary>
+/// Canonical telemetry identifiers for the BotNexus platform. All platform metrics
+/// and traces flow through the single named <see cref="Meter"/> and
+/// <see cref="ActivitySource"/> defined here so that exporters can subscribe by a
+/// stable, well-known scope name rather than each component minting its own.
+/// </summary>
+/// <remarks>
+/// Instrument names follow the convention <c>botnexus.&lt;area&gt;.&lt;instrument&gt;</c>
+/// (e.g. <c>botnexus.host.starts</c>). The scope name intentionally has no dots so it
+/// reads as a product identifier; the dotted convention applies to instruments only.
+/// </remarks>
+public static class BotNexusMeters
+{
+    /// <summary>
+    /// The canonical meter/activity scope name. Exporters subscribe with
+    /// <c>AddMeter("BotNexus")</c> / <c>AddSource("BotNexus")</c>.
+    /// </summary>
+    public const string Name = "BotNexus";
+
+    /// <summary>
+    /// Instrumentation scope version, pinned to the telemetry assembly version so
+    /// dashboards can distinguish instrument-shape changes across releases.
+    /// </summary>
+    public static readonly string Version =
+        typeof(BotNexusMeters).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? typeof(BotNexusMeters).Assembly.GetName().Version?.ToString()
+        ?? "0.0.0";
+
+    /// <summary>
+    /// The single platform <see cref="System.Diagnostics.Metrics.Meter"/>. Prefer resolving
+    /// <see cref="IMetrics"/> from DI in application code; this instance exists for the facade
+    /// and for static call sites that cannot take a constructor dependency.
+    /// </summary>
+    public static readonly Meter Meter = new(Name, Version);
+
+    /// <summary>
+    /// The single platform <see cref="System.Diagnostics.ActivitySource"/> for tracing.
+    /// No custom spans are emitted yet; this is the scaffold PBI2+ will build on.
+    /// </summary>
+    public static readonly ActivitySource ActivitySource = new(Name, Version);
+
+    /// <summary>
+    /// Builds a convention-compliant instrument name of the form
+    /// <c>botnexus.&lt;area&gt;.&lt;instrument&gt;</c>.
+    /// </summary>
+    /// <param name="area">Logical subsystem, e.g. <c>host</c>, <c>session</c>.</param>
+    /// <param name="instrument">Instrument leaf name, e.g. <c>starts</c>.</param>
+    public static string InstrumentName(string area, string instrument)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(area);
+        ArgumentException.ThrowIfNullOrWhiteSpace(instrument);
+        return $"botnexus.{area}.{instrument}";
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Telemetry/BotNexusMetrics.cs
+++ b/src/gateway/BotNexus.Gateway.Telemetry/BotNexusMetrics.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics.Metrics;
+
+namespace BotNexus.Gateway.Telemetry;
+
+/// <summary>
+/// Default <see cref="IMetrics"/> implementation backed by the single canonical
+/// <see cref="BotNexusMeters.Meter"/>. Registered as a singleton by
+/// <c>AddBotNexusTelemetry</c>. Kept allocation-light: it holds no state beyond the
+/// shared meter reference and simply forwards instrument creation.
+/// </summary>
+public sealed class BotNexusMetrics : IMetrics
+{
+    private readonly Meter _meter;
+
+    /// <summary>
+    /// Creates a facade over the canonical platform meter.
+    /// </summary>
+    public BotNexusMetrics()
+        : this(BotNexusMeters.Meter)
+    {
+    }
+
+    /// <summary>
+    /// Creates a facade over an explicit meter. Primarily for tests that want to observe
+    /// instruments through a dedicated <see cref="MeterListener"/> without touching the
+    /// process-wide canonical meter.
+    /// </summary>
+    /// <param name="meter">The meter instruments are created on.</param>
+    public BotNexusMetrics(Meter meter)
+    {
+        ArgumentNullException.ThrowIfNull(meter);
+        _meter = meter;
+    }
+
+    /// <inheritdoc />
+    public Counter<T> CreateCounter<T>(string name, string? unit = null, string? description = null)
+        where T : struct
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return _meter.CreateCounter<T>(name, unit, description);
+    }
+
+    /// <inheritdoc />
+    public Histogram<T> CreateHistogram<T>(string name, string? unit = null, string? description = null)
+        where T : struct
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return _meter.CreateHistogram<T>(name, unit, description);
+    }
+
+    /// <inheritdoc />
+    public UpDownCounter<T> CreateUpDownCounter<T>(string name, string? unit = null, string? description = null)
+        where T : struct
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return _meter.CreateUpDownCounter<T>(name, unit, description);
+    }
+
+    /// <inheritdoc />
+    public ObservableGauge<T> CreateObservableGauge<T>(
+        string name,
+        Func<T> observeValue,
+        string? unit = null,
+        string? description = null)
+        where T : struct
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(observeValue);
+        return _meter.CreateObservableGauge(name, observeValue, unit, description);
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Telemetry/HostStartupMetrics.cs
+++ b/src/gateway/BotNexus.Gateway.Telemetry/HostStartupMetrics.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Hosting;
+
+namespace BotNexus.Gateway.Telemetry;
+
+/// <summary>
+/// Emits the <c>botnexus.host.starts</c> smoke counter exactly once when the host starts.
+/// This is the foundation PBI's proof-of-life measurement: it verifies the metrics plane is
+/// live end-to-end (facade → Meter → MeterProvider) without instrumenting any hot path.
+/// </summary>
+public sealed class HostStartupMetrics : IHostedService
+{
+    /// <summary>Canonical name of the host-start smoke counter.</summary>
+    public static readonly string StartsCounterName = BotNexusMeters.InstrumentName("host", "starts");
+
+    private readonly System.Diagnostics.Metrics.Counter<long> _starts;
+
+    /// <summary>
+    /// Creates the hosted service and its counter instrument from the injected facade.
+    /// </summary>
+    /// <param name="metrics">The platform metrics facade.</param>
+    public HostStartupMetrics(IMetrics metrics)
+    {
+        ArgumentNullException.ThrowIfNull(metrics);
+        _starts = metrics.CreateCounter<long>(
+            StartsCounterName,
+            unit: "{start}",
+            description: "Number of times the BotNexus host process has started.");
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _starts.Add(1);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/gateway/BotNexus.Gateway.Telemetry/IMetrics.cs
+++ b/src/gateway/BotNexus.Gateway.Telemetry/IMetrics.cs
@@ -1,0 +1,63 @@
+using System.Diagnostics.Metrics;
+
+namespace BotNexus.Gateway.Telemetry;
+
+/// <summary>
+/// Thin, injectable facade over the canonical BotNexus <see cref="Meter"/>. Application
+/// code depends on this interface rather than newing up its own <see cref="Meter"/> so that
+/// (a) every instrument lands in the single well-known instrumentation scope exporters
+/// subscribe to, and (b) call sites remain mockable in unit tests.
+/// </summary>
+/// <remarks>
+/// Instrument names must follow the <c>botnexus.&lt;area&gt;.&lt;instrument&gt;</c> convention;
+/// use <see cref="BotNexusMeters.InstrumentName(string, string)"/> to build them.
+/// </remarks>
+public interface IMetrics
+{
+    /// <summary>
+    /// Creates a monotonically increasing counter (e.g. total host starts, messages processed).
+    /// </summary>
+    /// <typeparam name="T">The measurement value type (must be a struct).</typeparam>
+    /// <param name="name">Convention-compliant instrument name.</param>
+    /// <param name="unit">Optional UCUM unit string.</param>
+    /// <param name="description">Optional human-readable description.</param>
+    Counter<T> CreateCounter<T>(string name, string? unit = null, string? description = null)
+        where T : struct;
+
+    /// <summary>
+    /// Creates a histogram for recording a distribution of values (e.g. request latency).
+    /// </summary>
+    /// <typeparam name="T">The measurement value type (must be a struct).</typeparam>
+    /// <param name="name">Convention-compliant instrument name.</param>
+    /// <param name="unit">Optional UCUM unit string.</param>
+    /// <param name="description">Optional human-readable description.</param>
+    Histogram<T> CreateHistogram<T>(string name, string? unit = null, string? description = null)
+        where T : struct;
+
+    /// <summary>
+    /// Creates an up/down counter for values that can increase and decrease
+    /// (e.g. active sessions, queue depth).
+    /// </summary>
+    /// <typeparam name="T">The measurement value type (must be a struct).</typeparam>
+    /// <param name="name">Convention-compliant instrument name.</param>
+    /// <param name="unit">Optional UCUM unit string.</param>
+    /// <param name="description">Optional human-readable description.</param>
+    UpDownCounter<T> CreateUpDownCounter<T>(string name, string? unit = null, string? description = null)
+        where T : struct;
+
+    /// <summary>
+    /// Registers an observable gauge whose value is sampled on demand from
+    /// <paramref name="observeValue"/> at collection time.
+    /// </summary>
+    /// <typeparam name="T">The measurement value type (must be a struct).</typeparam>
+    /// <param name="name">Convention-compliant instrument name.</param>
+    /// <param name="observeValue">Callback invoked by the SDK to sample the current value.</param>
+    /// <param name="unit">Optional UCUM unit string.</param>
+    /// <param name="description">Optional human-readable description.</param>
+    ObservableGauge<T> CreateObservableGauge<T>(
+        string name,
+        Func<T> observeValue,
+        string? unit = null,
+        string? description = null)
+        where T : struct;
+}

--- a/src/gateway/BotNexus.Gateway.Telemetry/TelemetryConfig.cs
+++ b/src/gateway/BotNexus.Gateway.Telemetry/TelemetryConfig.cs
@@ -1,0 +1,20 @@
+namespace BotNexus.Gateway.Telemetry;
+
+/// <summary>
+/// Binds the <c>telemetry</c> configuration section. This PBI lands only the in-process
+/// metrics/tracing foundation; exporter (OTLP) configuration is deferred to a later PBI,
+/// so there is deliberately no egress/endpoint surface here yet.
+/// </summary>
+public sealed class TelemetryConfig
+{
+    /// <summary>Configuration section name under the root config.</summary>
+    public const string SectionName = "telemetry";
+
+    /// <summary>
+    /// Whether the in-process OpenTelemetry metrics/tracing plane is active. Defaults to
+    /// <see langword="true"/>. When <see langword="false"/>, <c>AddBotNexusTelemetry</c>
+    /// still registers <see cref="IMetrics"/> (so call sites resolve) but does not wire the
+    /// OpenTelemetry MeterProvider/TracerProvider.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+}

--- a/src/gateway/BotNexus.Gateway.Telemetry/TelemetryServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway.Telemetry/TelemetryServiceCollectionExtensions.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace BotNexus.Gateway.Telemetry;
+
+/// <summary>
+/// Registers the BotNexus telemetry foundation: the <see cref="IMetrics"/> facade and the
+/// OpenTelemetry SDK MeterProvider/TracerProvider scoped to the canonical
+/// <see cref="BotNexusMeters.Name"/> instrumentation scope.
+/// </summary>
+public static class TelemetryServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the BotNexus metrics core and OpenTelemetry SDK wiring.
+    /// </summary>
+    /// <remarks>
+    /// Always registers <see cref="IMetrics"/> so call sites resolve regardless of
+    /// configuration. When <see cref="TelemetryConfig.Enabled"/> is <see langword="true"/>
+    /// (the default), also wires <c>AddOpenTelemetry().WithMetrics(...)</c> subscribed to the
+    /// <c>"BotNexus"</c> meter plus AspNetCore and Http instrumentation, and a
+    /// <c>WithTracing(...)</c> scaffold subscribed to the <c>"BotNexus"</c> ActivitySource.
+    /// No exporter is configured, so there is no OTLP/network egress by default.
+    /// </remarks>
+    /// <param name="services">The service collection to add to.</param>
+    /// <param name="configuration">Root configuration; the <c>telemetry</c> section is bound.</param>
+    /// <returns>The same <paramref name="services"/> instance for chaining.</returns>
+    public static IServiceCollection AddBotNexusTelemetry(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var section = configuration.GetSection(TelemetryConfig.SectionName);
+        services.Configure<TelemetryConfig>(section);
+
+        var config = section.Get<TelemetryConfig>() ?? new TelemetryConfig();
+
+        // Always register the facade so DI resolution never depends on the enabled flag.
+        services.AddSingleton<IMetrics, BotNexusMetrics>();
+
+        // Proof-of-life smoke counter (botnexus.host.starts) increments on boot.
+        services.AddHostedService<HostStartupMetrics>();
+
+        if (!config.Enabled)
+        {
+            return services;
+        }
+
+        services.AddOpenTelemetry()
+            .WithMetrics(builder =>
+            {
+                builder.AddMeter(BotNexusMeters.Name);
+                builder.AddAspNetCoreInstrumentation();
+                builder.AddHttpClientInstrumentation();
+            })
+            .WithTracing(builder =>
+            {
+                // Tracing scaffold only: subscribe to the canonical source so PBI2+ can
+                // start emitting spans without further host wiring. No custom spans yet.
+                builder.AddSource(BotNexusMeters.Name);
+                builder.AddAspNetCoreInstrumentation();
+                builder.AddHttpClientInstrumentation();
+            });
+
+        return services;
+    }
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/MeterCentralizationArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/MeterCentralizationArchitectureTests.cs
@@ -1,0 +1,127 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness function: platform code emits metrics through the
+/// <c>IMetrics</c> facade / the canonical <c>BotNexusMeters</c> scope, never by
+/// newing up an ad-hoc <see cref="System.Diagnostics.Metrics.Meter"/>. A private
+/// <c>new Meter("...")</c> creates an instrumentation scope that no exporter
+/// subscribes to, so its measurements are silently dropped. Centralising on the
+/// single <c>"BotNexus"</c> meter keeps every instrument observable.
+/// </summary>
+/// <remarks>
+/// The fence scans tracked C# source under <c>src/</c> for <c>new Meter(</c>. The
+/// only sanctioned construction sites live inside the telemetry project
+/// (<c>BotNexusMeters</c> owns the canonical meter; <c>BotNexusMetrics</c> accepts an
+/// injected meter for the facade), so those files are allowlisted by basename.
+/// Test code is out of scope - tests legitimately create private meters plus
+/// <c>MeterListener</c>s to observe instruments in isolation.
+/// </remarks>
+public sealed class MeterCentralizationArchitectureTests
+{
+    // Sanctioned meter construction sites, all inside BotNexus.Gateway.Telemetry.
+    private static readonly HashSet<string> AllowedFiles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "BotNexusMeters.cs",   // owns the single canonical "BotNexus" meter
+        "BotNexusMetrics.cs",  // facade; accepts an injected meter (default = canonical)
+    };
+
+    // Matches "new Meter(" with optional whitespace, catching ad-hoc scope creation.
+    private static readonly Regex NewMeter = new(
+        @"new\s+Meter\s*\(",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void NoPlatformSource_ConstructsAdHocMeter()
+    {
+        var repoRoot = FindRepoRoot();
+        var offenders = new List<string>();
+
+        foreach (var relative in EnumerateTrackedFiles(repoRoot))
+        {
+            var normalised = relative.Replace('\\', '/');
+            if (!normalised.StartsWith("src/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+            if (!normalised.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            if (AllowedFiles.Contains(Path.GetFileName(normalised)))
+            {
+                continue;
+            }
+
+            var absolute = Path.Combine(repoRoot, relative);
+            if (!File.Exists(absolute))
+            {
+                continue;
+            }
+
+            string content;
+            try
+            {
+                content = File.ReadAllText(absolute);
+            }
+            catch (IOException)
+            {
+                continue;
+            }
+
+            if (NewMeter.IsMatch(content))
+            {
+                offenders.Add($"{normalised}: constructs an ad-hoc Meter - resolve IMetrics or use BotNexusMeters instead");
+            }
+        }
+
+        offenders.Sort(StringComparer.Ordinal);
+        offenders.ShouldBeEmpty(
+            "Platform source constructs an ad-hoc System.Diagnostics.Metrics.Meter. " +
+            "Instruments on a private meter are dropped by exporters that only subscribe " +
+            "to the canonical \"BotNexus\" scope. Resolve IMetrics from DI or use " +
+            "BotNexusMeters. Only the telemetry project may construct a Meter.\n" +
+            "Offenders:\n  " + string.Join("\n  ", offenders));
+    }
+
+    private static IEnumerable<string> EnumerateTrackedFiles(string repoRoot)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo("git", "ls-files")
+            {
+                WorkingDirectory = repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            },
+        };
+
+        process.Start();
+        string? line;
+        while ((line = process.StandardOutput.ReadLine()) is not null)
+        {
+            if (!string.IsNullOrWhiteSpace(line))
+            {
+                yield return line;
+            }
+        }
+        process.WaitForExit();
+        process.ExitCode.ShouldBe(0, "git ls-files failed: " + process.StandardError.ReadToEnd());
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        return current.FullName;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Telemetry.Tests/BotNexus.Gateway.Telemetry.Tests.csproj
+++ b/tests/gateway/BotNexus.Gateway.Telemetry.Tests/BotNexus.Gateway.Telemetry.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Telemetry\BotNexus.Gateway.Telemetry.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/gateway/BotNexus.Gateway.Telemetry.Tests/BotNexusMetersTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Telemetry.Tests/BotNexusMetersTests.cs
@@ -1,0 +1,45 @@
+using BotNexus.Gateway.Telemetry;
+using Shouldly;
+
+namespace BotNexus.Gateway.Telemetry.Tests;
+
+/// <summary>
+/// Tests for <see cref="BotNexusMeters"/> canonical identifiers and naming convention.
+/// </summary>
+public sealed class BotNexusMetersTests
+{
+    [Fact]
+    public void Name_IsCanonicalScope()
+    {
+        BotNexusMeters.Name.ShouldBe("BotNexus");
+    }
+
+    [Fact]
+    public void Meter_And_ActivitySource_UseCanonicalName()
+    {
+        BotNexusMeters.Meter.Name.ShouldBe("BotNexus");
+        BotNexusMeters.ActivitySource.Name.ShouldBe("BotNexus");
+    }
+
+    [Fact]
+    public void Version_IsNotBlank()
+    {
+        BotNexusMeters.Version.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void InstrumentName_FollowsConvention()
+    {
+        BotNexusMeters.InstrumentName("host", "starts").ShouldBe("botnexus.host.starts");
+    }
+
+    [Theory]
+    [InlineData(null, "starts")]
+    [InlineData("host", null)]
+    [InlineData("", "starts")]
+    [InlineData("host", "  ")]
+    public void InstrumentName_InvalidArgs_Throws(string? area, string? instrument)
+    {
+        Should.Throw<ArgumentException>(() => BotNexusMeters.InstrumentName(area!, instrument!));
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Telemetry.Tests/BotNexusMetricsTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Telemetry.Tests/BotNexusMetricsTests.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics.Metrics;
+using BotNexus.Gateway.Telemetry;
+using Shouldly;
+
+namespace BotNexus.Gateway.Telemetry.Tests;
+
+/// <summary>
+/// Tests for the <see cref="BotNexusMetrics"/> facade over a <see cref="Meter"/>.
+/// </summary>
+public sealed class BotNexusMetricsTests
+{
+    [Fact]
+    public void CreateCounter_EmitsMeasurements_ObservableViaMeterListener()
+    {
+        using var meter = new Meter("BotNexus.Test.Counter");
+        var metrics = new BotNexusMetrics(meter);
+
+        long observed = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter == meter)
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, _, _) => observed += measurement);
+        listener.Start();
+
+        var counter = metrics.CreateCounter<long>("botnexus.test.counter");
+        counter.Add(3);
+        counter.Add(4);
+
+        observed.ShouldBe(7);
+    }
+
+    [Fact]
+    public void CreateHistogram_RecordsMeasurements_ObservableViaMeterListener()
+    {
+        using var meter = new Meter("BotNexus.Test.Histogram");
+        var metrics = new BotNexusMetrics(meter);
+
+        var recorded = new List<double>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter == meter)
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((_, measurement, _, _) => recorded.Add(measurement));
+        listener.Start();
+
+        var histogram = metrics.CreateHistogram<double>("botnexus.test.latency", unit: "ms");
+        histogram.Record(1.5);
+        histogram.Record(2.5);
+
+        recorded.ShouldBe(new[] { 1.5, 2.5 });
+    }
+
+    [Fact]
+    public void CreateUpDownCounter_TracksNetValue_ObservableViaMeterListener()
+    {
+        using var meter = new Meter("BotNexus.Test.UpDown");
+        var metrics = new BotNexusMetrics(meter);
+
+        long net = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter == meter)
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, _, _) => net += measurement);
+        listener.Start();
+
+        var updown = metrics.CreateUpDownCounter<long>("botnexus.test.active");
+        updown.Add(5);
+        updown.Add(-2);
+
+        net.ShouldBe(3);
+    }
+
+    [Fact]
+    public void CreateObservableGauge_SamplesValue_OnCollection()
+    {
+        using var meter = new Meter("BotNexus.Test.Gauge");
+        var metrics = new BotNexusMetrics(meter);
+
+        var current = 42;
+        long? observed = null;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter == meter)
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, _, _) => observed = measurement);
+        listener.Start();
+
+        _ = metrics.CreateObservableGauge("botnexus.test.gauge", () => (long)current);
+        listener.RecordObservableInstruments();
+
+        observed.ShouldBe(42);
+    }
+
+    [Fact]
+    public void Constructor_NullMeter_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => new BotNexusMetrics(null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CreateCounter_BlankName_Throws(string name)
+    {
+        using var meter = new Meter("BotNexus.Test.Blank");
+        var metrics = new BotNexusMetrics(meter);
+
+        Should.Throw<ArgumentException>(() => metrics.CreateCounter<long>(name));
+    }
+
+    [Fact]
+    public void CreateObservableGauge_NullCallback_Throws()
+    {
+        using var meter = new Meter("BotNexus.Test.NullCb");
+        var metrics = new BotNexusMetrics(meter);
+
+        Should.Throw<ArgumentNullException>(
+            () => metrics.CreateObservableGauge<long>("botnexus.test.gauge", null!));
+    }
+
+    [Fact]
+    public void DefaultConstructor_UsesCanonicalMeter()
+    {
+        var metrics = new BotNexusMetrics();
+
+        // Instruments created here belong to the canonical "BotNexus" scope; a listener
+        // filtering on that meter name should see the measurement.
+        long observed = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == BotNexusMeters.Name
+                && instrument.Name == "botnexus.test.canonical")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, _, _) => observed += measurement);
+        listener.Start();
+
+        var counter = metrics.CreateCounter<long>("botnexus.test.canonical");
+        counter.Add(11);
+
+        observed.ShouldBe(11);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Telemetry.Tests/HostStartupMetricsTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Telemetry.Tests/HostStartupMetricsTests.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics.Metrics;
+using BotNexus.Gateway.Telemetry;
+using Shouldly;
+
+namespace BotNexus.Gateway.Telemetry.Tests;
+
+/// <summary>
+/// Tests for the <see cref="HostStartupMetrics"/> boot smoke counter.
+/// </summary>
+public sealed class HostStartupMetricsTests
+{
+    [Fact]
+    public void CounterName_FollowsConvention()
+    {
+        HostStartupMetrics.StartsCounterName.ShouldBe("botnexus.host.starts");
+    }
+
+    [Fact]
+    public async Task StartAsync_IncrementsSmokeCounter_ObservableViaMeterListener()
+    {
+        using var meter = new Meter("BotNexus.Test.Host");
+        var metrics = new BotNexusMetrics(meter);
+
+        long observed = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter == meter && instrument.Name == HostStartupMetrics.StartsCounterName)
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, _, _) => observed += measurement);
+        listener.Start();
+
+        var service = new HostStartupMetrics(metrics);
+        await service.StartAsync(CancellationToken.None);
+
+        observed.ShouldBe(1);
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public void Constructor_NullMetrics_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => new HostStartupMetrics(null!));
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Telemetry.Tests/TelemetryServiceCollectionExtensionsTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Telemetry.Tests/TelemetryServiceCollectionExtensionsTests.cs
@@ -1,0 +1,108 @@
+using BotNexus.Gateway.Telemetry;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+using Shouldly;
+
+namespace BotNexus.Gateway.Telemetry.Tests;
+
+/// <summary>
+/// Tests for the <c>AddBotNexusTelemetry</c> DI wiring shape.
+/// </summary>
+public sealed class TelemetryServiceCollectionExtensionsTests
+{
+    private static IConfiguration BuildConfig(params (string Key, string Value)[] values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values.Select(v =>
+                new KeyValuePair<string, string?>(v.Key, v.Value)))
+            .Build();
+    }
+
+    [Fact]
+    public void AddBotNexusTelemetry_RegistersIMetrics()
+    {
+        var services = new ServiceCollection();
+        services.AddBotNexusTelemetry(BuildConfig());
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetService<IMetrics>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddBotNexusTelemetry_DefaultEnabled_WiresMeterProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddBotNexusTelemetry(BuildConfig());
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetService<MeterProvider>().ShouldNotBeNull();
+        provider.GetService<TracerProvider>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddBotNexusTelemetry_ExplicitEnabledTrue_WiresMeterProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddBotNexusTelemetry(BuildConfig(("telemetry:Enabled", "true")));
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetService<MeterProvider>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddBotNexusTelemetry_Disabled_StillRegistersIMetrics()
+    {
+        var services = new ServiceCollection();
+        services.AddBotNexusTelemetry(BuildConfig(("telemetry:Enabled", "false")));
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetService<IMetrics>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddBotNexusTelemetry_Disabled_DoesNotWireMeterProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddBotNexusTelemetry(BuildConfig(("telemetry:Enabled", "false")));
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetService<MeterProvider>().ShouldBeNull();
+        provider.GetService<TracerProvider>().ShouldBeNull();
+    }
+
+    [Fact]
+    public void AddBotNexusTelemetry_ReturnsSameCollection()
+    {
+        var services = new ServiceCollection();
+        var result = services.AddBotNexusTelemetry(BuildConfig());
+        result.ShouldBeSameAs(services);
+    }
+
+    [Fact]
+    public void AddBotNexusTelemetry_NullServices_Throws()
+    {
+        IServiceCollection services = null!;
+        Should.Throw<ArgumentNullException>(() => services.AddBotNexusTelemetry(BuildConfig()));
+    }
+
+    [Fact]
+    public void AddBotNexusTelemetry_NullConfiguration_Throws()
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentNullException>(() => services.AddBotNexusTelemetry(null!));
+    }
+
+    [Fact]
+    public void AddBotNexusTelemetry_IMetrics_IsSingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddBotNexusTelemetry(BuildConfig());
+
+        using var provider = services.BuildServiceProvider();
+        var a = provider.GetRequiredService<IMetrics>();
+        var b = provider.GetRequiredService<IMetrics>();
+        a.ShouldBeSameAs(b);
+    }
+}


### PR DESCRIPTION
Closes #1849

## Changes
- New `BotNexus.Gateway.Telemetry` project: canonical `Meter` name `BotNexus` (versioned instrumentation scope), naming convention `botnexus.<area>.<instrument>`.
- `IMetrics` thin injectable facade over a `Meter` (CreateCounter/CreateHistogram/CreateUpDownCounter/ObservableGauge) so callers don't new-up their own `Meter` and it's mockable in tests.
- `AddBotNexusTelemetry(IServiceCollection, IConfiguration)`: calls `AddOpenTelemetry().WithMetrics(b => b.AddMeter(\"BotNexus\"))` and registers `IMetrics`. Idempotent alongside the existing tracing wiring in Program.cs.
- `HostStartupMetrics` smoke counter (`botnexus.host.starts`) proving the meter emits.
- `TelemetryConfig` (`telemetry.enabled`, default true) — foundation only, no OTLP exporter surface yet (deferred to a later PBI).
- Architecture fence `MeterCentralizationArchitectureTests` keeps meter creation centralized.
- Docs: added Telemetry section to `docs/configuration.md`.

## Verification
- Full solution build: 0 warnings / 0 errors.
- Telemetry.Tests 29/29, Architecture.Tests 218/218, Scenarios.Tests 29/29 — all green.

## Merge Notes
Foundation PBI1 of epic #1848. No hot-path instrumentation — safe to merge independently. PBI2 #1850 (shared durable usage-telemetry primitive) builds on this. File-disjoint from all other open PRs (new project + minimal Program.cs/slnx wiring).