### PR TITLE
refactor(gateway): promote exchange-completion metadata to typed AgentExchangeCompletionState

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentExchangeCompletionState.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentExchangeCompletionState.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+
+namespace BotNexus.Gateway.Abstractions.Models;
+
+/// <summary>
+/// Typed completion state for an agent-to-agent exchange, promoted from the four loose
+/// <see cref="Session.Metadata"/> string keys (<c>activeAgentExchangeId</c>,
+/// <c>finishedAgentExchangeId</c>, <c>finishedAgentExchangeReason</c>,
+/// <c>finishedAgentExchangeSummary</c>) that previously carried this state as an ad-hoc bag
+/// read/written through duplicate <c>MetadataString</c> JsonElement-coercion helpers
+/// (issue #612, CC-1).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Storage &amp; back-compat.</strong> This state is projected onto
+/// <see cref="Session.Metadata"/> so it round-trips through the existing session-store
+/// persistence (Sqlite / File / InMemory) without any schema change. New writes serialise the
+/// whole state under the single canonical key <see cref="MetadataKey"/>; reads
+/// <em>migrate-on-read</em>: a row that still carries the four legacy loose keys
+/// (<see cref="LegacyActiveExchangeIdKey"/> et al.) is transparently surfaced as this typed
+/// state, so pre-CC-1 persisted sessions keep working. Writes always clear the legacy loose
+/// keys so a stale value can never shadow the canonical blob.
+/// </para>
+/// <para>
+/// <strong>Freshness gate.</strong> <see cref="ActiveExchangeId"/> is written per-turn before
+/// the target agent is prompted; <see cref="FinishedExchangeId"/> is written by
+/// <c>FinishAgentExchangeTool</c> and must equal the active id for the completion signal to be
+/// honoured (F-11). The single JsonElement-tolerant coercion here replaces the duplicated
+/// helpers because <c>SqliteSessionStore</c> and <c>FileSessionStore</c> round-trip
+/// <c>object?</c> metadata as <see cref="JsonElement"/>.
+/// </para>
+/// </remarks>
+public sealed record AgentExchangeCompletionState
+{
+    /// <summary>The active exchange id the service writes before each turn (null when no turn is in flight).</summary>
+    public string? ActiveExchangeId { get; init; }
+
+    /// <summary>The exchange id the finish tool stamped when fired; must match <see cref="ActiveExchangeId"/> to be honoured.</summary>
+    public string? FinishedExchangeId { get; init; }
+
+    /// <summary>Caller-supplied completion reason.</summary>
+    public string? FinishedReason { get; init; }
+
+    /// <summary>Optional caller-supplied completion summary.</summary>
+    public string? FinishedSummary { get; init; }
+
+    /// <summary>Canonical metadata key the whole typed state is serialised under for new writes.</summary>
+    public const string MetadataKey = "agentExchangeCompletion";
+
+    /// <summary>Legacy loose metadata key for the active exchange id (migrate-on-read only).</summary>
+    public const string LegacyActiveExchangeIdKey = "activeAgentExchangeId";
+
+    /// <summary>Legacy loose metadata key for the finished exchange id (migrate-on-read only).</summary>
+    public const string LegacyFinishedExchangeIdKey = "finishedAgentExchangeId";
+
+    /// <summary>Legacy loose metadata key for the finished reason (migrate-on-read only).</summary>
+    public const string LegacyFinishedReasonKey = "finishedAgentExchangeReason";
+
+    /// <summary>Legacy loose metadata key for the finished summary (migrate-on-read only).</summary>
+    public const string LegacyFinishedSummaryKey = "finishedAgentExchangeSummary";
+
+    /// <summary>True when no field carries a value - such a state is never persisted.</summary>
+    public bool IsEmpty =>
+        ActiveExchangeId is null
+        && FinishedExchangeId is null
+        && FinishedReason is null
+        && FinishedSummary is null;
+
+    /// <summary>
+    /// Projects the completion state out of <paramref name="metadata"/>. Prefers the canonical
+    /// <see cref="MetadataKey"/> blob; falls back to migrating the four legacy loose keys.
+    /// Returns <c>null</c> when neither representation carries any value.
+    /// </summary>
+    public static AgentExchangeCompletionState? FromMetadata(IDictionary<string, object?> metadata)
+    {
+        if (metadata.TryGetValue(MetadataKey, out var raw) && Coerce(raw) is { IsEmpty: false } parsed)
+            return parsed;
+
+        var legacy = new AgentExchangeCompletionState
+        {
+            ActiveExchangeId = CoerceString(metadata, LegacyActiveExchangeIdKey),
+            FinishedExchangeId = CoerceString(metadata, LegacyFinishedExchangeIdKey),
+            FinishedReason = CoerceString(metadata, LegacyFinishedReasonKey),
+            FinishedSummary = CoerceString(metadata, LegacyFinishedSummaryKey)
+        };
+        return legacy.IsEmpty ? null : legacy;
+    }
+
+    /// <summary>
+    /// Writes <paramref name="state"/> onto <paramref name="metadata"/> under the canonical key,
+    /// always removing the legacy loose keys first so they can never shadow or stale-replay. A
+    /// <c>null</c> or empty state clears the canonical key too.
+    /// </summary>
+    public static void WriteTo(IDictionary<string, object?> metadata, AgentExchangeCompletionState? state)
+    {
+        metadata.Remove(LegacyActiveExchangeIdKey);
+        metadata.Remove(LegacyFinishedExchangeIdKey);
+        metadata.Remove(LegacyFinishedReasonKey);
+        metadata.Remove(LegacyFinishedSummaryKey);
+
+        if (state is null || state.IsEmpty)
+            metadata.Remove(MetadataKey);
+        else
+            metadata[MetadataKey] = state;
+    }
+
+    private static AgentExchangeCompletionState? Coerce(object? raw) => raw switch
+    {
+        null => null,
+        AgentExchangeCompletionState state => state,
+        JsonElement { ValueKind: JsonValueKind.Object } element => new AgentExchangeCompletionState
+        {
+            ActiveExchangeId = GetProperty(element, "activeExchangeId"),
+            FinishedExchangeId = GetProperty(element, "finishedExchangeId"),
+            FinishedReason = GetProperty(element, "finishedReason"),
+            FinishedSummary = GetProperty(element, "finishedSummary")
+        },
+        _ => null
+    };
+
+    private static string? GetProperty(JsonElement element, string name)
+        => element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static string? CoerceString(IDictionary<string, object?> metadata, string key)
+    {
+        if (!metadata.TryGetValue(key, out var value) || value is null)
+            return null;
+        return value switch
+        {
+            string s => s,
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            _ => null
+        };
+    }
+}

--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -181,6 +181,18 @@ public sealed class GatewaySession
     }
 
     /// <summary>
+    /// Typed agent-to-agent exchange-completion state (issue #612, CC-1). Facade over
+    /// <see cref="Session"/>.<see cref="Session.ExchangeCompletion"/>; replaces the four loose
+    /// exchange-completion metadata string keys with a single typed nullable record. Mutate
+    /// through this proxy so the reach-through fence stays satisfied.
+    /// </summary>
+    public AgentExchangeCompletionState? ExchangeCompletion
+    {
+        get => Session.ExchangeCompletion;
+        set => Session.ExchangeCompletion = value;
+    }
+
+    /// <summary>
     /// Dedicated outbound-stream reconnect-replay peer for this session. The 8
     /// stream-replay members previously hosted on the facade (#575) collapsed
     /// here so the conversational session surface is no longer mixed with

--- a/src/domain/BotNexus.Domain/Gateway/Models/Session.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Session.cs
@@ -90,6 +90,22 @@ public sealed record Session
     public Dictionary<string, object?> Metadata { get; set; } = [];
 
     /// <summary>
+    /// Typed agent-to-agent exchange-completion state (issue #612, CC-1). This is a projection
+    /// over <see cref="Metadata"/>: it replaces the four loose <c>activeAgentExchangeId</c> /
+    /// <c>finishedAgentExchangeId</c> / <c>finishedAgentExchangeReason</c> /
+    /// <c>finishedAgentExchangeSummary</c> string keys that previously carried this state.
+    /// Backing storage on <see cref="Metadata"/> keeps the state round-tripping through the
+    /// existing session-store persistence unchanged; the getter migrates-on-read from the legacy
+    /// loose keys so pre-CC-1 persisted rows keep working. <c>null</c> when no exchange completion
+    /// state is present. See <see cref="AgentExchangeCompletionState"/>.
+    /// </summary>
+    public AgentExchangeCompletionState? ExchangeCompletion
+    {
+        get => AgentExchangeCompletionState.FromMetadata(Metadata);
+        set => AgentExchangeCompletionState.WriteTo(Metadata, value);
+    }
+
+    /// <summary>
     /// Gets or sets the history.
     /// </summary>
     public List<SessionEntry> History { get; set; } = [];

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -215,16 +215,19 @@ public sealed class CrossWorldFederationController(
 
             // Clear the active-exchange id regardless of outcome so a follow-up turn for the same
             // session starts from a clean slate.
-            session.Metadata.Remove(FinishAgentExchangeTool.ActiveExchangeIdKey);
+            session.ExchangeCompletion = session.ExchangeCompletion is { } activeState
+                ? activeState with { ActiveExchangeId = null }
+                : null;
             if (exchangeFinished)
             {
                 // Echo the consumed payload onto the persisted session metadata for diagnostics
                 // and for any downstream walker that lists sessions for this conversation.
-                session.Metadata[FinishAgentExchangeTool.FinishedExchangeIdKey] = exchangeId;
-                if (finishReason is not null)
-                    session.Metadata[FinishAgentExchangeTool.FinishedReasonKey] = finishReason;
-                if (!string.IsNullOrEmpty(finishSummary))
-                    session.Metadata[FinishAgentExchangeTool.FinishedSummaryKey] = finishSummary;
+                session.ExchangeCompletion = (session.ExchangeCompletion ?? new AgentExchangeCompletionState()) with
+                {
+                    FinishedExchangeId = exchangeId,
+                    FinishedReason = finishReason ?? (session.ExchangeCompletion?.FinishedReason),
+                    FinishedSummary = string.IsNullOrEmpty(finishSummary) ? null : finishSummary
+                };
                 // State-machine closure (bug-hunt MEDIUM-3 on PR #553): once the target agent has
                 // explicitly signalled completion via finish_agent_exchange, the receiver-side
                 // session is terminated. ResolveSessionAsync's sealed-session guard then refuses
@@ -297,7 +300,9 @@ public sealed class CrossWorldFederationController(
             logger.LogWarning(ex,
                 "Cross-world relay failed for session '{SessionId}' on agent '{TargetAgentId}'.",
                 sessionId, session.AgentId);
-            session.Metadata.Remove(FinishAgentExchangeTool.ActiveExchangeIdKey);
+            session.ExchangeCompletion = session.ExchangeCompletion is { } activeState
+                ? activeState with { ActiveExchangeId = null }
+                : null;
             session.Status = GatewaySessionStatus.Sealed;
             session.Metadata["error"] = ex.Message;
             await sessionStore.SaveAsync(session, CancellationToken.None).ConfigureAwait(false);

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeCompletionGate.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeCompletionGate.cs
@@ -59,12 +59,14 @@ public static class AgentExchangeCompletionGate
         // (2) Freshness gate: only honour the tool when its persisted payload references THIS
         // turn's active id. Without this, a stale write from a previous turn (or from another
         // tool path that happens to write the same metadata keys) could be replayed.
-        var finishedExchangeId = MetadataString(refreshedMetadata, FinishAgentExchangeTool.FinishedExchangeIdKey);
-        if (!string.Equals(finishedExchangeId, expectedExchangeId, StringComparison.Ordinal))
+        // The typed AgentExchangeCompletionState migrates-on-read from any legacy loose keys.
+        var completion = AgentExchangeCompletionState.FromMetadata(refreshedMetadata);
+        if (completion is null
+            || !string.Equals(completion.FinishedExchangeId, expectedExchangeId, StringComparison.Ordinal))
             return false;
 
-        reason = MetadataString(refreshedMetadata, FinishAgentExchangeTool.FinishedReasonKey);
-        summary = MetadataString(refreshedMetadata, FinishAgentExchangeTool.FinishedSummaryKey);
+        reason = completion.FinishedReason;
+        summary = completion.FinishedSummary;
         return true;
     }
 
@@ -77,28 +79,11 @@ public static class AgentExchangeCompletionGate
     /// </summary>
     public static void PrepareTurn(IDictionary<string, object?> metadata, string exchangeId)
     {
-        metadata[FinishAgentExchangeTool.ActiveExchangeIdKey] = exchangeId;
-        metadata.Remove(FinishAgentExchangeTool.FinishedExchangeIdKey);
-        metadata.Remove(FinishAgentExchangeTool.FinishedReasonKey);
-        metadata.Remove(FinishAgentExchangeTool.FinishedSummaryKey);
-    }
-
-    /// <summary>
-    /// JsonElement-tolerant metadata read. <c>SqliteSessionStore</c> and <c>FileSessionStore</c>
-    /// round-trip <c>object?</c> metadata as <see cref="System.Text.Json.JsonElement"/>, so a
-    /// plain <c>as string</c> cast silently returns <c>null</c> — which would turn a freshness
-    /// check into a silent always-fail.
-    /// </summary>
-    public static string? MetadataString(IDictionary<string, object?> metadata, string key)
-    {
-        if (!metadata.TryGetValue(key, out var value) || value is null)
-            return null;
-        return value switch
+        // Set a fresh active id and clear any prior finish payload so a previous turn's write
+        // cannot satisfy the freshness gate. WriteTo also strips the legacy loose keys.
+        AgentExchangeCompletionState.WriteTo(metadata, new AgentExchangeCompletionState
         {
-            string s => s,
-            System.Text.Json.JsonElement element when element.ValueKind == System.Text.Json.JsonValueKind.String
-                => element.GetString(),
-            _ => null
-        };
+            ActiveExchangeId = exchangeId
+        });
     }
 }

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -219,17 +219,21 @@ public sealed class AgentExchangeService : IAgentExchangeService
                     // SaveAsync persists the canonical metadata view.
                     if (!ReferenceEquals(refreshed, session))
                     {
-                        session.Metadata[FinishAgentExchangeTool.FinishedExchangeIdKey] = exchangeId;
-                        session.Metadata[FinishAgentExchangeTool.FinishedReasonKey] = finishReason ?? string.Empty;
-                        if (!string.IsNullOrEmpty(finishSummary))
-                            session.Metadata[FinishAgentExchangeTool.FinishedSummaryKey] = finishSummary;
+                        session.ExchangeCompletion = (session.ExchangeCompletion ?? new AgentExchangeCompletionState()) with
+                        {
+                            FinishedExchangeId = exchangeId,
+                            FinishedReason = finishReason ?? string.Empty,
+                            FinishedSummary = string.IsNullOrEmpty(finishSummary) ? null : finishSummary
+                        };
                     }
                     return new AgentExchangeTurnEngine.ExchangeTurnOutcome(responseText, Finished: true, finishReason, finishSummary);
                 }
 
                 return new AgentExchangeTurnEngine.ExchangeTurnOutcome(responseText, Finished: false, null, null);
             },
-            beforeSeal: s => s.Metadata.Remove(FinishAgentExchangeTool.ActiveExchangeIdKey),
+            beforeSeal: s => s.ExchangeCompletion = s.ExchangeCompletion is { } c
+                ? c with { ActiveExchangeId = null }
+                : null,
             onSealSuccess: static _ => { },
             cancellationToken).ConfigureAwait(false);
     }

--- a/src/gateway/BotNexus.Gateway/Tools/FinishAgentExchangeTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/FinishAgentExchangeTool.cs
@@ -3,6 +3,7 @@ using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 
 namespace BotNexus.Gateway.Tools;
@@ -39,17 +40,17 @@ public sealed class FinishAgentExchangeTool(
     ISessionStore sessionStore,
     SessionId sessionId) : IAgentTool
 {
-    /// <summary>Metadata key for the active exchange id the service writes before each turn.</summary>
-    public const string ActiveExchangeIdKey = "activeAgentExchangeId";
+    /// <summary>Legacy loose metadata key for the active exchange id (retained for back-compat reads).</summary>
+    public const string ActiveExchangeIdKey = AgentExchangeCompletionState.LegacyActiveExchangeIdKey;
 
-    /// <summary>Metadata key the tool writes the matching exchange id into when fired.</summary>
-    public const string FinishedExchangeIdKey = "finishedAgentExchangeId";
+    /// <summary>Legacy loose metadata key the tool wrote the matching exchange id into (retained for back-compat reads).</summary>
+    public const string FinishedExchangeIdKey = AgentExchangeCompletionState.LegacyFinishedExchangeIdKey;
 
-    /// <summary>Metadata key for the caller-supplied completion reason.</summary>
-    public const string FinishedReasonKey = "finishedAgentExchangeReason";
+    /// <summary>Legacy loose metadata key for the caller-supplied completion reason (retained for back-compat reads).</summary>
+    public const string FinishedReasonKey = AgentExchangeCompletionState.LegacyFinishedReasonKey;
 
-    /// <summary>Metadata key for the caller-supplied completion summary.</summary>
-    public const string FinishedSummaryKey = "finishedAgentExchangeSummary";
+    /// <summary>Legacy loose metadata key for the caller-supplied completion summary (retained for back-compat reads).</summary>
+    public const string FinishedSummaryKey = AgentExchangeCompletionState.LegacyFinishedSummaryKey;
 
     public string Name => "finish_agent_exchange";
     public string Label => "Finish agent exchange";
@@ -105,8 +106,8 @@ public sealed class FinishAgentExchangeTool(
             ?? throw new InvalidOperationException(
                 "No active agent exchange to finish (session not found).");
 
-        var activeExchangeId = MetadataString(session.Metadata, ActiveExchangeIdKey);
-        if (string.IsNullOrWhiteSpace(activeExchangeId))
+        var completion = session.ExchangeCompletion;
+        if (completion is null || string.IsNullOrWhiteSpace(completion.ActiveExchangeId))
             throw new InvalidOperationException(
                 "No active agent-to-agent exchange. The finish_agent_exchange tool may only be called "
                 + "during an exchange loop driven by another agent.");
@@ -114,12 +115,12 @@ public sealed class FinishAgentExchangeTool(
         var reason = (ReadString(arguments, "reason") ?? string.Empty).Trim();
         var summary = ReadString(arguments, "summary")?.Trim();
 
-        session.Metadata[FinishedExchangeIdKey] = activeExchangeId;
-        session.Metadata[FinishedReasonKey] = reason;
-        if (!string.IsNullOrEmpty(summary))
-            session.Metadata[FinishedSummaryKey] = summary;
-        else
-            session.Metadata.Remove(FinishedSummaryKey);
+        session.ExchangeCompletion = completion with
+        {
+            FinishedExchangeId = completion.ActiveExchangeId,
+            FinishedReason = reason,
+            FinishedSummary = string.IsNullOrEmpty(summary) ? null : summary
+        };
         await sessionStore.SaveAsync(session, cancellationToken).ConfigureAwait(false);
 
         return TextResult(
@@ -135,24 +136,6 @@ public sealed class FinishAgentExchangeTool(
             string s => s,
             JsonElement element when element.ValueKind == JsonValueKind.String => element.GetString(),
             _ => value.ToString()
-        };
-    }
-
-    /// <summary>
-    /// Same JsonElement-tolerant read pattern used by <c>CrossWorldFederationController.MetadataString</c>:
-    /// <c>SqliteSessionStore</c> and <c>FileSessionStore</c> round-trip <c>object?</c> metadata as
-    /// <see cref="JsonElement"/>, so a naive <c>as string</c> cast silently returns <c>null</c>
-    /// and the guard above falsely accepts the call.
-    /// </summary>
-    private static string? MetadataString(IDictionary<string, object?> metadata, string key)
-    {
-        if (!metadata.TryGetValue(key, out var value) || value is null)
-            return null;
-        return value switch
-        {
-            string s => s,
-            JsonElement element when element.ValueKind == JsonValueKind.String => element.GetString(),
-            _ => null
         };
     }
 

--- a/tests/domain/BotNexus.Domain.Tests/AgentExchangeCompletionStateTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/AgentExchangeCompletionStateTests.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Domain.Tests;
+
+/// <summary>
+/// Covers the typed <see cref="AgentExchangeCompletionState"/> promoted from the four loose
+/// exchange-completion metadata keys (issue #612, CC-1): typed round-trip through the
+/// <see cref="Session.Metadata"/> backing store, migrate-on-read from legacy loose keys, and the
+/// invariant that writes always clear the legacy keys so a stale value can never shadow the blob.
+/// </summary>
+public sealed class AgentExchangeCompletionStateTests
+{
+    [Fact]
+    public void ExchangeCompletion_TypedRoundTrip_SurvivesMetadataProjection()
+    {
+        var session = new Session
+        {
+            ExchangeCompletion = new AgentExchangeCompletionState
+            {
+                ActiveExchangeId = "ex-1",
+                FinishedExchangeId = "ex-1",
+                FinishedReason = "done",
+                FinishedSummary = "all good"
+            }
+        };
+
+        var read = session.ExchangeCompletion;
+
+        read.ShouldNotBeNull();
+        read!.ActiveExchangeId.ShouldBe("ex-1");
+        read.FinishedExchangeId.ShouldBe("ex-1");
+        read.FinishedReason.ShouldBe("done");
+        read.FinishedSummary.ShouldBe("all good");
+    }
+
+    [Fact]
+    public void ExchangeCompletion_MigratesOnRead_FromLegacyLooseKeys()
+    {
+        // Simulate a pre-CC-1 persisted row that still carries the four loose string keys.
+        var session = new Session();
+        session.Metadata[AgentExchangeCompletionState.LegacyActiveExchangeIdKey] = "legacy-active";
+        session.Metadata[AgentExchangeCompletionState.LegacyFinishedExchangeIdKey] = "legacy-finished";
+        session.Metadata[AgentExchangeCompletionState.LegacyFinishedReasonKey] = "legacy-reason";
+        session.Metadata[AgentExchangeCompletionState.LegacyFinishedSummaryKey] = "legacy-summary";
+
+        var read = session.ExchangeCompletion;
+
+        read.ShouldNotBeNull();
+        read!.ActiveExchangeId.ShouldBe("legacy-active");
+        read.FinishedExchangeId.ShouldBe("legacy-finished");
+        read.FinishedReason.ShouldBe("legacy-reason");
+        read.FinishedSummary.ShouldBe("legacy-summary");
+    }
+
+    [Fact]
+    public void ExchangeCompletion_MigratesOnRead_FromJsonElementLegacyKeys()
+    {
+        // Sqlite/File stores round-trip metadata values as JsonElement on read.
+        var session = new Session();
+        using var doc = JsonDocument.Parse("\"json-active\"");
+        session.Metadata[AgentExchangeCompletionState.LegacyActiveExchangeIdKey] = doc.RootElement.Clone();
+
+        var read = session.ExchangeCompletion;
+
+        read.ShouldNotBeNull();
+        read!.ActiveExchangeId.ShouldBe("json-active");
+    }
+
+    [Fact]
+    public void ExchangeCompletion_Write_ClearsLegacyLooseKeys()
+    {
+        var session = new Session();
+        session.Metadata[AgentExchangeCompletionState.LegacyActiveExchangeIdKey] = "stale";
+        session.Metadata[AgentExchangeCompletionState.LegacyFinishedReasonKey] = "stale-reason";
+
+        session.ExchangeCompletion = new AgentExchangeCompletionState { ActiveExchangeId = "fresh" };
+
+        session.Metadata.ShouldNotContainKey(AgentExchangeCompletionState.LegacyActiveExchangeIdKey);
+        session.Metadata.ShouldNotContainKey(AgentExchangeCompletionState.LegacyFinishedReasonKey);
+        session.Metadata.ShouldContainKey(AgentExchangeCompletionState.MetadataKey);
+        session.ExchangeCompletion!.ActiveExchangeId.ShouldBe("fresh");
+    }
+
+    [Fact]
+    public void ExchangeCompletion_NoState_ReadsAsNull()
+    {
+        new Session().ExchangeCompletion.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExchangeCompletion_SetNull_ClearsCanonicalAndLegacyKeys()
+    {
+        var session = new Session
+        {
+            ExchangeCompletion = new AgentExchangeCompletionState { ActiveExchangeId = "ex-1" }
+        };
+        session.Metadata.ShouldContainKey(AgentExchangeCompletionState.MetadataKey);
+
+        session.ExchangeCompletion = null;
+
+        session.Metadata.ShouldNotContainKey(AgentExchangeCompletionState.MetadataKey);
+        session.ExchangeCompletion.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FromMetadata_PrefersCanonicalBlob_OverLegacyKeys()
+    {
+        var session = new Session
+        {
+            ExchangeCompletion = new AgentExchangeCompletionState { ActiveExchangeId = "canonical" }
+        };
+        // A stray legacy key should not shadow the canonical blob.
+        session.Metadata[AgentExchangeCompletionState.LegacyActiveExchangeIdKey] = "legacy";
+
+        AgentExchangeCompletionState.FromMetadata(session.Metadata)!.ActiveExchangeId.ShouldBe("canonical");
+    }
+
+    [Fact]
+    public void IsEmpty_TrueOnlyWhenAllFieldsNull()
+    {
+        new AgentExchangeCompletionState().IsEmpty.ShouldBeTrue();
+        new AgentExchangeCompletionState { FinishedSummary = "x" }.IsEmpty.ShouldBeFalse();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
@@ -411,12 +411,13 @@ public sealed class AgentExchangeArchiveTests
                 if (capturedSessionId is { } sid)
                 {
                     var s = sessionStore.GetAsync(sid, CancellationToken.None).GetAwaiter().GetResult();
-                    if (s is not null
-                        && s.Metadata.TryGetValue(FinishAgentExchangeTool.ActiveExchangeIdKey, out var v)
-                        && v is string activeId)
+                    if (s?.ExchangeCompletion?.ActiveExchangeId is { Length: > 0 } activeId)
                     {
-                        s.Metadata[FinishAgentExchangeTool.FinishedExchangeIdKey] = activeId;
-                        s.Metadata[FinishAgentExchangeTool.FinishedReasonKey] = "shipped";
+                        s.ExchangeCompletion = s.ExchangeCompletion with
+                        {
+                            FinishedExchangeId = activeId,
+                            FinishedReason = "shipped"
+                        };
                         sessionStore.SaveAsync(s, CancellationToken.None).GetAwaiter().GetResult();
                     }
                 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeConversationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeConversationTests.cs
@@ -292,12 +292,13 @@ public sealed class AgentExchangeConversationTests
                 if (capturedSessionId is { } sid)
                 {
                     var s = sessionStore.GetAsync(sid, CancellationToken.None).GetAwaiter().GetResult();
-                    if (s is not null
-                        && s.Metadata.TryGetValue("activeAgentExchangeId", out var v)
-                        && v is string activeId)
+                    if (s?.ExchangeCompletion?.ActiveExchangeId is { Length: > 0 } activeId)
                     {
-                        s.Metadata["finishedAgentExchangeId"] = activeId;
-                        s.Metadata["finishedAgentExchangeReason"] = "shipped";
+                        s.ExchangeCompletion = s.ExchangeCompletion with
+                        {
+                            FinishedExchangeId = activeId,
+                            FinishedReason = "shipped"
+                        };
                         sessionStore.SaveAsync(s, CancellationToken.None).GetAwaiter().GetResult();
                     }
                 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
@@ -513,12 +513,15 @@ public sealed class AgentExchangeServiceTests
     {
         var s = store.GetAsync(sessionId, CancellationToken.None).GetAwaiter().GetResult();
         if (s is null) return;
-        if (!s.Metadata.TryGetValue("activeAgentExchangeId", out var activeRaw) || activeRaw is not string activeId)
+        var completion = s.ExchangeCompletion;
+        if (completion?.ActiveExchangeId is not { Length: > 0 } activeId)
             return;
-        s.Metadata["finishedAgentExchangeId"] = activeId;
-        s.Metadata["finishedAgentExchangeReason"] = reason;
-        if (!string.IsNullOrEmpty(summary))
-            s.Metadata["finishedAgentExchangeSummary"] = summary;
+        s.ExchangeCompletion = completion with
+        {
+            FinishedExchangeId = activeId,
+            FinishedReason = reason,
+            FinishedSummary = string.IsNullOrEmpty(summary) ? null : summary
+        };
         store.SaveAsync(s, CancellationToken.None).GetAwaiter().GetResult();
     }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using BotNexus.Domain;
+using BotNexus.Domain;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Agents;
@@ -825,11 +825,14 @@ public sealed class CrossWorldFederationControllerTests
                     var s = sessions.GetAsync(sid, CancellationToken.None).GetAwaiter().GetResult();
                     if (s is not null)
                     {
-                        // Deliberately write a finishedAgentExchangeId that does NOT match the
-                        // activeAgentExchangeId — simulates a confused/malicious tool writing a
+                        // Deliberately write a finished exchange id that does NOT match the
+                        // active exchange id - simulates a confused/malicious tool writing a
                         // payload from an unrelated exchange (or a previous turn's id).
-                        s.Metadata["finishedAgentExchangeId"] = "an-unrelated-exchange-id";
-                        s.Metadata["finishedAgentExchangeReason"] = "should not be honoured";
+                        s.ExchangeCompletion = (s.ExchangeCompletion ?? new AgentExchangeCompletionState()) with
+                        {
+                            FinishedExchangeId = "an-unrelated-exchange-id",
+                            FinishedReason = "should not be honoured"
+                        };
                         sessions.SaveAsync(s, CancellationToken.None).GetAwaiter().GetResult();
                     }
                 }
@@ -1228,12 +1231,13 @@ public sealed class CrossWorldFederationControllerTests
                 if (capturedSessionId is { } sid)
                 {
                     var s = sessions.GetAsync(sid, CancellationToken.None).GetAwaiter().GetResult();
-                    if (s is not null
-                        && s.Metadata.TryGetValue("activeAgentExchangeId", out var v)
-                        && v is string activeId)
+                    if (s?.ExchangeCompletion?.ActiveExchangeId is { Length: > 0 } activeId)
                     {
-                        s.Metadata["finishedAgentExchangeId"] = activeId;
-                        s.Metadata["finishedAgentExchangeReason"] = "shipped";
+                        s.ExchangeCompletion = s.ExchangeCompletion with
+                        {
+                            FinishedExchangeId = activeId,
+                            FinishedReason = "shipped"
+                        };
                         sessions.SaveAsync(s, CancellationToken.None).GetAwaiter().GetResult();
                     }
                 }
@@ -1386,14 +1390,14 @@ public sealed class CrossWorldFederationControllerTests
                 if (capturedSessionId is { } sid)
                 {
                     var s = sessions.GetAsync(sid, CancellationToken.None).GetAwaiter().GetResult();
-                    if (s is not null
-                        && s.Metadata.TryGetValue("activeAgentExchangeId", out var v)
-                        && v is string activeId)
+                    if (s?.ExchangeCompletion?.ActiveExchangeId is { Length: > 0 } activeId)
                     {
-                        s.Metadata["finishedAgentExchangeId"] = activeId;
-                        s.Metadata["finishedAgentExchangeReason"] = finishReason;
-                        if (!string.IsNullOrEmpty(finishSummary))
-                            s.Metadata["finishedAgentExchangeSummary"] = finishSummary;
+                        s.ExchangeCompletion = s.ExchangeCompletion with
+                        {
+                            FinishedExchangeId = activeId,
+                            FinishedReason = finishReason,
+                            FinishedSummary = string.IsNullOrEmpty(finishSummary) ? null : finishSummary
+                        };
                         sessions.SaveAsync(s, CancellationToken.None).GetAwaiter().GetResult();
                     }
                 }
@@ -1436,14 +1440,14 @@ public sealed class CrossWorldFederationControllerTests
                 if (capturedSessionId is { } sid)
                 {
                     var s = sessions.GetAsync(sid, CancellationToken.None).GetAwaiter().GetResult();
-                    if (s is not null
-                        && s.Metadata.TryGetValue("activeAgentExchangeId", out var v)
-                        && v is string activeId)
+                    if (s?.ExchangeCompletion?.ActiveExchangeId is { Length: > 0 } activeId)
                     {
-                        s.Metadata["finishedAgentExchangeId"] = activeId;
-                        s.Metadata["finishedAgentExchangeReason"] = finishReason;
-                        if (!string.IsNullOrEmpty(finishSummary))
-                            s.Metadata["finishedAgentExchangeSummary"] = finishSummary;
+                        s.ExchangeCompletion = s.ExchangeCompletion with
+                        {
+                            FinishedExchangeId = activeId,
+                            FinishedReason = finishReason,
+                            FinishedSummary = string.IsNullOrEmpty(finishSummary) ? null : finishSummary
+                        };
                         sessions.SaveAsync(s, CancellationToken.None).GetAwaiter().GetResult();
                     }
                 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/FinishAgentExchangeToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/FinishAgentExchangeToolTests.cs
@@ -23,7 +23,7 @@ public sealed class FinishAgentExchangeToolTests
         var store = new InMemorySessionStore();
         var sid = SessionId.From("test-session-1");
         var session = MakeSession(sid);
-        session.Metadata[FinishAgentExchangeTool.ActiveExchangeIdKey] = "active-xchg-123";
+        session.ExchangeCompletion = new AgentExchangeCompletionState { ActiveExchangeId = "active-xchg-123" };
         await store.SaveAsync(session, CancellationToken.None);
 
         var tool = new FinishAgentExchangeTool(store, sid);
@@ -38,9 +38,9 @@ public sealed class FinishAgentExchangeToolTests
 
         result.Content.ShouldNotBeEmpty();
         var refreshed = (await store.GetAsync(sid, CancellationToken.None))!;
-        refreshed.Metadata[FinishAgentExchangeTool.FinishedExchangeIdKey].ShouldBe("active-xchg-123");
-        refreshed.Metadata[FinishAgentExchangeTool.FinishedReasonKey].ShouldBe("objective met");
-        refreshed.Metadata[FinishAgentExchangeTool.FinishedSummaryKey].ShouldBe("Reviewed the PR; no blockers.");
+        refreshed.ExchangeCompletion!.FinishedExchangeId.ShouldBe("active-xchg-123");
+        refreshed.ExchangeCompletion.FinishedReason.ShouldBe("objective met");
+        refreshed.ExchangeCompletion.FinishedSummary.ShouldBe("Reviewed the PR; no blockers.");
     }
 
     [Fact]
@@ -64,8 +64,8 @@ public sealed class FinishAgentExchangeToolTests
         ex.Message.ShouldContain("No active agent-to-agent exchange");
 
         var refreshed = (await store.GetAsync(sid, CancellationToken.None))!;
-        refreshed.Metadata.ShouldNotContainKey(FinishAgentExchangeTool.FinishedExchangeIdKey);
-        refreshed.Metadata.ShouldNotContainKey(FinishAgentExchangeTool.FinishedReasonKey);
+        (refreshed.ExchangeCompletion?.FinishedExchangeId).ShouldBeNull();
+        (refreshed.ExchangeCompletion?.FinishedReason).ShouldBeNull();
     }
 
     [Fact]
@@ -77,6 +77,8 @@ public sealed class FinishAgentExchangeToolTests
         var store = new InMemorySessionStore();
         var sid = SessionId.From("test-session-3");
         var session = MakeSession(sid);
+        // Legacy loose key carrying a JsonElement (as Sqlite/File stores round-trip) must still
+        // migrate-on-read into the typed active id.
         session.Metadata[FinishAgentExchangeTool.ActiveExchangeIdKey] =
             JsonDocument.Parse("\"active-xchg-456\"").RootElement;
         await store.SaveAsync(session, CancellationToken.None);
@@ -89,7 +91,7 @@ public sealed class FinishAgentExchangeToolTests
 
         result.Content.ShouldNotBeEmpty();
         var refreshed = (await store.GetAsync(sid, CancellationToken.None))!;
-        refreshed.Metadata[FinishAgentExchangeTool.FinishedExchangeIdKey].ShouldBe("active-xchg-456");
+        refreshed.ExchangeCompletion!.FinishedExchangeId.ShouldBe("active-xchg-456");
     }
 
     [Fact]
@@ -100,8 +102,11 @@ public sealed class FinishAgentExchangeToolTests
         var store = new InMemorySessionStore();
         var sid = SessionId.From("test-session-4");
         var session = MakeSession(sid);
-        session.Metadata[FinishAgentExchangeTool.ActiveExchangeIdKey] = "active-xchg-789";
-        session.Metadata[FinishAgentExchangeTool.FinishedSummaryKey] = "prior summary that should not leak";
+        session.ExchangeCompletion = new AgentExchangeCompletionState
+        {
+            ActiveExchangeId = "active-xchg-789",
+            FinishedSummary = "prior summary that should not leak"
+        };
         await store.SaveAsync(session, CancellationToken.None);
 
         var tool = new FinishAgentExchangeTool(store, sid);
@@ -109,7 +114,7 @@ public sealed class FinishAgentExchangeToolTests
         await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["reason"] = "done" });
 
         var refreshed = (await store.GetAsync(sid, CancellationToken.None))!;
-        refreshed.Metadata.ShouldNotContainKey(FinishAgentExchangeTool.FinishedSummaryKey);
+        (refreshed.ExchangeCompletion?.FinishedSummary).ShouldBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #612 (CC-1)

## Changes
Promotes the four loose `Session.Metadata` exchange-completion keys (`activeAgentExchangeId` / `finishedAgentExchangeId` / `finishedAgentExchangeReason` / `finishedAgentExchangeSummary`) to a single typed `AgentExchangeCompletionState` record.

- New `AgentExchangeCompletionState` record (`ActiveExchangeId` / `FinishedExchangeId` / `FinishedReason` / `FinishedSummary`), projected over `Session.Metadata` so it round-trips through Sqlite/File/InMemory session stores with **no schema change**.
- `Session.ExchangeCompletion` and `GatewaySession.ExchangeCompletion` typed nullable facade properties.
- **Migrate-on-read**: pre-CC-1 rows carrying the four legacy loose keys are transparently surfaced as the typed state (JsonElement-tolerant). Writes always strip the legacy keys so a stale value can never shadow the canonical blob.
- Removes the two duplicate `MetadataString` JsonElement-coercion helpers (`AgentExchangeCompletionGate.MetadataString` + `FinishAgentExchangeTool.MetadataString`) — the single coercion now lives in the record.
- Updated all write/read sites: `AgentExchangeService`, `AgentExchangeCompletionGate`, `FinishAgentExchangeTool`, `CrossWorldFederationController`.

## Tests
- New `AgentExchangeCompletionStateTests` (8 cases): typed round-trip, migrate-on-read from legacy string + JsonElement keys, write-clears-legacy, null-clears, canonical-preferred-over-legacy, IsEmpty.
- Updated existing exchange tests (Service/Archive/Conversation/CrossWorldFederation/FinishTool) to drive the typed property; behaviour and freshness/mutation guards unchanged.
- Full impacted suite green (Domain 397, Gateway 3548, Architecture, Scenarios).

## Merge Notes
File-disjoint from all current open PRs (#1847/1855/1856/1857/1858/1859/1860/1861 touch none of these files). Safe to merge in any order. Part of the #612 CC-1 typed-model cleanup (net -110/+25 production LOC target; delivers the dedupe + type promotion).